### PR TITLE
fix: reboot after firstboot install to apply group membership changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,12 @@ Connect only one Meshtastic device during first install.
 3. Power on the Pi
 4. Wait 1–2 minutes, then open **http://meshcenter.local** in your browser
    to watch the 7-step installation progress (updates every 3 seconds)
-5. When installation completes, you will be automatically redirected to MeshCenter
+5. When installation completes, the Pi reboots automatically to apply
+   system group changes (radio/camera/GPIO permissions)
+
+> 🔄 The Pi reboots automatically after installation to apply
+> all system settings. MeshCenter will be available ~30 seconds
+> after the reboot at **http://meshcenter.local:5000**
 
 > ⏱ **Installation time:**
 > | Device | Without camera | With camera |
@@ -212,6 +217,7 @@ Connect only one Meshtastic device during first install.
 > | Pi Zero 2W | ~15 min | ~90 min |
 >
 > Camera support is auto-detected or enabled via `meshcenter-options` file.
+> Times above don't include the ~30s reboot at the end.
 
 ### 6 — Open MeshCenter
 

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -90,7 +90,6 @@ import http.server, socketserver, os
 
 PORT = 80
 PROGRESS_FILE = "/tmp/meshcenter-progress.txt"
-REDIRECT_FILE = "/tmp/meshcenter-redirect.txt"
 APP_PORT = 5000
 
 STEPS = [
@@ -195,17 +194,6 @@ HTML_PAGE = """<!DOCTYPE html>
 
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
-        # If installation is done — redirect to :5000
-        try:
-            redirect_url = open(REDIRECT_FILE).read().strip()
-            if redirect_url:
-                self.send_response(302)
-                self.send_header('Location', redirect_url)
-                self.end_headers()
-                return
-        except FileNotFoundError:
-            pass
-
         try:
             status = open(PROGRESS_FILE).read().strip()
         except Exception:
@@ -252,7 +240,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             footer = "Starting..."
             refresh_tag = '<meta http-equiv="refresh" content="3">'
         elif current_step >= 7:
-            footer = "Finishing up..."
+            footer = "Finishing up — the Pi will reboot shortly. Reopen this page after ~30s."
             refresh_tag = '<meta http-equiv="refresh" content="2">'
         else:
             footer = "Page refreshes every 3 seconds."
@@ -300,18 +288,6 @@ update_progress() {
         [[ "$INSTALL_CAMERA" == "yes" ]] && echo "CAMERA:yes" || true
     } > "$PROGRESS_FILE"
     log "Step ${step}/7: ${message}"
-}
-
-stop_progress_server() {
-    if [[ -n "$PROGRESS_PID" ]]; then
-        # Write the redirect URL — the page picks it up on its next refresh.
-        local ip
-        ip="$(hostname -I 2>/dev/null | awk '{print $1}')"
-        echo "http://${ip}:${APP_PORT}/" > /tmp/meshcenter-redirect.txt
-        sleep 4  # give the browser a chance to catch the redirect
-        kill "$PROGRESS_PID" 2>/dev/null || true
-        PROGRESS_PID=""
-    fi
 }
 
 trap 'rc=$?; log "ERROR: unexpected failure at line $LINENO (exit code $rc)"; exit $rc' ERR
@@ -908,6 +884,18 @@ log "Log:        $LOG_FILE"
 log "============================================================"
 
 update_progress 7 "Installation complete"
-stop_progress_server
+
+# Group membership changes (dialout, gpio, i2c, ...) applied earlier via
+# usermod only take effect for new sessions — meshcenter.service was started
+# in this same first-boot session, so the radio device may not be usable
+# until the user's group list is re-resolved. Reboot to guarantee the
+# service comes back up with correct permissions instead of leaving the
+# user to debug a working install that can't see its own radio.
+log "Rebooting to apply group membership changes..."
+log "MeshCenter will be available at http://${HOST_NAME}.local:${APP_PORT} after reboot"
+log "============================================================"
+
+# Schedule the reboot a few seconds out so this log line has time to flush.
+( sleep 5 && reboot ) &
 
 exit 0


### PR DESCRIPTION
## Summary
Confirmed on real hardware: after a fresh install, meshcenter.service couldn't see the Meshtastic radio until a manual reboot. Root cause — `usermod -a -G dialout ...` (and gpio/i2c/etc.) only takes effect for new login sessions; `meshcenter.service` was started in the same first-boot session that ran `usermod`, so the process never picked up the new group membership until the box was rebooted.

- meshcenter-firstboot.sh now reboots automatically ~5s after `DONE_FILE` is written, so the service comes back up in a fresh session with correct group permissions instead of leaving the user to debug an install that silently can't see its own radio.
- Removed `stop_progress_server()` and the `REDIRECT_FILE` redirect-to-`:5000` mechanism — redirecting the browser into a service that's about to go down for reboot was worse UX than just showing "Finishing up..." until the connection drops. Also dropped `import`-level dead code this left behind.
- README.md: step 5 and the install-time note now describe the automatic reboot instead of the old (now-removed) auto-redirect claim.

## Test plan
- [x] `bash -n meshcenter-firstboot.sh` — syntax OK
- [x] Embedded progress-server Python compiles (`py_compile`)
- [ ] End-to-end boot test confirming the radio is detected without a manual reboot after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)