### PR TITLE
fix: AbortError race on forced channel refresh + voltage chart axis clipping

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3607,11 +3607,18 @@ async function loadChatList() {
 
     try {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 15000);
         const forceChannelRefresh = initialChannelRefreshPending;
         const chatsUrl = forceChannelRefresh
             ? '/api/chats?refresh_channels=1'
             : '/api/chats';
+        // A forced channel refresh makes the server stop the listener, wait
+        // for the serial port to release, open a fresh connection, and wait
+        // out a cooldown before resuming (see api/api_chat.py's
+        // discover_radio_channels()/radio_session() budget notes) - that
+        // alone can approach 15s on a slow/first connect, so it needs more
+        // slack than the plain cached-list request or this reliably aborts
+        // on first page load.
+        const timeoutId = setTimeout(() => controller.abort(), forceChannelRefresh ? 30000 : 15000);
 
         const response = await fetch(chatsUrl, {
             signal: controller.signal,
@@ -10829,8 +10836,21 @@ function renderTelemetryChart(container, records, type) {
     }
 
     if (type === 'power') {
-        yConfig.min = 3.40;
-        yConfig.max = 4.30;
+        const voltageValues = datasets
+            .filter(d => d.metricType === 'voltage')
+            .flatMap(d => d.data)
+            .filter(v => v !== null && v !== undefined && !isNaN(v));
+
+        if (voltageValues.length > 0) {
+            const minVoltage = Math.min(...voltageValues);
+            const maxVoltage = Math.max(...voltageValues);
+            const padding = Math.max(0.05, (maxVoltage - minVoltage) * 0.1);
+            yConfig.min = Math.floor((minVoltage - padding) * 100) / 100;
+            yConfig.max = Math.ceil((maxVoltage + padding) * 100) / 100;
+        } else {
+            yConfig.min = 3.40;
+            yConfig.max = 4.30;
+        }
 
         y1Config.min = 250;
         y1Config.max = 1000;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2027,7 +2027,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260817-session-a-ui-fixes"></script>
+<script src="/static/chat.js?v=20260817-voltage-chart-scale"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
- The forced `/api/chats?refresh_channels=1` request (fires once per server start, on the first page load) stops the listener, waits for serial release, reconnects, and cools down before resuming — a budget that can approach the client's 15s abort timeout, dropping the request with `signal is aborted without reason`. Gives that specific request 30s instead of 15s.
- The power/voltage telemetry chart hardcoded its y-axis to 3.40–4.30V (single-cell LiPo range), clipping nodes whose voltage falls outside that band. Scales the axis to the actual voltage data instead, same approach already used for the power axis.

## Test plan
- [x] Verified on dev (192.168.2.104): fresh navigate after service restart no longer logs `[CHAT] Error` / AbortError; `refresh_channels=1` completes `200 OK`.
- [x] Verified on dev: node with 4.815V now gets a `4.76–4.87V` axis instead of clipping at the old 4.30V ceiling.
- [x] Verified on dev: node with historical voltage down to 3.33V now shows correctly instead of clipping at the old 3.40V floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)