### PR TITLE
feat: show weather provider name next to Live/Cache badge

### DIFF
--- a/api/api_weather.py
+++ b/api/api_weather.py
@@ -19,6 +19,15 @@ _SECRET_VAR_NAMES = {
     "weatherapi": "WEATHERAPI_API_KEY",
 }
 
+# Provider website links for the "Live · <Provider>" badge. The display
+# name itself comes from each WeatherProvider's own display_name attribute
+# (weather/providers/*.py) rather than being duplicated here - only the
+# website URL isn't part of that existing interface.
+_PROVIDER_URLS = {
+    "openweather": "https://openweathermap.org",
+    "weatherapi": "https://www.weatherapi.com",
+}
+
 
 def _normalize_api_key(value):
     key = str(value or "").strip()
@@ -107,6 +116,12 @@ def register_weather_routes(
             location_name=location.get("name", ""),
             location_source=location.get("source", "configured"),
         )
+        active_id = weather_manager.active_id
+        payload["provider"] = {
+            "id": active_id,
+            "name": weather_manager.active().display_name,
+            "url": _PROVIDER_URLS.get(active_id, "#"),
+        }
         return jsonify(payload), 200 if payload.get("ok") else 503
 
     @app.get("/api/weather/config")

--- a/static/style.css
+++ b/static/style.css
@@ -9357,10 +9357,28 @@ html[data-theme="dark"] .system-log-panel {
     white-space: nowrap;
 }
 .weather-current-copy { min-width: 0; }
-.weather-summary-state {
+.weather-state-group {
     position: absolute;
     left: 12px;
     bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.weather-provider-link {
+    color: inherit;
+    font-size: 9px;
+    font-weight: 650;
+    text-decoration: none;
+    opacity: 0.85;
+}
+.weather-provider-link:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+.weather-provider-link::before {
+    content: "· ";
 }
 
 @media (max-width: 420px) {

--- a/static/weather.js
+++ b/static/weather.js
@@ -158,6 +158,23 @@ function setWeatherState(state, label) {
     if (badge) badge.textContent = label;
 }
 
+// The provider link is a separate element next to weatherStateBadge rather
+// than nested inside it: the badge is a <button> updated via .textContent
+// (so it can't render an <a> tag at all), and putting an <a> inside a
+// <button> that already has its own onclick would be invalid, conflicting
+// nested-interactive-content HTML anyway.
+function setWeatherProviderLink(provider) {
+    const link = document.getElementById('weatherProviderLink');
+    if (!link) return;
+    if (provider && provider.name) {
+        link.textContent = provider.name;
+        link.href = provider.url || '#';
+        link.style.display = '';
+    } else {
+        link.style.display = 'none';
+    }
+}
+
 function renderWeather(data) {
     weatherLastData = data;
     weatherSetupRequired = false;
@@ -180,6 +197,7 @@ function renderWeather(data) {
     } else {
         setWeatherState('online', window.I18N.t('weather.status_live'));
     }
+    setWeatherProviderLink(data.provider);
 }
 
 // Matches the display names chat.js's setWeatherProvider() toast uses -
@@ -204,6 +222,7 @@ function renderWeatherError(data) {
     weatherText('weatherFeelsLike', activeWeatherProviderDisplayName());
     weatherText('weatherUpdated', weatherSetupRequired ? window.I18N.t('weather.click_setup') : window.I18N.t('weather.retry_later'));
     renderWeatherForecast([]);
+    setWeatherProviderLink(null);
 }
 
 function currentWeatherReferenceSignature() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260815-activity-card">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260815-weather-provider">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
@@ -200,7 +200,10 @@
                         </div>
                     </div>
 
-                    <button class="weather-state-badge weather-summary-state" id="weatherStateBadge" type="button" onclick="handleWeatherBadgeClick()" title="Refresh weather or open Weather Provider settings" data-i18n-title="weather.refresh_or_configure_tooltip" data-i18n="common.loading_short">Loading</button>
+                    <div class="weather-state-group" id="weatherStateGroup">
+                        <button class="weather-state-badge" id="weatherStateBadge" type="button" onclick="handleWeatherBadgeClick()" title="Refresh weather or open Weather Provider settings" data-i18n-title="weather.refresh_or_configure_tooltip" data-i18n="common.loading_short">Loading</button>
+                        <a class="weather-provider-link" id="weatherProviderLink" href="#" target="_blank" rel="noopener noreferrer" style="display:none"></a>
+                    </div>
                 </div>
 
                 <div class="weather-metrics">
@@ -2026,7 +2029,7 @@
 </script>
 <script src="/static/chat.js?v=20260815-activity-card"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
-<script src="/static/weather.js?v=20260808-weather-provider"></script>
+<script src="/static/weather.js?v=20260815-weather-provider"></script>
 
 <div class="modal-overlay" id="wifiConnectModal" style="display:none;" onclick="closeWifiConnectModal()">
     <div class="modal-content wifi-connect-modal" onclick="event.stopPropagation()">


### PR DESCRIPTION
## Summary
Adds a clickable provider-name link ("Live · OpenWeather") next to the weather card's Live/Cache badge.

- `api/api_weather.py`: `/api/weather/current` now returns a `provider` object (`id`/`name`/`url`) on every response, success or error. `name` comes from each `WeatherProvider.display_name` (already exists in `weather/providers/*.py`) rather than a duplicated lookup table; only the website URL needed a small new `_PROVIDER_URLS` dict, since that isn't part of the existing provider interface.
- Frontend: added the link as a sibling of `#weatherStateBadge`, not nested inside it.

## Why restructured instead of literal nesting
Two real problems with putting an `<a>` inside the badge as originally proposed:
1. `#weatherStateBadge`'s label is set via `badge.textContent = label` in `setWeatherState()` — `.textContent` can't render an embedded `<a>` tag at all; it would show as literal escaped text.
2. `#weatherStateBadge` is a `<button>` with its own `onclick="handleWeatherBadgeClick()"`. Nesting an `<a>` inside a `<button>` is invalid HTML5 (no interactive content inside interactive content) and would conflict with the button's existing click-to-refresh/configure behavior.

Instead, the link is a new sibling `<a id="weatherProviderLink">`, and both are wrapped in `.weather-state-group` (renamed from `.weather-summary-state`, which only ever styled this one button — confirmed via grep nothing else referenced it) so they sit together visually as "Live · OpenWeather" via flexbox, without touching the badge's own click behavior.

## Test plan
- [x] `python -m py_compile api/api_weather.py`
- [x] `node -c static/weather.js`
- [x] Confirmed `.weather-summary-state` had no other references before renaming it
- [ ] Not verified in an actual browser — no configured radio/`config.py` in this environment. Please check the badge in the live UI (both providers, light/dark theme, and the error/setup-required state) after deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)