### PR TITLE
fix: Waveshare213gDriver.stop() doesn't release GPIO at OS level

### DIFF
--- a/modules/display/drivers/waveshare_213g.py
+++ b/modules/display/drivers/waveshare_213g.py
@@ -108,7 +108,13 @@ class Waveshare213gDriver(DisplayDriver):
         which calls stop() on exactly such a driver."""
         try:
             if self._started and self._epdconfig is not None:
-                self._epdconfig.module_exit()
+                # cleanup=True is required here - the vendor's default
+                # (False) only calls .off() on the 4 gpiozero pin objects,
+                # not .close(). .off() leaves the pin claimed at the
+                # pin-factory level (lgpio), so a plain module_exit() call
+                # looked like a clean stop but never actually released the
+                # physical GPIO lines - see tools/test_gpio_cleanup.py.
+                self._epdconfig.module_exit(cleanup=True)
         finally:
             self._epd = None
             self._epdconfig = None

--- a/tools/test_gpio_cleanup.py
+++ b/tools/test_gpio_cleanup.py
@@ -1,0 +1,82 @@
+"""Hardware test for the Waveshare213gDriver.stop() GPIO-cleanup fix
+(module_exit(cleanup=True) - see waveshare_213g.py's stop()).
+
+GpioRegistry alone can't prove GPIO is actually free at the OS/pin-factory
+level - it's a Python-process dict that will say "released" the moment
+release() is called, regardless of whether the underlying gpiozero pin
+objects were ever .close()'d. This test bypasses GpioRegistry entirely and
+tries to re-claim the exact same physical pins directly through gpiozero,
+the same library the vendor driver uses - if the pin is genuinely free,
+construction succeeds; if the vendor driver only .off()'d it without
+.close()'ing it, gpiozero/lgpio raises (pin still owned by the old,
+supposedly-stopped driver's pin objects, since Waveshare213gDriver.stop()
+never dropped its references to self._epdconfig's still-open pin objects).
+
+Run directly on the dev node over SSH (stop meshcenter.service first, or
+this will conflict with the live driver instead of testing the intended
+scenario):
+
+    (venv) flint@meshcenter-test:~/meshcenter$ sudo systemctl stop meshcenter.service
+    (venv) flint@meshcenter-test:~/meshcenter$ python3 tools/test_gpio_cleanup.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("test_gpio_cleanup")
+
+
+def main() -> int:
+    from modules.display.drivers.waveshare_213g import DEFAULT_PINS, Waveshare213gDriver
+    from modules.display.gpio_registry import GpioRegistry
+
+    driver = Waveshare213gDriver(gpio_registry=GpioRegistry())
+    if not driver.start():
+        log.error("start() failed: %s", driver.get_status())
+        return 1
+    log.info("start() ok - pins claimed: %s", DEFAULT_PINS)
+
+    driver.stop()
+    log.info("stop() done")
+
+    # Bypass GpioRegistry completely - reclaim the exact same physical pins
+    # straight through gpiozero, the way any unrelated process (or a
+    # freshly re-init'd driver instance) would.
+    import gpiozero
+
+    reclaimed = []
+    try:
+        rst = gpiozero.LED(DEFAULT_PINS["rst"])
+        reclaimed.append(rst)
+        dc = gpiozero.LED(DEFAULT_PINS["dc"])
+        reclaimed.append(dc)
+        pwr = gpiozero.LED(DEFAULT_PINS["pwr"])
+        reclaimed.append(pwr)
+        busy = gpiozero.Button(DEFAULT_PINS["busy"], pull_up=False)
+        reclaimed.append(busy)
+    except Exception as exc:
+        log.error(
+            "FAIL: could not reclaim pins after stop() - GPIO still held "
+            "at the OS level: %r",
+            exc,
+        )
+        for obj in reclaimed:
+            obj.close()
+        return 1
+
+    for obj in reclaimed:
+        obj.close()
+
+    log.info("PASS: all 4 pins (rst/dc/pwr/busy) successfully reclaimed "
+              "directly via gpiozero after stop() - GPIO genuinely released")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes `Waveshare213gDriver.stop()` not actually releasing GPIO at the OS/pin-factory level - a gap flagged during Stage 2 (WeAct) bring-up but not fixed at the time (see PR #12's history in `epaper_stage2_weact.md`).

## Root cause

`RaspberryPi.module_exit(self, cleanup=False)` in the vendored `epdconfig.py` only calls `.off()` on its 4 gpiozero pin objects (RST/DC/PWR/BUSY) when `cleanup` is left at its default `False` - `.off()` sets the pin LOW but does not release it from the pin factory (gpiozero/lgpio). Only `.close()`, gated behind `cleanup=True`, actually does that. `waveshare_213g.py`'s `stop()` called `module_exit()` with no arguments, so `.close()` was never reached - `stop()` looked clean (no exception, `GpioRegistry.release()` ran) but the physical GPIO lines stayed held by the old pin objects.

Scope check: WeAct's `weact_154.py`/`_weact_ssd1681.py` has its own driver (not vendored) whose `stop()` -> `Ssd1681.close()` already calls `.close()` on all of its gpiozero objects - confirmed this bug does not affect WeAct, it's isolated to the Waveshare vendor-wrapper path.

## Fix

One-line change in `waveshare_213g.py`'s `stop()`: `self._epdconfig.module_exit()` -> `self._epdconfig.module_exit(cleanup=True)`.

## Accepted risk (explicit, not silent)

**This fix has NOT been verified live on real hardware.** A test (`tools/test_gpio_cleanup.py`) was written that bypasses `GpioRegistry` entirely and tries to reclaim the same physical pins directly via `gpiozero` after `stop()` - if the pin is genuinely free, construction succeeds; if not, it raises. This is the right test in principle, but it could not be run on the dev node right now: the Waveshare panel is physically disconnected there (replaced by the WeAct panel since Stage 2), and running `Waveshare213gDriver.start()` against the wrong panel risks hanging indefinitely - `epd2in13g_v2.py`'s `ReadBusy()` busy-waits on the BUSY pin with **no timeout**, and the two panels use different, incompatible BUSY polarity/protocol.

By explicit user decision, this PR proceeds on code-review confidence only (the mechanism is fully understood and traced, see Root cause above) rather than blocking on physically reconnecting the Waveshare panel. `tools/test_gpio_cleanup.py` is included and should be run for real the next time the Waveshare panel is physically reattached, before treating this as hardware-confirmed.

## Test plan

- [ ] `tools/test_gpio_cleanup.py` passes on dev hardware with the Waveshare panel physically connected (not yet run - see accepted risk above)
- [x] Code-reviewed: fix traced to the exact vendor call and gpiozero `.close()` semantics; scope-checked against WeAct's driver (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
