### PR TITLE
fix: dark theme for telemetry modal shell, export button, records count

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14211,6 +14211,58 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     border-color: #263c52;
 }
 
+/* Telemetry modal shell background. .modal-overlay.telemetry-modal
+   .modal-content (~line 1810) hardcodes background:#ffffff unconditionally
+   at specificity (0,3,0), which beats the generic
+   [data-theme="dark"] .modal-content rule (0,2,0) - so that generic dark
+   override never actually applied to this modal. Out-specified here
+   ((0,4,0): one attribute + three classes) instead of touching the
+   light-mode rule or the shared .modal-content rule other modals use.
+   .modal-header / .modal-header span / .modal-close already have correct
+   dark-theme text colors (confirmed via computed styles) - they just
+   needed an actually-dark parent background to be visible against;
+   nothing else to change there.
+   Verified live via DevTools computed styles on the dev node before and
+   after: modal bg was rgb(255,255,255) unconditionally, is now
+   rgb(27,45,64) in dark theme, and header/close text (already
+   rgb(244,248,252)/rgb(169,190,209)) reads correctly against it. */
+[data-theme="dark"] .modal-overlay.telemetry-modal .modal-content {
+    background: #1b2d40;
+}
+
+/* .telemetry-time-controls .time-btn is NOT touched here - verified live
+   via DevTools that it already renders dark/theme-aware colors
+   (computed background rgb(22,34,49) = var(--mc-bg-subtle), text
+   rgb(195,209,223) = var(--mc-text-secondary)) from a rule in
+   static/ui-kit.css (`.time-btn, .cpu-range-btn, .telemetry-time-controls
+   .time-btn`), which loads after this file and ties this file's
+   .time-btn rule on specificity, so it already wins the cascade. Its
+   :hover/.active variants are covered by the same ui-kit.css rule set and
+   already look correct too - nothing here would improve on it, and
+   duplicating it would just be two sources of truth for the same colors.
+
+   .telemetry-export-btn and .telemetry-records-count have no such
+   coverage anywhere (verified: still rendering their unconditional
+   light-mode white background / #888 text), so those genuinely need
+   dark-theme rules. Reused this codebase's existing "secondary button on
+   dark" colors (#263b50/#dbe8f5/#415a72, #304a62 hover - see
+   [data-theme="dark"] .modal-action-btn:not(.danger) a few lines up)
+   instead of inventing new ones, for consistency with every other
+   secondary button already dark-themed in this file. */
+[data-theme="dark"] .telemetry-export-btn {
+    background: #263b50;
+    color: #dbe8f5;
+    border-color: #415a72;
+}
+[data-theme="dark"] .telemetry-export-btn:hover {
+    background: #304a62;
+    color: #dbe8f5;
+    border-color: #415a72;
+}
+[data-theme="dark"] .telemetry-records-count {
+    color: #9eb3c8;
+}
+
 /* Custom telemetry export dialog (openCustomTelemetryExport(),
    static/chat.js) - a separate overlay from .modal-overlay/.modal-content
    (custom-export-*/export-* classes), so it isn't covered by the

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260816-chart-dark">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260816-telemetry-modal-dark">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
## Summary
Root cause found via live DevTools computed-style inspection on the dev node (192.168.2.104), not guessing: `.modal-overlay.telemetry-modal .modal-content` (style.css ~1810) hardcodes `background:#ffffff` unconditionally at specificity `(0,3,0)`, which beats the generic `[data-theme="dark"] .modal-content` rule `(0,2,0)` — so the modal shell stayed white in both themes. Its header text color correctly flips to near-white (no competing override on that rule), which is exactly the washed-out unreadable header from the report.

Also resolved the range-button color discrepancy raised in the report: the buttons already render dark, theme-aware colors via a rule in `static/ui-kit.css` (`var(--mc-bg-subtle)`/`var(--mc-text-secondary)`), which loads *after* `style.css` and ties its `.time-btn` rule on specificity — so it already wins the cascade. Confirmed via `document.styleSheets` inspection, not a caching artifact, not blend-mode/opacity/filter. Left `.time-btn`/`:hover`/`.active` untouched, matching the report's own conclusion that this already looks correct.

## Changes
- `[data-theme="dark"] .modal-overlay.telemetry-modal .modal-content`: `background: #1b2d40` (matches the generic dark `.modal-content` value). Out-specifies the light-mode rule rather than editing it; doesn't touch `.modal-content`/`.modal-header`/`.modal-close` themselves (shared by other modals) — their existing dark text-color rules apply correctly once the parent background is actually dark.
- `[data-theme="dark"] .telemetry-export-btn` (+ `:hover`): reused this codebase's existing "secondary button on dark" colors (`#263b50`/`#304a62`/`#dbe8f5`/`#415a72`) instead of inventing new ones.
- `[data-theme="dark"] .telemetry-records-count`: `color: #9eb3c8` (established muted-text convention), replacing the light-mode `#888` which was too low-contrast on dark.
- `.telemetry-card` / `.telemetry-chart-container`: untouched, already correct from a previous fix.

## Verification
Injected the exact CSS rules via the browser console against the live dev-node page (dark theme, telemetry modal open) and confirmed computed styles matched expectations *before* writing them to the source file:
- Modal bg: `rgb(255,255,255)` → `rgb(27,45,64)`
- Header text `rgb(244,248,252)` and close button `rgb(169,190,209)` now read correctly against the dark background (values themselves unchanged — the fix was giving them a background to be visible on)
- Export button: `rgb(255,255,255)`/`rgb(85,85,85)` → `rgb(38,59,80)`/`rgb(219,232,245)`
- Records count: `rgb(136,136,136)` → `rgb(158,179,200)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)