### PR TITLE
feat: auto-seed chats.json for discovered channels on refresh_channels

### DIFF
--- a/api/api_chat.py
+++ b/api/api_chat.py
@@ -393,6 +393,41 @@ def register_chat_routes(
             with channel_cache_lock:
                 channel_cache["timestamp"] = now_ts
                 channel_cache["channels"] = [dict(item) for item in discovered]
+
+            # Auto-seed chats.json for newly discovered channels so they
+            # appear in the UI immediately, without waiting for a first
+            # incoming message. chats/state_lock/save_chats are already
+            # available as closures from register_chat_routes()'s
+            # parameters — no need to import them from server.
+            try:
+                with state_lock:
+                    seeded = False
+                    for ch in discovered:
+                        chat_id = ch["id"]
+                        if chat_id in chats:
+                            continue
+                        # ch["name"] is always "{base} [{index}]" (see the
+                        # f-string above) — strip that exact suffix rather
+                        # than a blind rsplit(" ["), which would mangle a
+                        # channel name that itself legitimately contains " [".
+                        suffix = f" [{ch['index']}]"
+                        bare_name = ch["name"][:-len(suffix)] if ch["name"].endswith(suffix) else ch["name"]
+                        chats[chat_id] = {
+                            "id": chat_id,
+                            "name": bare_name,
+                            "type": "channel",
+                            "last_message": "",
+                            "last_time": "",
+                            "unread": 0,
+                        }
+                        print(f"[CHANNELS] Auto-seeded chat: {chat_id} ({bare_name})", flush=True)
+                        seeded = True
+                    if seeded:
+                        save_chats()
+            except Exception as seed_error:
+                print(f"[CHANNELS] Auto-seed warning: {seed_error}", flush=True)
+                # Non-fatal — channel will appear after first incoming message
+
             return discovered
 
         # Keep the previous valid configuration during a temporary serial conflict.


### PR DESCRIPTION
## Summary
`discover_radio_channels()` now auto-creates a `chats.json` record for any channel it discovers that doesn't have one yet, right after a successful live discovery (inside the existing `if discovered:` block, before caching/returning) — so channels show up in the UI immediately instead of waiting for a first incoming/outgoing message.

## Deviations from the original spec
- **Import**: used the `chats`/`state_lock`/`save_chats` already threaded into `register_chat_routes(...)`'s parameters (confirmed in scope as closures at this call site) instead of `from server import chats, state_lock, save_chats`. This file follows the repo's dependency-injection-by-parameter-list pattern per CLAUDE.md specifically to avoid importing shared mutable state from `server.py`.
- **Seed schema**: used the same fields as every other channel-chat seed site in `server.py` (`id`/`name`/`type`/`last_message`/`last_time`/`unread`) instead of the proposed `messages`/`is_channel`/`ignored`/`favorite` fields, which don't match what `get_chats_list()` actually reads — those are computed fresh from the global `messages` list and node-id lookups, not stored per-chat. Storing them would just be dead/unused data.
- **Bare-name extraction**: strips the exact `" [{index}]"` suffix `discover_radio_channels()` just appended, rather than `name.rsplit(" [", 1)[0]`, which would truncate a channel name that legitimately contains `" ["` in its actual configured text.

## Test plan
- [x] `python -m py_compile api/api_chat.py`
- [ ] On a node with an unseen secondary channel, hit `/api/chats?refresh_channels=1` and confirm the channel appears in `chats.json` with a bare name and shows up in the UI without needing an incoming message first

🤖 Generated with [Claude Code](https://claude.com/claude-code)