### PR TITLE
fix: dark theme for Camera tab off-state placeholder

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14263,6 +14263,35 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     color: #9eb3c8;
 }
 
+/* Camera tab "off" placeholder (#cameraOffPlaceholder, shown over the
+   preview area when the camera is powered down). .video-panel/.video-header
+   and the VIDEO/FPS/SCREENSHOT fields below are already dark-themed via
+   the shared var(--mc-*) design tokens (confirmed live) - only this
+   overlay and its contents were still hardcoded to a light gradient.
+   Reuses the exact same tokens driving the rest of this card instead of
+   introducing new hex values: var(--mc-card-bg) (#162433, same as
+   .video-panel), var(--mc-text) (#f2f7fc, same token .video-title uses),
+   var(--mc-text-secondary) (#c3d1df, same as .control-group label).
+
+   The pastel green/red power buttons (.camera-off-start-btn,
+   #cameraPowerBtn in both states) were checked for contrast and left
+   alone - all three combos exceed WCAG AA 4.5:1 as "soft badge" accents
+   (#e9f7ed/#216b3a: 5.88:1, #fff5f5/#a32929: 6.75:1,
+   #eef9f1/#267340: 5.39:1), so no dark-theme override needed there. */
+[data-theme="dark"] .camera-off-placeholder {
+    background: var(--mc-card-bg);
+}
+[data-theme="dark"] .camera-off-title {
+    color: var(--mc-text);
+}
+[data-theme="dark"] .camera-off-text {
+    color: var(--mc-text-secondary);
+}
+[data-theme="dark"] .camera-off-icon {
+    filter: none;
+    opacity: 0.95;
+}
+
 /* Custom telemetry export dialog (openCustomTelemetryExport(),
    static/chat.js) - a separate overlay from .modal-overlay/.modal-content
    (custom-export-*/export-* classes), so it isn't covered by the

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260816-telemetry-modal-dark">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260816-camera-off-dark">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
## Summary
Investigation (live DevTools on the dev node, dark theme, Camera tab open) found most of the tab already correctly dark-themed via the shared `var(--mc-*)` design tokens: `.video-panel`, `.video-header` (via `.mc-workspace-header` + ui-kit.css), the camera control tabs, the bottom info bar, and the VIDEO/FPS/SCREENSHOT select fields all already render dark correctly. The only real gap was `#cameraOffPlaceholder` (shown over the preview when the camera is off) and its contents — hardcoded to a light gradient with dark text, no `[data-theme="dark"]` coverage anywhere, and (unlike the telemetry-modal case) no competing/higher-specificity rule fighting it — a genuine gap, not a specificity conflict.

## Contrast check on the pastel power buttons (per WCAG AA, ≥4.5:1)
- `.camera-off-start-btn` (`#e9f7ed`/`#216b3a`): **5.88:1**
- `#cameraPowerBtn` on-state (`#fff5f5`/`#a32929`): **6.75:1**
- `#cameraPowerBtn.camera-power-off` (`#eef9f1`/`#267340`): **5.39:1**

All three pass comfortably — left untouched, no dark-theme override added for any of them.

## Changes (all `[data-theme="dark"]`-scoped, light theme untouched)
- `.camera-off-placeholder`: `background: var(--mc-card-bg)` (`#162433`, same token `.video-panel` uses)
- `.camera-off-title`: `color: var(--mc-text)` (`#f2f7fc`, same token `.video-title` uses)
- `.camera-off-text`: `color: var(--mc-text-secondary)` (`#c3d1df`, same as `.control-group label`)
- `.camera-off-icon`: `filter: none` (was `grayscale(.35)`), `opacity: 0.95` (was `.8`) — the 📷 emoji looked muddy against the new dark background with the light-mode desaturation filter still applied

## Verification
Injected the exact CSS via the browser console against the live dev-node page (dark theme, camera-off placeholder forced visible), confirmed computed styles matched expectations, and took a screenshot showing the readable dark placeholder — before writing any of it to the source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)