### PR TITLE
ci: auto-attach firstrun.sh to releases + update download links

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,20 @@
+name: Attach installer to release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  attach-installer:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload firstrun.sh to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: firstrun.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@
 
 After flashing, the SD card appears as a drive called **bootfs**.
 
-Download **[firstrun.sh](https://raw.githubusercontent.com/FlintUA/MeshCenter/main/firstrun.sh)**
+Download **[firstrun.sh](https://github.com/FlintUA/MeshCenter/releases/latest/download/firstrun.sh)**
 and copy it to the **root** of the bootfs drive:
 
 ```

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ then flash to the SD card.
 ### 2 — Add the installer
 
 After flashing, the SD card appears as a drive called **bootfs**.
-Download **[firstrun.sh](https://raw.githubusercontent.com/FlintUA/MeshCenter/main/firstrun.sh)**
+Download **[firstrun.sh](https://github.com/FlintUA/MeshCenter/releases/latest/download/firstrun.sh)**
 and copy it to the root of that drive:
 
 | OS | Path |


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-assets.yml`: uploads `firstrun.sh` as a downloadable release asset on every published GitHub release.
- Attached `firstrun.sh` to the existing `v1.6.0` release manually (via `gh release upload`), since the workflow only runs on future publishes.
- README.md / INSTALL.md: firstrun.sh download link updated from the `raw.githubusercontent.com` blob URL to `/releases/latest/download/firstrun.sh`, so the browser downloads the file directly instead of displaying it as text, and the link never needs updating on future releases.

## Test plan
- [x] `firstrun.sh` confirmed attached to v1.6.0 (`gh release view v1.6.0`)
- [ ] Publish a future release and confirm the workflow attaches firstrun.sh automatically
- [ ] Click the README/INSTALL.md link and confirm it triggers a file download, not a text view

🤖 Generated with [Claude Code](https://claude.com/claude-code)