### PR TITLE
chore: add lsof to installer system packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -262,6 +262,7 @@ step_system_packages() {
         avahi-daemon \
         network-manager \
         iw \
+        lsof \
         --no-install-recommends \
         -qq
 

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -411,7 +411,8 @@ apt-get install -y --no-install-recommends \
     avahi-daemon \
     network-manager \
     iw \
-    usbutils
+    usbutils \
+    lsof
 
 systemctl enable avahi-daemon >/dev/null 2>&1 || true
 systemctl start avahi-daemon || true


### PR DESCRIPTION
## Summary
Adds `lsof` to the apt package list in both installer scripts:
- `meshcenter-firstboot.sh`: after `usbutils`
- `install.sh`: after `iw` (this script has no `usbutils` entry to place it near)

🤖 Generated with [Claude Code](https://claude.com/claude-code)