### PR TITLE
fix: Waveshare213gDriver - lock around shared vendor state (2nd race)

### DIFF
--- a/modules/display/drivers/waveshare_213g.py
+++ b/modules/display/drivers/waveshare_213g.py
@@ -15,16 +15,37 @@ and auto-instantiates that class at import time - there's no clean
 injection point for pins/SPI bus in the vendor code, so
 _configure_vendor_pins() below reconfigures the already-constructed
 instance in place instead.
+
+_VENDOR_LOCK below is a second, independent layer of protection against
+concurrent access to that same shared instance - not a duplicate of
+DisplayManager.swap_driver_and_start()'s worker-pause mechanism (see
+manager.py). That mechanism coordinates *when a new cycle is allowed to
+start* at the DisplayManager level, proactively avoiding contention in the
+common case. This lock protects the actual shared vendor resource at the
+driver level, and exists specifically for the case that mechanism can't
+cover: DisplayManager._worker_idle is set as soon as a refresh cycle
+*returns* (see manager.py's _run()), even if that cycle's own
+_run_with_timeout()-wrapped call abandoned a still-running background
+thread (Python can't force-cancel a thread) - so a worker cycle that times
+out on its own can leave an orphaned thread still touching
+epdconfig.implementation while DisplayManager believes it's idle and lets
+something else proceed. This lock is what actually prevents that
+collision, regardless of what DisplayManager's bookkeeping believes.
 """
 
 from __future__ import annotations
 
+import logging
 import sys
+import threading
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
 from modules.display.drivers.base import DisplayCapabilities, DisplayDriver
 from modules.display.gpio_registry import GpioRegistry
+
+logger = logging.getLogger("waveshare_213g")
 
 _VENDOR_DIR = Path(__file__).resolve().parent / "vendor"
 if str(_VENDOR_DIR) not in sys.path:
@@ -43,6 +64,53 @@ _CAPABILITIES = DisplayCapabilities(
 # pin-correspondence table.
 DEFAULT_PINS: dict[str, int] = {"rst": 17, "dc": 25, "cs": 8, "busy": 24, "pwr": 18}
 DEFAULT_SPI: dict[str, int] = {"bus": 0, "device": 0}
+
+# Module-level, not per-instance - epdconfig.implementation (the thing this
+# guards) is itself module-level shared state, so a per-instance lock would
+# still let two different Waveshare213gDriver instances (e.g. old + new
+# during a model-switch reinit) race on it.
+_VENDOR_LOCK = threading.Lock()
+
+# Bounded, not indefinite: an unconditional acquire() would just turn a
+# contended attempt into a second orphaned thread once ITS OWN outer
+# watchdog (DisplayManager's _run_with_timeout, default 75s) gives up
+# waiting on it - stacking up abandoned threads across retries instead of
+# fixing anything. A bounded wait fails fast and honestly instead. Set
+# somewhat above DisplayManager's default 75s refresh_timeout so a
+# genuinely still-running (not stuck) previous operation has a realistic
+# chance to finish and release the lock on its own.
+_VENDOR_LOCK_TIMEOUT = 90.0
+
+
+class VendorSessionLocked(Exception):
+    """Raised when _VENDOR_LOCK can't be acquired within
+    _VENDOR_LOCK_TIMEOUT - deliberately its own exception type (not a bare
+    RuntimeError) so it's unambiguous in logs and _last_error. This
+    project's e-paper work has already produced two other distinct
+    Waveshare failure signatures in the wild (a floating-BUSY hang before
+    the vendor init fix, and GPIODeviceClosed from the very module-level
+    corruption this lock now prevents) - conflating a third one (lock
+    contention) into a generic message would cost whoever debugs the next
+    incident the same untangling work all over again."""
+
+
+@contextmanager
+def _vendor_session():
+    """Hold _VENDOR_LOCK for the duration of any block that touches
+    epdconfig.implementation (directly or via a vendor EPD object bound to
+    it) - see the module docstring for why this exists alongside
+    DisplayManager's own worker-pause coordination, not instead of it."""
+    acquired = _VENDOR_LOCK.acquire(timeout=_VENDOR_LOCK_TIMEOUT)
+    if not acquired:
+        raise VendorSessionLocked(
+            f"vendor session lock: still held by a previous operation after "
+            f"{_VENDOR_LOCK_TIMEOUT:.0f}s wait - this is lock contention, "
+            f"NOT a hardware BUSY timeout"
+        )
+    try:
+        yield
+    finally:
+        _VENDOR_LOCK.release()
 
 
 class Waveshare213gDriver(DisplayDriver):
@@ -81,16 +149,17 @@ class Waveshare213gDriver(DisplayDriver):
         if self._gpio_registry is not None:
             self._gpio_registry.claim(self._pins, owner=self.id)
         try:
-            epdconfig, epd2in13g_v2 = self._configure_vendor_pins()
-            epd = epd2in13g_v2.EPD()
-            if epd.init() != 0:
-                self._last_error = "vendor EPD.init() returned non-zero"
-                return False
-            self._epdconfig = epdconfig
-            self._epd = epd
-            self._started = True
-            self._last_error = None
-            return True
+            with _vendor_session():
+                epdconfig, epd2in13g_v2 = self._configure_vendor_pins()
+                epd = epd2in13g_v2.EPD()
+                if epd.init() != 0:
+                    self._last_error = "vendor EPD.init() returned non-zero"
+                    return False
+                self._epdconfig = epdconfig
+                self._epd = epd
+                self._started = True
+                self._last_error = None
+                return True
         except Exception as exc:
             self._last_error = str(exc)
             return False
@@ -105,7 +174,14 @@ class Waveshare213gDriver(DisplayDriver):
         of this method) skipped that release entirely, leaking the claim
         until process restart - this matters in practice for
         DisplayManager.swap_driver_and_start()'s reinit-failure rollback path,
-        which calls stop() on exactly such a driver."""
+        which calls stop() on exactly such a driver.
+
+        Never raises - callers include a path (DisplayManager.
+        _render_with_retries()'s render-timeout branch) that calls stop()
+        without a try/except of its own; an uncaught exception there would
+        silently kill the whole worker thread. That's a real risk now that
+        _vendor_session() can raise VendorSessionLocked here too, not just
+        a pre-existing theoretical concern."""
         try:
             if self._started and self._epdconfig is not None:
                 # cleanup=True is required here - the vendor's default
@@ -114,7 +190,10 @@ class Waveshare213gDriver(DisplayDriver):
                 # pin-factory level (lgpio), so a plain module_exit() call
                 # looked like a clean stop but never actually released the
                 # physical GPIO lines - see tools/test_gpio_cleanup.py.
-                self._epdconfig.module_exit(cleanup=True)
+                with _vendor_session():
+                    self._epdconfig.module_exit(cleanup=True)
+        except Exception:
+            logger.exception("[EPAPER] %s.stop(): module_exit failed", self.id)
         finally:
             self._epd = None
             self._epdconfig = None
@@ -124,16 +203,19 @@ class Waveshare213gDriver(DisplayDriver):
 
     def render(self, image: Any, fast: bool = False) -> None:
         self._require_started()
-        buf = self._epd.getbuffer(image)
-        self._epd.display(buf)
+        with _vendor_session():
+            buf = self._epd.getbuffer(image)
+            self._epd.display(buf)
 
     def clear(self) -> None:
         self._require_started()
-        self._epd.Clear()
+        with _vendor_session():
+            self._epd.Clear()
 
     def sleep(self) -> None:
         self._require_started()
-        self._epd.sleep()  # vendor sleep() also calls module_exit() internally
+        with _vendor_session():
+            self._epd.sleep()  # vendor sleep() also calls module_exit() internally
         self._started = False
 
     def get_status(self) -> dict[str, Any]:

--- a/tools/test_waveshare_vendor_lock.py
+++ b/tools/test_waveshare_vendor_lock.py
@@ -1,0 +1,148 @@
+"""Unit test (no hardware) for waveshare_213g.py's _VENDOR_LOCK: proves the
+bounded-acquire behavior added to close the second race found in
+DisplayManager's retry loop (see manager.py's module docstring and
+_render_with_retries()) - an abandoned watchdog thread from a timed-out
+start() could still be touching epdconfig.implementation (module-level
+shared state) when a later attempt calls start() again on the same
+instance.
+
+Pure lock-logic test, deterministic by construction (holds the lock from
+the main thread, forcing a background caller to genuinely contend for it -
+not hoping a sleep() wins a timing race), so this runs anywhere with the
+venv active, no dev-node SSH or real panel needed:
+
+    python3 tools/test_waveshare_vendor_lock.py
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def test_bounded_acquire_fails_fast_and_distinctly() -> bool:
+    import modules.display.drivers.waveshare_213g as w
+
+    log_prefix = "test_bounded_acquire_fails_fast_and_distinctly"
+
+    # Shrink the timeout for a fast test - _vendor_session() reads the
+    # module global at call time, so patching it here is enough.
+    original_timeout = w._VENDOR_LOCK_TIMEOUT
+    w._VENDOR_LOCK_TIMEOUT = 0.5
+
+    try:
+        w._VENDOR_LOCK.acquire()  # hold it from the main thread
+        try:
+            t0 = time.monotonic()
+            raised = None
+            try:
+                with w._vendor_session():
+                    pass  # should never reach here
+            except Exception as exc:  # noqa: BLE001 - inspecting the type is the point
+                raised = exc
+            elapsed = time.monotonic() - t0
+
+            if not isinstance(raised, w.VendorSessionLocked):
+                print(f"FAIL [{log_prefix}]: expected VendorSessionLocked, got {raised!r}")
+                return False
+            if "lock contention" not in str(raised) or "BUSY" not in str(raised):
+                print(
+                    f"FAIL [{log_prefix}]: message not distinctly worded "
+                    f"(must mention lock contention AND explicitly rule out "
+                    f"a hardware BUSY timeout) - got: {raised}"
+                )
+                return False
+            if elapsed > 2.0:
+                print(f"FAIL [{log_prefix}]: took {elapsed:.2f}s, expected ~0.5s bounded wait")
+                return False
+        finally:
+            w._VENDOR_LOCK.release()
+    finally:
+        w._VENDOR_LOCK_TIMEOUT = original_timeout
+
+    print(f"PASS [{log_prefix}]: raised VendorSessionLocked with a distinct "
+          f"message in {elapsed:.2f}s, did not hang")
+    return True
+
+
+def test_stop_never_raises_on_lock_contention() -> bool:
+    import modules.display.drivers.waveshare_213g as w
+    from modules.display.gpio_registry import GpioRegistry
+
+    log_prefix = "test_stop_never_raises_on_lock_contention"
+
+    original_timeout = w._VENDOR_LOCK_TIMEOUT
+    w._VENDOR_LOCK_TIMEOUT = 0.3
+
+    registry = GpioRegistry()
+    driver = w.Waveshare213gDriver(gpio_registry=registry)
+    # Simulate "already started" without touching real hardware - stop()
+    # only needs self._started/_epdconfig truthy to attempt module_exit().
+    driver._started = True
+    driver._epdconfig = object()
+    registry.claim(driver._pins, owner=driver.id)
+
+    try:
+        w._VENDOR_LOCK.acquire()  # force stop()'s _vendor_session() to contend
+        try:
+            try:
+                driver.stop()
+            except Exception as exc:  # noqa: BLE001 - the point is that this must NOT happen
+                print(f"FAIL [{log_prefix}]: stop() raised {exc!r} - must never raise")
+                return False
+        finally:
+            w._VENDOR_LOCK.release()
+    finally:
+        w._VENDOR_LOCK_TIMEOUT = original_timeout
+
+    if registry.get_owner(driver._pins["rst"]) is not None:
+        print(f"FAIL [{log_prefix}]: GPIO registry claim was not released despite the lock failure")
+        return False
+    if driver._started:
+        print(f"FAIL [{log_prefix}]: driver still reports _started=True after stop()")
+        return False
+
+    print(f"PASS [{log_prefix}]: stop() swallowed the lock-contention failure, "
+          f"still released GPIO registry claim and reset state")
+    return True
+
+
+def test_lock_releases_normally_after_contention_clears() -> bool:
+    """Confirms the lock isn't left in a bad state by the above - a normal
+    acquire succeeds immediately once nothing is holding it."""
+    import modules.display.drivers.waveshare_213g as w
+
+    log_prefix = "test_lock_releases_normally_after_contention_clears"
+
+    t0 = time.monotonic()
+    with w._vendor_session():
+        pass
+    elapsed = time.monotonic() - t0
+
+    if elapsed > 1.0:
+        print(f"FAIL [{log_prefix}]: uncontended acquire took {elapsed:.2f}s, expected near-instant")
+        return False
+
+    print(f"PASS [{log_prefix}]: uncontended _vendor_session() acquired/released in {elapsed:.3f}s")
+    return True
+
+
+def main() -> int:
+    results = [
+        test_bounded_acquire_fails_fast_and_distinctly(),
+        test_stop_never_raises_on_lock_contention(),
+        test_lock_releases_normally_after_contention_clears(),
+    ]
+    if all(results):
+        print("ALL PASS")
+        return 0
+    print("FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the second, related race identified while verifying PR #16 (the reinit-vs-worker race fix): `_render_with_retries()` (`manager.py`) only calls `driver.stop()` after a timed-out `render()`, not after a timed-out `start()` - so on a retry, an abandoned watchdog thread from a prior `start()` attempt (Python can't force-cancel a thread) can still be running when the next attempt calls `start()` again on the same instance, both touching `epdconfig.implementation` (module-level shared state in the vendor wrapper). Same root cause as PR #16's race, different trigger.

This also closes a gap in PR #16 itself: `DisplayManager._worker_idle` is set as soon as a refresh cycle *returns*, even if that cycle abandoned a still-running background thread - so a subsequent `swap_driver_and_start()` could still collide with that orphan too, despite the worker-pause coordination PR #16 added.

## Fix

Adds a **module-level** (not per-instance - the state it guards, `epdconfig.implementation`, is itself module-level) `threading.Lock()` in `waveshare_213g.py`, held for the duration of every method that touches it: `start()`/`render()`/`clear()`/`sleep()`/`stop()`.

**Bounded acquire (90s), not indefinite.** An unconditional wait would just turn a contended attempt into a *second* orphaned thread once its own outer watchdog (`DisplayManager`'s default 75s `refresh_timeout`) gives up on it - stacking up abandoned threads across retries instead of fixing anything. A bounded wait fails fast and honestly instead.

**Distinct exception type (`VendorSessionLocked`), not a generic `RuntimeError`.** This project has already produced two other distinct Waveshare failure signatures this session - a floating-BUSY hang (fixed via the vendor init BUSY-kick, PR #11) and `GPIODeviceClosed` (the actual live symptom of the corruption this lock prevents). Conflating a third one (lock contention) into an indistinguishable message would cost whoever debugs the next incident the same untangling work all over again. The message explicitly states this is lock contention, **not** a hardware BUSY timeout.

**`stop()` now never raises** (catches its own exceptions, logs and swallows). A real risk introduced by this change, not a pre-existing one: `_render_with_retries()`'s render-timeout branch calls `self._driver.stop()` without its own `try/except` - an uncaught `VendorSessionLocked` there would have silently killed the entire worker thread.

**WeAct's driver doesn't need this** - `_weact_ssd1681.py` already constructs its own `gpiozero`/`spidev` objects per-instance from the start; there's no monkey-patched shared state to protect.

## How this relates to PR #16 (not a duplicate)

Two independent layers, by design:
- PR #16's worker-pause mechanism coordinates **when a new cycle is allowed to start**, at the `DisplayManager` level - proactive, avoids most contention in the common case, gives clean status reporting.
- This lock protects the **actual shared vendor resource**, at the driver level - the safety net for exactly the case the first mechanism can't cover (an orphaned thread `DisplayManager` already considers "idle").

## Test plan

- [x] `tools/test_waveshare_vendor_lock.py` (new) - pure lock logic, no hardware needed, deterministic (holds the lock from the main thread to force real contention, not timing luck): bounded acquire fails fast with the distinct exception and correct wording, `stop()` never raises even when contended (and still releases its GPIO registry claim / resets state), the lock isn't left in a bad state afterward. **PASS**, both locally and on dev hardware.
- [x] `tools/test_display_manager.py` Parts 2-4 (regression, no hardware needed) - **PASS**, no change in behavior.
- [ ] `tools/test_display_manager.py` Part 1 (real hardware) - **still fails** the same way it did before this fix (does not reach ONLINE within the test's 60s window) - see Accepted risk below. This fix was never expected to resolve that; it protects against *corruption*, not against a genuinely slow/stuck `start()`.

## Accepted risk (explicit, not silent)

**Part 1's real-hardware timeout remains unexplained after this fix, and is NOT the same issue this PR closes.** Confirmed via isolated runs directly on the dev node: `tools/test_epaper.py` (raw vendor driver, no wrapper) and `tools/test_epaper_driver.py` (`DisplayDriver` interface, main thread, no `DisplayManager`) both complete cleanly in well under a minute, repeatedly. Only `DisplayManager`'s own call path (worker thread → watchdog thread → `driver.start()`, two levels of thread nesting) reliably reproduces the stall, three separate times across this session, both before and after this lock fix.

One live hypothesis, not yet tested: the two-level thread nesting itself (vs. the single level exercised by the isolated tests above) may be the actual variable, not physical hardware instability - this has NOT been isolated yet and should be the next step if this is picked back up, rather than re-guessing at "flaky panel" again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
