### PR TITLE
fix: store bare channel names in server.py, let api_chat.py add [index]

### DIFF
--- a/server.py
+++ b/server.py
@@ -880,7 +880,7 @@ def load_chats():
         if CHANNEL_CHAT_ID not in chats:
             chats[CHANNEL_CHAT_ID] = {
                 "id": CHANNEL_CHAT_ID,
-                "name": f"{CHANNEL_CHAT_NAME} [0]",
+                "name": CHANNEL_CHAT_NAME,
                 "type": "channel",
                 "last_message": "",
                 "last_time": "",
@@ -890,9 +890,10 @@ def load_chats():
             # Keep the persisted primary-channel name in sync with the
             # current config.py — otherwise a stale name written by an old
             # CHANNEL_CHAT_NAME value survives in chats.json forever, since
-            # this used to be a one-time seed. Bracketed to match
-            # api/api_chat.py's discover_radio_channels() format.
-            chats[CHANNEL_CHAT_ID]["name"] = f"{CHANNEL_CHAT_NAME} [0]"
+            # this used to be a one-time seed. Stored bare: the "[index]"
+            # suffix is a display concern added by api/api_chat.py and
+            # static/chat.js, not something persisted here.
+            chats[CHANNEL_CHAT_ID]["name"] = CHANNEL_CHAT_NAME
         save_chats()
 
 def save_nodes():
@@ -2700,7 +2701,7 @@ def add_message(kind, sender, text, node_id="", chat_id=None, chat_name=None, re
                 chat_name = chats.get(chat_id, {}).get("name")
                 if not chat_name:
                     if chat_id == CHANNEL_CHAT_ID:
-                        chat_name = f"{CHANNEL_CHAT_NAME} [0]"
+                        chat_name = CHANNEL_CHAT_NAME
                     else:
                         channel_index = chat_id.split(":", 1)[-1] if ":" in chat_id else chat_id
                         chat_name = f"Channel {channel_index}"
@@ -3458,7 +3459,7 @@ def listen_meshtastic():
                             with state_lock:
                                 chats[chat_id] = {
                                     "id": chat_id,
-                                    "name": f"{CHANNEL_CHAT_NAME} [0]" if incoming_channel_index == 0 else f"Channel {incoming_channel_index} [{incoming_channel_index}]",
+                                    "name": CHANNEL_CHAT_NAME if incoming_channel_index == 0 else f"Channel {incoming_channel_index}",
                                     "type": "channel",
                                     "last_message": "",
                                     "last_time": "",
@@ -5275,7 +5276,7 @@ def api_waypoint_send():
 
         if post_notification:
             channel_id = channel_chat_id(channel_index)
-            channel_name = f"{CHANNEL_CHAT_NAME} [0]" if channel_index == 0 else f"Channel {channel_index} [{channel_index}]"
+            channel_name = CHANNEL_CHAT_NAME if channel_index == 0 else f"Channel {channel_index}"
             add_message(
                 "me",
                 LOCAL_NODE_NAME,

--- a/static/chat.js
+++ b/static/chat.js
@@ -3461,12 +3461,19 @@ function getChatNodeShortName(chat) {
 }
 
 // Appends "[index]" to a channel name, stripping a redundant trailing
-// "Channel <index>" fragment from the name first (e.g. the primary channel's
-// resolved name "LongFast Channel 0" becomes "LongFast [0]" instead of
-// "LongFast Channel 0 [0]"). Shared by the main chat channel list and the
-// Waypoint composer's channel picker so both stay in sync.
+// "Channel <index>" fragment and/or an already-appended "[N]" bracket from
+// the name first (e.g. the primary channel's resolved name
+// "LongFast Channel 0" becomes "LongFast [0]" instead of
+// "LongFast Channel 0 [0]", and a name that already arrived pre-bracketed
+// as "LongFast [0]" doesn't become "LongFast [0] [0]"). Shared by the main
+// chat channel list and the Waypoint composer's channel picker, whose
+// `name` values come from different backend sources (server.py's stored
+// chats vs. api/api_chat.py's live discovery) that aren't guaranteed to
+// agree on whether the index is already embedded — so this needs to be
+// idempotent either way.
 function formatChannelIndexLabel(name, index) {
-    const trimmedName = String(name || '').trim();
+    let trimmedName = String(name || '').trim();
+    trimmedName = trimmedName.replace(/\s*\[\d+\]\s*$/, '').trim();
     const suffixPattern = new RegExp(`^(.*?)\\s*channel\\s+${index}$`, 'i');
     const match = trimmedName.match(suffixPattern);
     const displayName = (match ? match[1].trim() : trimmedName) || 'Channel';


### PR DESCRIPTION
## Summary
Reverts the bracket-appending that PR #29/#31 added to `server.py` (single source of truth: `chats.json` stores bare names, `api/api_chat.py`'s `discover_radio_channels()` line 363 is the one place that formats with `[index]` for the live channel list).

## Root cause found beyond the literal spec
Investigation before applying this showed the real double-bracketing bug lives in `static/chat.js`'s `formatChannelIndexLabel()` — it's shared by two call sites reading from two different backend sources (`chat.name` from server.py's stored chats, `channel.name` from api_chat.py's live discovery), but only ever stripped a `"Channel N"` text suffix, never an already-appended `"[N]"` bracket. Reverting server.py alone only fixes the chat sidebar; the Waypoint composer's channel picker (which reads the still-bracketed `channels` array) would keep double-bracketing. Made the JS function idempotent — strips a trailing `[N]` first — so both call sites are safe regardless of which backend source they're fed.

(The originally proposed JS snippet had a regression of its own — its "Channel N" strip pattern was fully anchored instead of suffix-matching, and its `|| baseName` fallback silently undid the strip when it did match. Kept the original suffix-stripping logic and only added the bracket-stripping step in front of it.)

## Test plan
- [x] `python -m py_compile server.py api/api_chat.py`
- [x] Extracted the real `formatChannelIndexLabel()` from the edited file and ran it against bare, bracketed, and old-text-suffix inputs in Node — all idempotent, no double brackets, original fallback behavior preserved
- [ ] After node sync + chats.json cleanup + restart: confirm `/api/chats?refresh_channels=1` and the UI (sidebar + Waypoint composer) both show `"LongFast [0]"` / `"Flint-pvt [1]"` with no double brackets

🤖 Generated with [Claude Code](https://claude.com/claude-code)