### PR TITLE
fix: channel name index added by code, not embedded in CHANNEL_CHAT_NAME

### DIFF
--- a/api/api_chat.py
+++ b/api/api_chat.py
@@ -303,7 +303,7 @@ def register_chat_routes(
             return [{
                 "id": CHANNEL_CHAT_ID,
                 "index": 0,
-                "name": CHANNEL_CHAT_NAME,
+                "name": f"{CHANNEL_CHAT_NAME} [0]",
                 "type": "channel",
                 "is_channel": True,
                 "is_demo": False,
@@ -360,7 +360,7 @@ def register_chat_routes(
                     discovered.append({
                         "id": channel_chat_id(index),
                         "index": index,
-                        "name": f"{name} [{index}]" if int(index) > 0 else str(name),
+                        "name": f"{name} [{index}]",
                         "type": "channel",
                         "is_channel": True,
                         "is_demo": False,
@@ -397,7 +397,7 @@ def register_chat_routes(
         fallback = [{
             "id": CHANNEL_CHAT_ID,
             "index": 0,
-            "name": CHANNEL_CHAT_NAME,
+            "name": f"{CHANNEL_CHAT_NAME} [0]",
             "type": "channel",
             "is_channel": True,
             "is_demo": False,
@@ -578,7 +578,7 @@ def register_chat_routes(
 
         final_chat_id = CHANNEL_CHAT_ID
         receiver_name = "Broadcast"
-        chat_name = CHANNEL_CHAT_NAME
+        chat_name = f"{CHANNEL_CHAT_NAME} [0]"
         chat_type = "channel"
         channel_index = 0
 

--- a/config.example.py
+++ b/config.example.py
@@ -39,7 +39,7 @@ CHATS_FILE = f"{DATA_DIR}/chats.json"
 # ===== MESSAGE SETTINGS =====
 MAX_HISTORY_MESSAGES = 1000
 CHANNEL_CHAT_ID = "channel"
-CHANNEL_CHAT_NAME = "LongFast [0]"
+CHANNEL_CHAT_NAME = "LongFast"  # without index — the code appends [0] itself
 
 # ===== KNOWN NODES (pre-populated with your mesh) =====
 KNOWN_NODES = {


### PR DESCRIPTION
## Summary
- `config.example.py`: `CHANNEL_CHAT_NAME` reverts to `"LongFast"` (no embedded index) — the previous `"LongFast [0]"` was the source of confusion once other code paths also started appending an index.
- `api/api_chat.py` `discover_radio_channels()`: every channel — including primary (index 0) — now gets `" [index]"` appended uniformly; dropped the `if int(index) > 0` special case from the previous fix.

## Extra consistency fixes beyond the literal spec
Three other spots build a fallback dict/value for the primary channel using bare `CHANNEL_CHAT_NAME` directly, not through the discovery formatting logic:
- the radio-unavailable fallback in `discover_radio_channels()` (~line 306)
- the discovery final fallback used after a failed radio read (~line 400)
- the default `chat_name` in the send handler before any channel/DM branch overrides it (~line 581)

Left as bare `CHANNEL_CHAT_NAME`, these would now show `"LongFast"` with no bracket while the live discovery path shows `"LongFast [0]"` — the exact inconsistency this fix is meant to eliminate. Updated all three to `f"{CHANNEL_CHAT_NAME} [0]"`.

## Test plan
- [x] `python -m py_compile api/api_chat.py config.example.py`
- [ ] Verify in the UI that the primary channel now shows `"LongFast [0]"` consistently across the channel list, radio-unavailable state, and sent-message chat_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)