### PR TITLE
fix: e-paper System Screen - missing Path import broke CPU temperature

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -10,7 +10,7 @@ from system_log import get_system_events, log_system_event
 MESHCenter_SERVICE = "meshcenter.service"
 
 
-def register_system_routes(app):
+def register_system_routes(app, get_cpu_temperature=None):
 
     @app.route("/api/system/log")
     def api_system_log():
@@ -120,11 +120,18 @@ def register_system_routes(app):
         except Exception:
             pass
 
-        try:
-            with open("/sys/class/thermal/thermal_zone0/temp", "r") as f:
-                result["cpu_temp"] = round(int(f.read().strip()) / 1000, 1)
-        except Exception:
-            pass
+        # Not a second independent sensor read - shares the same source
+        # server.py's e-paper System Screen uses (_read_cpu_temperature()),
+        # passed in via get_cpu_temperature so both surfaces show the same
+        # number instead of two code paths that happen to read the same
+        # file and could silently drift apart (as they did before this
+        # was unified - see the e-paper System Screen fix this shipped
+        # alongside).
+        if get_cpu_temperature is not None:
+            try:
+                result["cpu_temp"] = get_cpu_temperature()
+            except Exception:
+                pass
 
         try:
             result["load_avg"] = os.getloadavg()[0]

--- a/modules/display/pages/system.py
+++ b/modules/display/pages/system.py
@@ -29,13 +29,18 @@ def render(caps: DisplayCapabilities, data: SystemScreenData, locale: str = DEFA
 
     draw_text(image, (4, 2), t("system", locale), "black", title_font)
 
+    # 1 decimal place - matches the web UI footer's precision convention
+    # for these same three metrics (static/chat.js's formatDockPercent()/
+    # formatTemperature()); this is the only Python-side formatter for
+    # them, so there's nowhere else a second, differently-precisioned one
+    # could creep in.
     def fmt(value, unit):
-        return f"{value:.0f}{unit}" if value is not None else "--"
+        return f"{value:.1f}{unit}" if value is not None else "--"
 
     rows = [
         (t("cpu", locale), fmt(data.cpu_percent, "%")),
         (t("ram", locale), fmt(data.ram_percent, "%")),
-        (t("temp", locale), fmt(data.cpu_temp_c, "C")),
+        (t("temp", locale), fmt(data.cpu_temp_c, "°C")),
     ]
     value_x = 4 + max(text_width(f"{label}:", label_font) for label, _ in rows) + 6
     y = 30

--- a/modules/display/service.py
+++ b/modules/display/service.py
@@ -96,8 +96,19 @@ CRITICAL_LOW_BATTERY_PERCENT = 10
 # stays identical across insignificant drift.
 _SIGNIFICANCE_BUCKET = 5
 
+# CPU temperature is a different unit/scale than a CPU/RAM percentage - a
+# 5-degree bucket would be far too coarse (real thermal drift is usually
+# under 1C between polls), and reusing _SIGNIFICANCE_BUCKET's step for it
+# would be a unit mismatch, not a shared constant. This exists for the
+# same reason _SIGNIFICANCE_BUCKET does: the System Screen shows 1-decimal
+# values (matching the web UI footer's precision, see system.py's fmt()),
+# and unbucketed raw values jitter on nearly every poll - showing that
+# raw jitter as text would reintroduce the exact refresh-per-tick problem
+# _SIGNIFICANCE_BUCKET was added to fix (e-Paper Stage 1 plan, Phase 5).
+_TEMP_SIGNIFICANCE_BUCKET = 1.0
 
-def _bucket(value: float | None, step: int = _SIGNIFICANCE_BUCKET) -> float | None:
+
+def _bucket(value: float | None, step: float = _SIGNIFICANCE_BUCKET) -> float | None:
     if value is None:
         return None
     return round(value / step) * step
@@ -258,7 +269,7 @@ def _render_page(page: str, manager, local_node_name, get_radio_status, get_list
     if page == "system":
         return system_page.render(caps, system_page.SystemScreenData(
             cpu_percent=_bucket(get_cpu_percent()), ram_percent=_bucket(get_ram_percent()),
-            cpu_temp_c=get_cpu_temp(),
+            cpu_temp_c=_bucket(get_cpu_temp(), step=_TEMP_SIGNIFICANCE_BUCKET),
         ), locale=locale)
 
     if page == "message":

--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ import csv
 import uuid
 import ast
 import sqlite3
+from pathlib import Path
 from contextlib import contextmanager
 from collections import defaultdict, deque
 from datetime import datetime
@@ -314,7 +315,7 @@ register_camera_routes(app, camera, handle_errors)
 # api/api_camera_manager.py's module docstring. Does not touch
 # /video_feed or anything else camera.py already owns.
 register_camera_manager_routes(app, device_manager, handle_errors)
-register_system_routes(app)
+register_system_routes(app, get_cpu_temperature=lambda: _read_cpu_temperature())
 
 # Constructing DisplayManager (and the driver it wraps) never touches
 # SPI/GPIO by itself - only display_manager.start(), called later from the


### PR DESCRIPTION
## Summary

Fixes the e-paper System Screen (`modules/display/pages/system.py`, reachable via the "Система"/"Show on Display" button) diverging from the web UI footer for the same node's CPU/RAM/Temp:

1. **Temperature always showed "--"**, even though the footer showed a real value at the same moment.
2. **Precision mismatch** - the screen showed whole numbers ("CPU: 0%"), the footer shows one decimal place ("CPU 1.8%").

## Root cause (temperature)

`server.py`'s `_read_cpu_temperature()` uses `pathlib.Path` - but `server.py` never imports `Path` anywhere else in the entire file (confirmed via `grep -n "\bPath\b" server.py` - exactly one usage, zero imports). The `NameError` this raises gets silently swallowed by the function's bare `except Exception: continue`, so it always fell through to `return None`, regardless of the sensor file being present and readable.

This was never caught because the web UI footer reads temperature through a **second, independent code path** - `api/api_system.py`'s `/api/system/info` route has its own inline read (plain `open()`, no `Path`), which never hit the bug. Confirmed live: at the same moment the System Screen showed `Темп.: --`, `/api/system/info` returned a real `cpu_temp` value.

## Fix

- Added the missing `from pathlib import Path` (`server.py`).
- **Eliminated the second independent path**, not just papered over the symptom: `api_system.py`'s `/api/system/info` no longer has its own inline sensor read - it now takes `get_cpu_temperature` (server.py's `_read_cpu_temperature`, passed in via the same dependency-injection convention every other route module in this codebase uses) and calls that instead. The footer and the e-paper System Screen are now provably reading the same source, not two implementations that happened to agree by coincidence.
- `system.py`'s `fmt()` now formats CPU/RAM/Temp with 1 decimal place, matching the footer's precision convention (`static/chat.js`'s `formatDockPercent()`/`formatTemperature()`) instead of whole numbers. This is the only Python-side formatter for these three values, so there's no second one with a different decimal count to drift out of sync later.
- **Temperature is now bucketed too**, via a new `_TEMP_SIGNIFICANCE_BUCKET` (1.0°C step - CPU/RAM's existing 5-percentage-point bucket step would be a unit mismatch for degrees). This is the same reason CPU/RAM were already bucketed (e-Paper Stage 1 Phase 5): `DisplayManager`'s dedup is a hash of whatever text actually gets drawn - unbucketed raw values (especially now that formatting shows a real decimal) would jitter on nearly every 5s poll and trigger a physical refresh on every trivial thermal wobble, exactly the problem bucketing was added to prevent in the first place. **Displayed values are therefore expected to be approximately equal to the footer's live reading, not identical tick-for-tick - by design**, not a residual bug (the footer itself refreshes every ~2s from a live unbucketed read; the e-paper screen intentionally doesn't).

## Test plan

- [x] Live, by photograph (not by "refresh completed" logs) - triggered `/api/hardware/display/show/system` on the real Waveshare panel and compared against the web UI footer at roughly the same time: screen showed `CPU: 15.0% / RAM: 55.0% / Темп.: 52.0°C`, footer showed `CPU 26.0% / RAM 62.4% / TEMP 52.6°C` moments later (real load changed between the two captures, ~20-30s apart given the panel's own refresh latency) - same ballpark, all three metrics present with real decimals, none showing `--`.
- [x] `tools/test_epaper_i18n.py` (all 4 locales × both panel models) - re-run after this change, no regression, all render without exceptions.
- [x] Confirmed the footer (`/api/system/info`) still returns a real `cpu_temp` after routing it through the shared getter - unchanged behavior from the caller's perspective, just no longer a duplicate implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
