### PR TITLE
fix: use Intl.DateTimeFormat for day names in schedule list — locale-aware

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -448,6 +448,28 @@ async function loadSchedules() {
   }
 }
 
+// Locale-aware day-name formatting: instead of a hardcoded translation
+// table, ask Intl.DateTimeFormat for each weekday's short name in the
+// active locale. 2026-01-04 was a Sunday, so 2026-01-(4+n) walks through
+// Sun..Sat for n = 0..6 - DAY_INDEX maps each day code to that offset.
+function _formatDays(days) {
+    if (!days || days.length === 0) return '';
+    if (days.length === 7) return window.I18N.t('time.every_day');
+    const weekdays = ['mon','tue','wed','thu','fri'];
+    if (days.length === 5 && weekdays.every(d => days.includes(d)))
+        return window.I18N.t('time.weekdays');
+
+    const DAY_INDEX = {sun:0, mon:1, tue:2, wed:3, thu:4, fri:5, sat:6};
+    const fmt = new Intl.DateTimeFormat(
+        TimeFormatter._getLocale(), {weekday: 'short'});
+    return days
+        .map(d => {
+            const ref = new Date(2026, 0, 4 + (DAY_INDEX[d] ?? 0));
+            return fmt.format(ref);
+        })
+        .join(', ');
+}
+
 function _scheduleSummaryText(rule) {
   const t = rule.trigger || {};
   if (t.mode === 'interval') {
@@ -457,10 +479,7 @@ function _scheduleSummaryText(rule) {
     return t.datetime ? TimeFormatter.formatDateTime(new Date(t.datetime)) : '';
   }
   const days = Array.isArray(t.days) ? t.days : [];
-  const allWeekdays = SCHEDULE_DAY_ORDER.slice(0, 5).every(d => days.includes(d)) && days.length === 5;
-  const dayLabel = allWeekdays
-    ? window.I18N.t('time.weekdays')
-    : (days.length === 7 ? window.I18N.t('time.every_day') : days.join(', '));
+  const dayLabel = _formatDays(days);
   return `${dayLabel} ${t.time || ''}`.trim();
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2027,7 +2027,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260816-timer-once-dark"></script>
+<script src="/static/chat.js?v=20260816-intl-days"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
`_formatDays` didn't exist in the codebase, and there was no hardcoded `{mon:'Пн', ...}` translation table to replace. The actual gap was in `_scheduleSummaryText()`'s fallback branch for a partial day selection (e.g. Mon/Wed/Fri) — it rendered raw, untranslated day codes via `days.join(', ')` (literally `"mon, wed, fri"`), not a hardcoded-but-translated abbreviation.

Added `_formatDays(days)` as specified — `Intl.DateTimeFormat` with a per-weekday reference date (2026-01-04 confirmed via `node -e` to actually be a Sunday) — and wired it into that fallback, replacing the old inline `join(', ')`/weekdays-check logic.

## Test plan
- [x] `node -c static/chat.js`
- [x] Isolated functional test of the extracted logic across en/de/ru/uk locales, plus empty/all-7/weekdays-only/single-day inputs — all correct (e.g. `ru` → `"пн, ср, пт"`, `de` → `"Mo, Mi, Fr"`)
- [ ] Not verified in an actual browser — please confirm the schedule list shows correctly localized day abbreviations for a custom day selection in each language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)