### PR TITLE
fix: always sync primary channel name from config on load, add [index] to secondary channel names in server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -886,7 +886,13 @@ def load_chats():
                 "last_time": "",
                 "unread": 0
             }
-            save_chats()
+        else:
+            # Keep the persisted primary-channel name in sync with the
+            # current config.py — otherwise a stale name written by an old
+            # CHANNEL_CHAT_NAME value survives in chats.json forever, since
+            # this used to be a one-time seed.
+            chats[CHANNEL_CHAT_ID]["name"] = CHANNEL_CHAT_NAME
+        save_chats()
 
 def save_nodes():
     with state_lock:
@@ -3451,7 +3457,7 @@ def listen_meshtastic():
                             with state_lock:
                                 chats[chat_id] = {
                                     "id": chat_id,
-                                    "name": CHANNEL_CHAT_NAME if incoming_channel_index == 0 else f"Channel {incoming_channel_index}",
+                                    "name": CHANNEL_CHAT_NAME if incoming_channel_index == 0 else f"Channel {incoming_channel_index} [{incoming_channel_index}]",
                                     "type": "channel",
                                     "last_message": "",
                                     "last_time": "",
@@ -5268,7 +5274,7 @@ def api_waypoint_send():
 
         if post_notification:
             channel_id = channel_chat_id(channel_index)
-            channel_name = CHANNEL_CHAT_NAME if channel_index == 0 else f"Channel {channel_index}"
+            channel_name = CHANNEL_CHAT_NAME if channel_index == 0 else f"Channel {channel_index} [{channel_index}]"
             add_message(
                 "me",
                 LOCAL_NODE_NAME,


### PR DESCRIPTION
## Summary
Root cause found while investigating a previous instruction (see conversation): `chats.json`'s primary-channel name was a one-time seed written by `load_chats()` — once created, it never picked up later `CHANNEL_CHAT_NAME` changes in `config.py`, so a node could show a stale name (e.g. the old default `"LongFast Channel 0"`) in chat history forever while `api/api_chat.py`'s live discovery endpoint showed the current value.

- `load_chats()`: primary-channel `chats[CHANNEL_CHAT_ID]["name"]` is now synced from `CHANNEL_CHAT_NAME` on every load, not just the first time the record is created.
- `listen_meshtastic()` and `api_waypoint_send()`: secondary channel names now get `[index]` appended (`"Channel 1 [1]"`), matching the convention `api/api_chat.py`'s `discover_radio_channels()` already uses.

## Scope note
Per the literal instruction, the primary channel's synced name stays bare (e.g. `"LongFast"`) — only secondary channels get the `[index]` suffix in this fix. `api/api_chat.py`'s discovery endpoint still shows the primary channel bracketed (`"LongFast [0]"`), so there's a remaining display difference between the chat list and the channel-discovery list for the primary channel specifically. Flagging this in case a fully unified `[0]` everywhere is wanted later — not fixing it here since it wasn't asked for.

## Test plan
- [x] `python -m py_compile server.py`
- [ ] Restart a node with a stale `chats.json` name and confirm it corrects on next load
- [ ] Confirm secondary channel names now show `"Channel N [N]"` consistently in chat history

🤖 Generated with [Claude Code](https://claude.com/claude-code)