### PR TITLE
fix: wait 1.5s after waitForConfig() so secondary channel roles settle before filtering

### DIFF
--- a/api/api_chat.py
+++ b/api/api_chat.py
@@ -333,6 +333,12 @@ def register_chat_routes(
                     except Exception as wait_error:
                         print(f"[CHANNELS] waitForConfig() warning: {wait_error}", flush=True)
 
+                # Give the radio extra time to sync secondary channel roles —
+                # they can briefly still report role=DISABLED (their unset
+                # default) right after waitForConfig() returns, before the
+                # full config has actually finished trickling in.
+                time.sleep(1.5)
+
                 raw_channels = getattr(getattr(interface, "localNode", None), "channels", None) or []
 
                 for fallback_index, channel in enumerate(raw_channels):


### PR DESCRIPTION
## Summary
Adds a 1.5s sleep after `waitForConfig()` in `discover_radio_channels()` so secondary channels' roles have settled before the disabled-channel filter runs, addressing the same class of "secondary channel briefly reports role=DISABLED right after connecting" issue already described in the surrounding comment.

## Deviation from the original spec
The proposed second change — removing `role == 0` from `disabled = "DISABLED" in role_text or role == 0`, leaving only the text check — was **not applied**. `role_text = str(role or "").upper()` evaluates to an empty string whenever `role` is a plain int `0` (falsy), which is exactly the common representation of a `DISABLED` protobuf enum value consumed via `getattr`. In that case `role == 0` is the *only* check that catches it — not a redundant "transient state" guard. Removing it would stop filtering genuinely-disabled/unconfigured channel slots entirely rather than fixing a timing issue. Kept that check unchanged; only the sleep was added.

## Test plan
- [x] `python -m py_compile api/api_chat.py`
- [ ] After node sync + restart: confirm secondary channels reliably appear in the channel list without needing a second discovery call, and that a genuinely-disabled channel slot still doesn't appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)