### PR TITLE
fix: add spacing between Schedules and Timers sections in time card

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -8236,6 +8236,16 @@ html[data-theme="light"] .node-card.favorite .node-favorite-slot {
     margin-bottom: 4px;
 }
 
+/* Space between the Schedules and Timers sections so they read as two
+   separate blocks, and a little breathing room under "+ New schedule"
+   so it doesn't crowd the Timers heading right below it. */
+#timeTimersSection {
+    margin-top: 16px;
+}
+#addScheduleBtn {
+    margin-bottom: 4px;
+}
+
 /* ============================================================
    NOTIFICATIONS CARD
    ============================================================ */


### PR DESCRIPTION
## Summary
Adds `margin-top: 16px` to `#timeTimersSection` and `margin-bottom: 4px` to `#addScheduleBtn` so the Schedules and Timers sections in `#timeCard` read as two visually separate blocks instead of crowding together. No existing values changed — confirmed via grep that neither selector had any prior CSS rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)