### PR TITLE
feat: rename Notifications card to Activity + dark theme fix + toast subtitle update

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -332,7 +332,7 @@ function renderNotificationsCard(notifications, unreadCount) {
 
   for (const n of notifications) {
     if (!shownDivider && n.timestamp < todayStartTs) {
-      html += `<div class="notifications-divider" data-i18n="notifications.earlier">Earlier</div>`;
+      html += `<div class="notifications-divider" data-i18n="activity.earlier">Earlier</div>`;
       shownDivider = true;
     }
     const icon  = n.level === 'error'   ? '⚠'

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -883,6 +883,12 @@
     "node_label": "Knoten",
     "selected_label": "Ausgewählt"
   },
+  "activity": {
+    "card_title": "Aktivität",
+    "clear_all": "Löschen",
+    "card_empty": "Keine Benachrichtigungen",
+    "earlier": "Früher"
+  },
   "notifications": {
     "ready": "Bereit",
     "open_with_message": "{message} – Benachrichtigungen öffnen",
@@ -899,12 +905,8 @@
     "about": "Über",
     "workspace": "Arbeitsbereich",
     "title": "Benachrichtigungen",
-    "recent_activity": "Letzte MeshCenter-Aktivität",
+    "subtitle": "Systembenachrichtigungen",
     "empty": "Noch keine Benachrichtigungen",
-    "card_title": "Benachrichtigungen",
-    "clear_all": "Löschen",
-    "card_empty": "Keine Benachrichtigungen",
-    "earlier": "Früher",
     "mark_read": "Als gelesen markieren",
     "test_btn": "Benachrichtigung testen"
   },

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -883,6 +883,12 @@
     "node_label": "Node",
     "selected_label": "Selected"
   },
+  "activity": {
+    "card_title": "Activity",
+    "clear_all": "Clear",
+    "card_empty": "No notifications",
+    "earlier": "Earlier"
+  },
   "notifications": {
     "ready": "Ready",
     "open_with_message": "{message} - open notifications",
@@ -899,12 +905,8 @@
     "about": "About",
     "workspace": "Workspace",
     "title": "Notifications",
-    "recent_activity": "Recent MeshCenter activity",
+    "subtitle": "System alerts and events",
     "empty": "No notifications yet",
-    "card_title": "Notifications",
-    "clear_all": "Clear",
-    "card_empty": "No notifications",
-    "earlier": "Earlier",
     "mark_read": "Mark as read",
     "test_btn": "Test notification"
   },

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -883,6 +883,12 @@
     "node_label": "Узел",
     "selected_label": "Выбран"
   },
+  "activity": {
+    "card_title": "Активность",
+    "clear_all": "Очистить",
+    "card_empty": "Нет уведомлений",
+    "earlier": "Ранее"
+  },
   "notifications": {
     "ready": "Готово",
     "open_with_message": "{message} — открыть уведомления",
@@ -899,12 +905,8 @@
     "about": "О программе",
     "workspace": "Рабочая область",
     "title": "Уведомления",
-    "recent_activity": "Последние события MeshCenter",
+    "subtitle": "Системные оповещения",
     "empty": "Пока нет уведомлений",
-    "card_title": "Уведомления",
-    "clear_all": "Очистить",
-    "card_empty": "Нет уведомлений",
-    "earlier": "Ранее",
     "mark_read": "Отметить прочитанным",
     "test_btn": "Тест уведомления"
   },

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -883,6 +883,12 @@
     "node_label": "Вузол",
     "selected_label": "Вибрано"
   },
+  "activity": {
+    "card_title": "Активність",
+    "clear_all": "Очистити",
+    "card_empty": "Немає сповіщень",
+    "earlier": "Раніше"
+  },
   "notifications": {
     "ready": "Готово",
     "open_with_message": "{message} — відкрити сповіщення",
@@ -899,12 +905,8 @@
     "about": "Про програму",
     "workspace": "Робоча область",
     "title": "Сповіщення",
-    "recent_activity": "Останні події MeshCenter",
+    "subtitle": "Системні сповіщення",
     "empty": "Поки що немає сповіщень",
-    "card_title": "Сповіщення",
-    "clear_all": "Очистити",
-    "card_empty": "Немає сповіщень",
-    "earlier": "Раніше",
     "mark_read": "Позначити як прочитане",
     "test_btn": "Тест сповіщення"
   },

--- a/static/style.css
+++ b/static/style.css
@@ -14746,3 +14746,20 @@ html[data-theme="dark"] #timeCard {
     color: #ff9299;
 }
 [data-theme="dark"] .btn.btn-xs.btn-danger:hover { background: rgba(207,71,82,.28); }
+
+/* #notificationsCard (Activity card) dark theme - same pattern as
+   #timeCard above: bg #172638, border #263c52, shadow rgba(0,0,0,.24),
+   text colors reuse the same #e5eff8 primary / #dbe8f5 secondary /
+   #9eb3c8 muted convention rather than inventing new ones. */
+body[data-theme="dark"] #notificationsCard,
+html[data-theme="dark"] #notificationsCard {
+    border-color: #263c52;
+    background: #172638;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, .24);
+}
+[data-theme="dark"] .notifications-card-title { color: #e5eff8; }
+[data-theme="dark"] .notifications-item-title { color: #e5eff8; }
+[data-theme="dark"] .notifications-item-time { color: #9eb3c8; }
+[data-theme="dark"] .notifications-item-body { color: #dbe8f5; }
+[data-theme="dark"] .notifications-empty { color: #9eb3c8; }
+[data-theme="dark"] .notifications-divider { color: #9eb3c8; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260813-time-hero">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260815-activity-card">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
@@ -164,19 +164,19 @@
                      onclick="toggleNotificationsCard()" role="button"
                      aria-expanded="false" aria-controls="notificationsCardBody">
                     <span class="notifications-card-title" id="notificationsCardTitle">
-                        <span data-i18n="notifications.card_title">Notifications</span>
+                        <span data-i18n="activity.card_title">Activity</span>
                         <span class="notifications-badge" id="notificationsBadge" style="display:none">0</span>
                     </span>
                     <div class="notifications-card-actions">
                         <button class="btn btn-sm notifications-clear-btn" id="notificationsClearBtn"
                                 onclick="event.stopPropagation(); clearAllNotifications()"
-                                data-i18n="notifications.clear_all" style="display:none">Clear</button>
+                                data-i18n="activity.clear_all" style="display:none">Clear</button>
                         <span class="notifications-chevron" id="notificationsChevron">▸</span>
                     </div>
                 </div>
                 <div class="notifications-card-body" id="notificationsCardBody" style="display:none">
                     <div id="notificationsList"></div>
-                    <div class="notifications-empty" id="notificationsEmpty" data-i18n="notifications.card_empty">No notifications</div>
+                    <div class="notifications-empty" id="notificationsEmpty" data-i18n="activity.card_empty">No notifications</div>
                 </div>
             </section>
 
@@ -1811,7 +1811,7 @@
                      hidden
                      onclick="event.stopPropagation()">
                 <header class="notification-popover-header">
-                    <div><strong data-i18n="notifications.title">Notifications</strong><span data-i18n="notifications.recent_activity">Recent MeshCenter activity</span></div>
+                    <div><strong data-i18n="notifications.title">Notifications</strong><span data-i18n="notifications.subtitle">System alerts and events</span></div>
                     <button type="button" class="notification-clear-btn" onclick="clearNotifications()" data-i18n="modals.clear">Clear</button>
                 </header>
                 <div class="notification-list" id="notificationList"></div>
@@ -2024,7 +2024,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260813-time-hero"></script>
+<script src="/static/chat.js?v=20260815-activity-card"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260808-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
- Renamed the `#notificationsCard` workspace card from "Notifications" to "Activity": its title, clear button, empty state, and "Earlier" divider now use a new `activity.*` i18n namespace instead of `notifications.*`. Other three keys (`clear_all`/`card_empty`/`earlier`) keep their existing translated text in de/ru/uk — only `card_title` gets new wording per the spec.
- Added a dark-theme CSS override for `#notificationsCard`, following the exact `#timeCard` pattern (same dual selector, same bg/border/shadow, same primary/secondary/muted text color convention — no new colors invented).
- Updated the bottom status-dock notification popover's subtitle (`#notificationPopover`, a separate component with its own "Notifications" title, left unchanged) from "Recent MeshCenter activity" to a new `notifications.subtitle` key with the specified translations.
- Bumped the shared `?v=` cache-busting suffix on `chat.js`/`style.css`.

## Deviations / scope notes
- Left `notifications.mark_read` alone — grepped the whole codebase, it's not referenced by any `data-i18n` or `I18N.t()` call anywhere, unrelated to this card despite being in the original key list.
- Left `notifications.test_btn` alone — it's a System Actions settings button, not a label rendered inside `#notificationsCard`.
- Added a dark-theme rule for `.notifications-item-body` beyond the four selectors requested — it renders in the same list items as `item-title`/`item-time` and would otherwise be the one unstyled element in an already-dark-themed card.

## Test plan
- [x] `scripts/check-i18n.py` — all four catalogs in sync
- [x] All four `i18n/*.json` files parse as valid JSON
- [x] `node -c static/chat.js` — syntax OK
- [x] Grepped for leftover `notifications.card_title` / `.clear_all` / `.card_empty` / `.earlier` / `.recent_activity` references — none found
- [ ] Not verified in an actual browser — no configured radio/`config.py` in this environment to run the Flask app. Please eyeball the card (light + dark theme) and the dock popover subtitle after deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)