### PR TITLE
fix: e-paper System Screen ignores the temperature-unit setting

### DIFF
--- a/modules/display/pages/system.py
+++ b/modules/display/pages/system.py
@@ -16,7 +16,29 @@ from modules.display.renderer import draw_text, load_font, new_canvas, text_widt
 class SystemScreenData:
     cpu_percent: float | None = None
     ram_percent: float | None = None
-    cpu_temp_c: float | None = None
+    cpu_temp_c: float | None = None  # always Celsius - see _format_temp() for unit conversion
+    temperature_unit: str = "c"  # "c" | "f" | "both" - settings.units.temperature
+
+
+def _celsius_to_fahrenheit(c: float) -> float:
+    return c * 9.0 / 5.0 + 32.0
+
+
+def _format_temp(celsius: float | None, unit: str) -> str:
+    """Mirrors static/chat.js's formatTemperature() (same 3 unit modes,
+    same 1-decimal precision) so the e-paper screen and the web UI footer
+    agree on more than just the underlying sensor value - found missing
+    after the System Screen's temperature bug was fixed: the screen kept
+    drawing Celsius regardless of this setting, so switching units in
+    Settings made the footer and the screen disagree even though both
+    were already reading the same source."""
+    if celsius is None:
+        return "--"
+    if unit == "f":
+        return f"{_celsius_to_fahrenheit(celsius):.1f}°F"
+    if unit == "both":
+        return f"{celsius:.1f}°C/{_celsius_to_fahrenheit(celsius):.1f}°F"
+    return f"{celsius:.1f}°C"
 
 
 def render(caps: DisplayCapabilities, data: SystemScreenData, locale: str = DEFAULT_LOCALE):
@@ -40,7 +62,7 @@ def render(caps: DisplayCapabilities, data: SystemScreenData, locale: str = DEFA
     rows = [
         (t("cpu", locale), fmt(data.cpu_percent, "%")),
         (t("ram", locale), fmt(data.ram_percent, "%")),
-        (t("temp", locale), fmt(data.cpu_temp_c, "°C")),
+        (t("temp", locale), _format_temp(data.cpu_temp_c, data.temperature_unit)),
     ]
     value_x = 4 + max(text_width(f"{label}:", label_font) for label, _ in rows) + 6
     y = 30

--- a/modules/display/service.py
+++ b/modules/display/service.py
@@ -179,6 +179,7 @@ def epaper_worker(
     get_cpu_temp: Callable[[], float | None] = lambda: None,
     get_latest_message: Callable[[], dict[str, Any] | None] = lambda: None,
     get_display_language: Callable[[], str] = lambda: DEFAULT_LOCALE,
+    get_temperature_unit: Callable[[], str] = lambda: "c",
     stop_event: threading.Event | None = None,
 ) -> None:
     stop_event = stop_event or threading.Event()
@@ -192,6 +193,7 @@ def epaper_worker(
                     get_ram_percent, get_listener_alive, local_node_name, content_state,
                     get_battery_percent, get_active_page, get_last_error,
                     get_power_readings, get_cpu_temp, get_latest_message, get_display_language,
+                    get_temperature_unit,
                 )
         except Exception:
             logger.exception("[EPAPER] epaper_worker: poll failed")
@@ -245,7 +247,8 @@ def _build_status_fields(
 
 def _render_page(page: str, manager, local_node_name, get_radio_status, get_listener_alive,
                   get_last_error, get_power_readings, get_cpu_percent, get_ram_percent,
-                  get_cpu_temp, get_latest_message, locale: str = DEFAULT_LOCALE):
+                  get_cpu_temp, get_latest_message, locale: str = DEFAULT_LOCALE,
+                  temperature_unit: str = "c"):
     """Build+render whichever page is currently selected (plan section
     34's "Show on Display"), using only already-collected state - same
     invariant as the Status Screen (section 40)."""
@@ -269,7 +272,13 @@ def _render_page(page: str, manager, local_node_name, get_radio_status, get_list
     if page == "system":
         return system_page.render(caps, system_page.SystemScreenData(
             cpu_percent=_bucket(get_cpu_percent()), ram_percent=_bucket(get_ram_percent()),
+            # Bucketed in Celsius (the sensor's native unit) regardless of
+            # display unit - converting first would need a differently-
+            # scaled bucket step per unit for no benefit, since the bucket
+            # only exists to stabilize the rendered image, not to be
+            # user-facing itself.
             cpu_temp_c=_bucket(get_cpu_temp(), step=_TEMP_SIGNIFICANCE_BUCKET),
+            temperature_unit=temperature_unit,
         ), locale=locale)
 
     if page == "message":
@@ -291,6 +300,7 @@ def _poll_once(
     get_cpu_temp=lambda: None,
     get_latest_message=lambda: None,
     get_display_language=lambda: DEFAULT_LOCALE,
+    get_temperature_unit=lambda: "c",
 ) -> None:
     data, content_key = _build_status_fields(
         state_lock, nodes, get_radio_status, get_cpu_percent, get_ram_percent,
@@ -340,7 +350,7 @@ def _poll_once(
         image = _render_page(
             active_page, manager, local_node_name, get_radio_status, get_listener_alive,
             get_last_error, get_power_readings, get_cpu_percent, get_ram_percent,
-            get_cpu_temp, get_latest_message, locale,
+            get_cpu_temp, get_latest_message, locale, get_temperature_unit(),
         )
         if image is not None:
             manager.mark_dirty(image)
@@ -373,6 +383,7 @@ def build_page_image_now(
     get_last_error, get_power_readings, get_cpu_percent, get_ram_percent,
     get_cpu_temp, get_latest_message,
     locale: str = DEFAULT_LOCALE,
+    temperature_unit: str = "c",
 ):
     """For POST /api/hardware/display/show/<page> - builds whichever page
     was requested right now, for an immediate (CRITICAL) push. Returns
@@ -383,5 +394,5 @@ def build_page_image_now(
     return _render_page(
         page, manager, local_node_name, get_radio_status, get_listener_alive,
         get_last_error, get_power_readings, get_cpu_percent, get_ram_percent,
-        get_cpu_temp, get_latest_message, locale,
+        get_cpu_temp, get_latest_message, locale, temperature_unit,
     )

--- a/server.py
+++ b/server.py
@@ -397,6 +397,16 @@ def _epaper_get_display_language():
         language_setting = normalize_settings(settings).get("language", "auto")
     return resolve_display_language(language_setting)
 
+def _epaper_get_temperature_unit():
+    # Same settings.units.temperature ("c"/"f"/"both") the web UI footer
+    # reads (static/chat.js's formatTemperature()) - found missing after
+    # the System Screen temperature fix shipped: the screen always drew
+    # Celsius regardless of this setting, so switching units in Settings
+    # made the footer and the e-paper screen disagree even though both
+    # were reading the same underlying sensor value.
+    with state_lock:
+        return normalize_settings(settings).get("units", {}).get("temperature", "c")
+
 def _epaper_build_status_image_now():
     return build_status_image_now(
         display_manager, state_lock, nodes,
@@ -412,6 +422,7 @@ def _epaper_build_page_image_now(page):
         _epaper_get_power_readings, _epaper_get_cpu_percent, _epaper_get_ram_percent,
         _epaper_get_cpu_temp, _epaper_get_latest_message,
         locale=_epaper_get_display_language(),
+        temperature_unit=_epaper_get_temperature_unit(),
     )
 
 register_hardware_display_routes(
@@ -5767,6 +5778,7 @@ if __name__ == "__main__":
                 get_cpu_temp=_epaper_get_cpu_temp,
                 get_latest_message=_epaper_get_latest_message,
                 get_display_language=_epaper_get_display_language,
+                get_temperature_unit=_epaper_get_temperature_unit,
             ),
             daemon=True,
         ).start()


### PR DESCRIPTION
## Summary

Follow-up to PR #18 (System Screen temperature fix), found live by the user right after that PR merged: switching **Settings > Units > Temperature to Fahrenheit** changed the web UI footer (`static/chat.js`'s `formatTemperature()`) but not the e-paper System Screen, which kept drawing Celsius regardless. Same underlying sensor value, but a real remaining format mismatch between the two surfaces - exactly the kind of gap PR #18 was meant to close, just one dimension I didn't check at the time (precision and source were verified; unit conversion wasn't).

## Fix

- `server.py` adds `_epaper_get_temperature_unit()`, reading `settings["units"]["temperature"]` ("c"/"f"/"both") - mirrors the existing `_epaper_get_display_language()` pattern exactly.
- Threaded through `modules/display/service.py` the same way `locale` already is (`epaper_worker`, `_poll_once`, `_render_page`, `build_page_image_now`).
- `system.py` adds `_format_temp()`, mirroring `formatTemperature()`'s three modes (`c`/`f`/`both`) and 1-decimal precision.
- **Bucketing still happens in Celsius** (`_TEMP_SIGNIFICANCE_BUCKET`, the sensor's native unit) *before* conversion - converting first would need a differently-scaled bucket step per unit for no real benefit, since the bucket exists only to stabilize the rendered image (avoid a physical refresh on every trivial thermal wobble), not to be a user-facing number itself.

## Test plan

- [x] Rendered all 3 unit modes (`c`/`f`/`both`) offline on the dev node's real Pillow/DejaVu, both panel widths - `"both"` produces the longest string (`"53.7°C/128.7°F"`) and was the one I was actually worried about fitting on WeAct's narrower 200px canvas; it fits cleanly with margin on both panels, no clipping.
- [x] Live, by photograph, on the physical Waveshare panel with `units.temperature` actually set to `"f"`: screen showed `Темп.: 122.0°F`, footer showed `TEMP 121.8°F` at roughly the same time - matches within the expected bucket tolerance (same as PR #18's Celsius verification), not exact tick-for-tick by the same design tradeoff documented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
