### PR TITLE
fix: DisplayManager - close race between the worker thread and reinit

### DIFF
--- a/api/api_hardware_display.py
+++ b/api/api_hardware_display.py
@@ -163,15 +163,16 @@ def register_hardware_display_routes(
         # actual physical pins are identical (both panels use the same
         # HAT header). Without this, reconfiguring onto the very pins the
         # current driver already holds would incorrectly look like a
-        # conflict with itself. replace_driver() below also releases this
-        # via the old driver's stop() - doing it here too is redundant but
-        # harmless (GpioRegistry.release() is idempotent).
+        # conflict with itself. swap_driver_and_start() below also releases
+        # this via the old driver's stop() - doing it here too is redundant
+        # but harmless (GpioRegistry.release() is idempotent).
         gpio_registry.release(config.get("model", DEFAULT_MODEL))
         try:
             gpio_registry.check(new_config["pins"], owner=new_config.get("model", DEFAULT_MODEL))
         except GpioConflictError as exc:
-            # The live driver itself was never touched (replace_driver()
-            # hasn't run yet at this point) - it's still actively holding
+            # The live driver itself was never touched
+            # (swap_driver_and_start() hasn't run yet at this point) - it's
+            # still actively holding
             # its current pins. Restore its registry claim before
             # returning, or the registry would incorrectly believe those
             # pins are free while the running driver still uses them.
@@ -183,16 +184,14 @@ def register_hardware_display_routes(
         except ValueError as exc:
             return jsonify({"ok": False, "error": str(exc)}), 400
 
-        display_manager.replace_driver(new_driver)
-        ok, error = display_manager.try_start_now(timeout=REINIT_CHECK_TIMEOUT)
+        ok, error = display_manager.swap_driver_and_start(new_driver, timeout=REINIT_CHECK_TIMEOUT)
 
         if not ok:
             # Roll back to the previous, already-working configuration
             # rather than leaving the live manager on a driver we just
             # proved doesn't work.
             old_driver = build_driver(config, gpio_registry)
-            display_manager.replace_driver(old_driver)
-            display_manager.try_start_now(timeout=REINIT_CHECK_TIMEOUT)
+            display_manager.swap_driver_and_start(old_driver, timeout=REINIT_CHECK_TIMEOUT)
             return jsonify({"ok": False, "error": error}), 400
 
         config.update(new_config)

--- a/modules/display/drivers/waveshare_213g.py
+++ b/modules/display/drivers/waveshare_213g.py
@@ -104,7 +104,7 @@ class Waveshare213gDriver(DisplayDriver):
         An early `if not self._started: return` here (an earlier version
         of this method) skipped that release entirely, leaking the claim
         until process restart - this matters in practice for
-        DisplayManager.replace_driver()'s reinit-failure rollback path,
+        DisplayManager.swap_driver_and_start()'s reinit-failure rollback path,
         which calls stop() on exactly such a driver."""
         try:
             if self._started and self._epdconfig is not None:

--- a/modules/display/drivers/weact_154.py
+++ b/modules/display/drivers/weact_154.py
@@ -98,7 +98,7 @@ class Weact154Driver(DisplayDriver):
         `if not self._started: return` here (an earlier version of this
         method) skipped that release entirely, leaking the claim until
         process restart - this matters in practice for
-        DisplayManager.replace_driver()'s reinit-failure rollback path,
+        DisplayManager.swap_driver_and_start()'s reinit-failure rollback path,
         which calls stop() on exactly such a driver."""
         try:
             if self._started and self._epd is not None:

--- a/modules/display/manager.py
+++ b/modules/display/manager.py
@@ -93,6 +93,28 @@ class DisplayManager:
         self._stop_flag = threading.Event()
         self._worker: threading.Thread | None = None
 
+        # Coordinates the worker thread against swap_driver_and_start()
+        # (called from a Flask request thread via /reinit) - without this,
+        # both could call start()/render() on self._driver at once, and the
+        # Waveshare driver's vendor wrapper monkey-patches module-level
+        # shared state (epdconfig.implementation), so a concurrent call
+        # from two threads corrupts it out from under each other (observed
+        # live: a start() timeout immediately followed by
+        # GPIODeviceClosed('Button is closed or uninitialized')).
+        # _pause_for_reinit: "clear to proceed" gate, inverted from the
+        #   usual Event idiom on purpose - starts *set* (worker runs
+        #   normally). swap_driver_and_start() clear()s it before it
+        #   touches self._driver, so the worker's wait() (checked *before*
+        #   starting a new _refresh() cycle) blocks until set() is called
+        #   again in swap_driver_and_start()'s finally.
+        # _worker_idle: set whenever the worker is NOT currently inside
+        #   _refresh() - swap_driver_and_start() waits for this (bounded)
+        #   before it's safe to stop the old driver / start the new one.
+        self._pause_for_reinit = threading.Event()
+        self._pause_for_reinit.set()
+        self._worker_idle = threading.Event()
+        self._worker_idle.set()
+
         self._status = DisplayStatus.DISABLED
         self._stats = RefreshStats()
         self._last_hash: str | None = None
@@ -162,49 +184,66 @@ class DisplayManager:
             debounce_seconds if debounce_seconds is not None else DEFAULT_DEBOUNCE_SECONDS[mode]
         )
 
-    def replace_driver(self, new_driver: DisplayDriver) -> None:
-        """Swap the wrapped driver (e.g. after a GPIO/SPI/timeout config
-        change) without tearing down the worker thread or losing
-        debounce/stats state - only the physical-driver half of the
-        manager changes. Stops the old driver first to release its
-        GPIO/SPI claim before the new one can be started. Deliberately
-        NOT part of the "applied live" settings path (set_refresh_mode) -
-        a bad pin value here can reproduce the BUSY-hang debugging from
-        Phases 1-2, so callers are expected to pair this with
-        try_start_now() and only persist the new config if that succeeds
-        (see api/api_hardware_display.py's re-init route)."""
-        old_driver = self._driver
-        try:
-            old_driver.stop()
-        except Exception:
-            logger.exception("[EPAPER] replace_driver: failed to stop the old driver cleanly")
-        self._driver = new_driver
-        self._last_hash = None  # force a real refresh against the new driver next time
-        self._status = DisplayStatus.CONFIGURED
+    def swap_driver_and_start(
+        self, new_driver: DisplayDriver, timeout: float | None = None,
+    ) -> tuple[bool, str | None]:
+        """Atomically swap the wrapped driver and validate it starts -
+        replaces the old two-step replace_driver()+try_start_now() API,
+        which had a race: the worker thread could call start()/render() on
+        self._driver in the window between those two calls (or even
+        concurrently with either one), and the Waveshare driver's vendor
+        wrapper monkey-patches module-level shared state
+        (epdconfig.implementation), so two threads touching it at once
+        corrupts it out from under each other - confirmed live via a
+        start() timeout immediately followed by
+        GPIODeviceClosed('Button is closed or uninitialized').
 
-    def try_start_now(self, timeout: float | None = None) -> tuple[bool, str | None]:
-        """Synchronously attempt to start the current driver, bounded by a
-        timeout. Only for the explicit GPIO/SPI re-init action - the
-        normal async refresh pipeline always goes through _ensure_started()
-        instead. Gives the caller an immediate pass/fail (e.g. "GPIO24
-        conflicts" or a BUSY-timeout) instead of only discovering a bad
-        pin config on the next debounced refresh, minutes later."""
+        Pauses the worker (it won't start a new _refresh() cycle) and waits
+        for any cycle already in flight to finish before touching
+        self._driver at all, so start()/render() are never reachable from
+        two threads at once for the same driver instance. Bounded by
+        `timeout` even if the worker is wedged (e.g. inside its own 75s
+        watchdog) - a still-running old driver session is abandoned rather
+        than let a stuck worker hang a reinit request forever; the caller
+        (api/api_hardware_display.py's re-init route) is on a Flask request
+        thread and already expects a bounded wait here.
+
+        Only for the explicit GPIO/SPI/model re-init action - the normal
+        async refresh pipeline always goes through _ensure_started()
+        instead. Deliberately NOT part of the "applied live" settings path
+        (set_refresh_mode) - a bad pin value here can reproduce the
+        BUSY-hang debugging from Phases 1-2, so callers are expected to
+        only persist the new config if this returns True."""
         timeout = timeout if timeout is not None else self._refresh_timeout
-        self._status = DisplayStatus.INITIALIZING
+        self._pause_for_reinit.clear()  # block the worker from starting a new cycle
+        try:
+            self._worker_idle.wait(timeout=timeout)
 
-        def _start_or_raise():
-            if not self._driver.start():
-                raise RuntimeError(self._driver.get_status().get("error") or "start() returned False")
+            old_driver = self._driver
+            try:
+                old_driver.stop()
+            except Exception:
+                logger.exception("[EPAPER] swap_driver_and_start: failed to stop the old driver cleanly")
+            self._driver = new_driver
+            self._last_hash = None  # force a real refresh against the new driver next time
+            self._status = DisplayStatus.INITIALIZING
 
-        completed, error = _run_with_timeout(_start_or_raise, timeout)
-        if not completed:
-            self._status = DisplayStatus.ERROR
-            return False, f"start() timed out after {timeout:.0f}s"
-        if error is not None:
-            self._status = DisplayStatus.ERROR
-            return False, str(error)
-        self._status = DisplayStatus.CONFIGURED
-        return True, None
+            def _start_or_raise():
+                if not new_driver.start():
+                    raise RuntimeError(new_driver.get_status().get("error") or "start() returned False")
+
+            completed, error = _run_with_timeout(_start_or_raise, timeout)
+            if not completed:
+                self._status = DisplayStatus.ERROR
+                return False, f"start() timed out after {timeout:.0f}s"
+            if error is not None:
+                self._status = DisplayStatus.ERROR
+                return False, str(error)
+            self._status = DisplayStatus.CONFIGURED
+            return True, None
+        finally:
+            self._pause_for_reinit.set()  # let the worker resume
+            self._wake.set()  # in case a frame arrived while we were paused
 
     # -- worker thread --------------------------------------------------
 
@@ -227,7 +266,20 @@ class DisplayManager:
                 if image is None:
                     continue
 
-            self._refresh(image)
+            # Cooperative pause point (see swap_driver_and_start()) - don't
+            # start touching self._driver while a reinit is mid-swap. Not
+            # inside _refresh() itself: the point is to never let a driver
+            # method call and a reinit's own start() overlap, so the
+            # boundary has to be before the first one, not wrapped around it.
+            self._pause_for_reinit.wait()
+            if self._stop_flag.is_set():
+                return
+
+            self._worker_idle.clear()
+            try:
+                self._refresh(image)
+            finally:
+                self._worker_idle.set()
 
     def _take_pending(self) -> tuple[Any, EventPriority]:
         with self._lock:

--- a/tools/test_display_manager.py
+++ b/tools/test_display_manager.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -271,14 +272,181 @@ def part3_debounce_survives_drifting_content() -> bool:
     return True
 
 
+class _FakeGatedDriver:
+    """DisplayDriver stand-in that (a) can hold start() open on a
+    controllable gate, so a test can deterministically catch the worker
+    thread *inside* start() rather than hoping a sleep() wins a timing
+    race, and (b) tracks - across all instances, via a class-level lock -
+    whether two instances' start()/render()/stop() are ever "active"
+    (entered but not yet returned) at the same time. That's the exact
+    failure mode swap_driver_and_start() exists to prevent (see
+    manager.py): the vendor Waveshare wrapper monkey-patches module-level
+    shared state, so two instances' start()/render() running concurrently
+    corrupts each other regardless of which instances they are - this
+    check doesn't care about identity, only about overlap."""
+
+    _active_lock = threading.Lock()
+    _active: str | None = None
+    violations: list[str] = []
+
+    def __init__(self, name: str, start_gate: threading.Event | None = None):
+        self.name = name
+        self.display_name = name
+        self.id = name
+        self._started = False
+        self._start_gate = start_gate
+        self.entered_start = threading.Event()
+        self.start_returned = threading.Event()
+        self.stop_called = threading.Event()
+
+    def _enter(self, where: str) -> None:
+        with _FakeGatedDriver._active_lock:
+            if _FakeGatedDriver._active is not None:
+                _FakeGatedDriver.violations.append(
+                    f"{self.name}.{where}() entered while {_FakeGatedDriver._active} was still active"
+                )
+            _FakeGatedDriver._active = f"{self.name}.{where}"
+
+    def _exit(self) -> None:
+        with _FakeGatedDriver._active_lock:
+            _FakeGatedDriver._active = None
+
+    def detect(self) -> dict[str, Any] | None:
+        return {"model": self.name}
+
+    def start(self, **options: Any) -> bool:
+        self._enter("start")
+        try:
+            self.entered_start.set()
+            if self._start_gate is not None:
+                self._start_gate.wait(timeout=5)
+            self._started = True
+            return True
+        finally:
+            self.start_returned.set()
+            self._exit()
+
+    def stop(self) -> None:
+        self.stop_called.set()
+        self._enter("stop")
+        try:
+            self._started = False
+        finally:
+            self._exit()
+
+    def get_status(self) -> dict[str, Any]:
+        return {"ok": True, "started": self._started, "model": self.name}
+
+    def render(self, image: Any, fast: bool = False) -> None:
+        self._enter("render")
+        self._exit()
+
+    def clear(self) -> None:
+        pass
+
+    def sleep(self) -> None:
+        pass
+
+
+class _FakeImage:
+    def tobytes(self):
+        return b"fake"
+
+
+def part4_reinit_does_not_race_worker() -> bool:
+    """Regression test for a real race found live (2026-08-12): the worker
+    thread and swap_driver_and_start() (called from a Flask request thread
+    via /reinit) could both call start()/render() on the same driver
+    instance at once, since nothing paused the worker during a reinit.
+    Observed live as a start() timeout immediately followed by
+    GPIODeviceClosed('Button is closed or uninitialized').
+
+    Deterministic by construction, not by luck: driver_a's start() is held
+    open on a gate until the test has *confirmed* (via entered_start, not
+    a sleep) that the worker is genuinely inside it, then confirms the
+    concurrently-started reinit is genuinely still blocked (driver_a not
+    yet stopped, driver_b not yet started) before releasing the gate -
+    matching the lesson from the GpioRegistry HTTP-test mistake: a test
+    that can't distinguish bug-present from bug-fixed proves nothing."""
+    from modules.display.manager import DisplayManager
+    from modules.display.models import EventPriority
+
+    log.info("=== Part 4: swap_driver_and_start() never overlaps the worker on one driver ===")
+
+    _FakeGatedDriver.violations.clear()
+    _FakeGatedDriver._active = None
+
+    start_gate = threading.Event()  # held closed - driver_a's start() blocks here
+    driver_a = _FakeGatedDriver("driver_a", start_gate=start_gate)
+    manager = DisplayManager(driver_a, refresh_timeout=5.0)
+    manager.start()
+
+    manager.mark_dirty(_FakeImage(), priority=EventPriority.CRITICAL)  # bypass debounce
+    if not driver_a.entered_start.wait(timeout=5):
+        manager.stop()
+        log.error("FAIL: worker never reached driver_a.start() - test setup broken")
+        return False
+
+    driver_b = _FakeGatedDriver("driver_b")
+    reinit_result: dict[str, Any] = {}
+
+    def _do_reinit():
+        ok, error = manager.swap_driver_and_start(driver_b, timeout=5.0)
+        reinit_result["ok"] = ok
+        reinit_result["error"] = error
+
+    reinit_thread = threading.Thread(target=_do_reinit, daemon=True)
+    reinit_thread.start()
+
+    # Prove the reinit is genuinely still blocked - not "probably" via a
+    # bigger sleep, but by checking the actual state it must not have
+    # reached yet: driver_a hasn't been stopped, driver_b hasn't started.
+    time.sleep(0.5)
+    if driver_a.stop_called.is_set() or driver_b.entered_start.is_set():
+        manager.stop()
+        log.error(
+            "FAIL: swap_driver_and_start() proceeded (driver_a stopped=%s, "
+            "driver_b started=%s) while driver_a.start() was still running",
+            driver_a.stop_called.is_set(), driver_b.entered_start.is_set(),
+        )
+        return False
+
+    # Now let driver_a.start() finish - the reinit should unblock and
+    # proceed in order: driver_a.start() returns, THEN driver_a.stop(),
+    # THEN driver_b.start().
+    start_gate.set()
+    reinit_thread.join(timeout=10)
+    manager.stop()
+
+    if reinit_thread.is_alive():
+        log.error("FAIL: swap_driver_and_start() never returned")
+        return False
+    if not reinit_result.get("ok"):
+        log.error("FAIL: swap_driver_and_start() reported failure: %s", reinit_result.get("error"))
+        return False
+    if not driver_a.start_returned.is_set() or not driver_a.stop_called.is_set():
+        log.error("FAIL: expected driver_a.start() to return and driver_a.stop() to be called")
+        return False
+    if not driver_b.entered_start.is_set():
+        log.error("FAIL: driver_b.start() was never called")
+        return False
+    if _FakeGatedDriver.violations:
+        log.error("FAIL: overlapping driver method calls detected: %s", _FakeGatedDriver.violations)
+        return False
+
+    log.info("PASS: reinit correctly waited for the in-flight worker cycle, no overlapping driver calls")
+    return True
+
+
 def main() -> int:
     ok1 = part1_real_hardware()
     ok2 = part2_simulated_timeout()
     ok3 = part3_debounce_survives_drifting_content()
-    if ok1 and ok2 and ok3:
+    ok4 = part4_reinit_does_not_race_worker()
+    if ok1 and ok2 and ok3 and ok4:
         log.info("ALL PASS")
         return 0
-    log.error("FAILED: part1=%s part2=%s part3=%s", ok1, ok2, ok3)
+    log.error("FAILED: part1=%s part2=%s part3=%s part4=%s", ok1, ok2, ok3, ok4)
     return 1
 
 


### PR DESCRIPTION
## Summary

Fixes a real, confirmed (not hypothetical) race condition in `DisplayManager`: the worker thread and the explicit GPIO/SPI/model re-init action (`/api/hardware/display/reinit`) could both call `start()`/`render()` on the same driver instance at once, since nothing paused the worker while a reinit was mid-swap.

## Root cause

`Waveshare213gDriver`'s vendor wrapper (`_configure_vendor_pins()`) monkey-patches `epdconfig.implementation` - **module-level shared state**, not per-instance. Two threads touching it concurrently corrupts it out from under each other.

The old two-step API (`replace_driver()` then `try_start_now()`, called separately from `/reinit`) had no coordination with the worker thread at all - `replace_driver()` swapped `self._driver` immediately, with the worker's own `_run()` loop free to call `start()`/`render()` on it at literally any point, including mid-swap.

**Confirmed live (2026-08-12):** while diagnosing an unrelated re-confirmation task with the Waveshare panel physically reconnected, concurrent Settings/reinit clicks (from the browser UI) overlapping with the worker's own refresh produced exactly this failure signature:
```
[EPAPER] Display start() timed out after 75s (attempt 1/3)
[EPAPER] Display refresh raised GPIODeviceClosed('Button is closed or uninitialized') (attempt 2/3)
[EPAPER] Display start() timed out after 75s (attempt 3/3)
```

## Fix

Replaces `replace_driver()` + `try_start_now()` with one atomic `swap_driver_and_start()`:
1. Clears a "clear to proceed" `Event` the worker checks before starting any new `_refresh()` cycle - blocks the worker from beginning new driver work.
2. Waits (bounded by the same timeout) for any cycle already in flight to finish - so a cycle that's already running is allowed to complete rather than being interrupted mid-call.
3. Only then touches `self._driver` - stops the old driver, swaps in the new one, starts it under the existing watchdog.
4. Releases the pause in `finally`, regardless of outcome.

`start()`/`render()` are now never reachable from two threads at once for the same driver instance.

`api/api_hardware_display.py`'s `/reinit` route updated to call the single new method (both for the main attempt and the rollback-on-failure path).

## Test plan

- [x] `tools/test_display_manager.py` Part 4 (new) - deterministic, not timing-luck-based: a gated fake driver blocks the worker inside `start()`, the test confirms via events (not sleeps) that a concurrently-started `swap_driver_and_start()` is genuinely still blocked before releasing the gate, then asserts no two driver method calls were ever active at once. **PASS.**
- [x] Parts 2-3 (pre-existing, no hardware needed) - re-run, no regression. **PASS.**
- [x] Part 1 (real hardware, Waveshare panel) run - **FAILED, see Accepted Risk below.** Re-run twice after a genuinely clean `systemctl stop`+fresh-process restart (not just the same long-lived process) - both times it did not reach ONLINE within the test's 60s window. Root cause identified (not left unexplained) - see below.

## Accepted risk (explicit, not silent)

**A second, related race exists and is NOT fixed by this PR.** Same root cause (shared `epdconfig.implementation`), different trigger: `_render_with_retries()` only calls `driver.stop()` after a timed-out `render()`, not after a timed-out `start()` - so on a retry, an abandoned watchdog thread from a prior `start()` attempt that hasn't actually finished yet (Python can't force-cancel a thread) can still be running when the next attempt calls `start()` again on the same instance.

This is very likely what Part 1's real-hardware test run above is actually hitting (confirmed the panel/BUSY/wiring itself is fine: `tools/test_epaper.py`, `tools/test_epaper_driver.py`, and a manual single background-thread repro of the exact same call pattern all completed in ~1-20s with zero issues when run directly, outside `DisplayManager`'s retry loop) - **not** physical hardware instability, despite an early hypothesis to that effect during live debugging.

Deliberately not fixed here: three candidate approaches were identified (isolate the vendor config per-instance instead of module-level shared state; don't retry after a `start()` timeout the way `render()` timeouts already do; a fencing/generation token around attempts), each with real trade-offs against the others - this needs the same deliberate design discussion this PR's fix got, not an end-of-session addition. Tracked as a separate, elevated-priority backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
