### PR TITLE
fix: channel names use {name} [{index}] format in chat API and config.example

### DIFF
--- a/api/api_chat.py
+++ b/api/api_chat.py
@@ -360,7 +360,7 @@ def register_chat_routes(
                     discovered.append({
                         "id": channel_chat_id(index),
                         "index": index,
-                        "name": str(name),
+                        "name": f"{name} [{index}]" if int(index) > 0 else str(name),
                         "type": "channel",
                         "is_channel": True,
                         "is_demo": False,

--- a/config.example.py
+++ b/config.example.py
@@ -39,7 +39,7 @@ CHATS_FILE = f"{DATA_DIR}/chats.json"
 # ===== MESSAGE SETTINGS =====
 MAX_HISTORY_MESSAGES = 1000
 CHANNEL_CHAT_ID = "channel"
-CHANNEL_CHAT_NAME = "LongFast Channel 0"
+CHANNEL_CHAT_NAME = "LongFast [0]"
 
 # ===== KNOWN NODES (pre-populated with your mesh) =====
 KNOWN_NODES = {


### PR DESCRIPTION
## Summary
- `config.example.py`: `CHANNEL_CHAT_NAME` default is now `"LongFast [0]"` to match the new naming convention.
- `api/api_chat.py` `discover_radio_channels()`: secondary channel names now get an ` [index]` suffix (e.g. `"Flint-pvt [1]"`), primary channel (index 0) stays bare.

## Deviation from the original spec
The third proposed change (wrapping `chat_name = configured.get("name", ...)` around line 591 with the same `[index]` suffix logic) was skipped. `configured` there is read straight from `discover_radio_channels()`, so after the second fix `configured["name"]` already carries the `[index]` suffix for secondary channels — applying the same transformation again would have produced double brackets (`"Flint-pvt [1] [1]"`). Left that line unchanged since it already gets the correct value.

`config.py` on existing installations was intentionally left untouched, as instructed.

## Test plan
- [x] `python -m py_compile api/api_chat.py config.example.py`
- [ ] Verify in the UI that secondary channels show as `"Name [N]"` and the primary channel shows without a suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)