### PR TITLE
fix: telemetry export custom-range date/time fields now respect the 12h/24h setting

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -10460,12 +10460,12 @@ function openCustomTelemetryExport() {
                     <div class="export-date-grid">
                         <label>
                             <span>${escapeHtml(window.I18N.t('nodes.date_from'))}</span>
-                            <input type="datetime-local" id="exportStartDate" value="${datetimeLocalValue(from)}">
+                            ${buildExportDateTimeFieldHtml('exportStart', from)}
                         </label>
 
                         <label>
                             <span>${escapeHtml(window.I18N.t('nodes.date_to'))}</span>
-                            <input type="datetime-local" id="exportEndDate" value="${datetimeLocalValue(now)}">
+                            ${buildExportDateTimeFieldHtml('exportEnd', now)}
                         </label>
                     </div>
                 </div>
@@ -10517,10 +10517,79 @@ function updateCustomExportMode() {
     }
 }
 
-function datetimeLocalValue(date) {
-    const pad = n => String(n).padStart(2, '0');
+function getExportAmPmLabels() {
+    const fmt = new Intl.DateTimeFormat(TimeFormatter._getLocale(), { hour: 'numeric', hour12: true });
+    const partAt = hour => fmt.formatToParts(new Date(2000, 0, 1, hour, 0)).find(p => p.type === 'dayPeriod')?.value;
 
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+    return { am: partAt(1) || 'AM', pm: partAt(13) || 'PM' };
+}
+
+// Native <input type="datetime-local">/<input type="time"> always render their
+// picker in the browser/OS locale's hour format, ignoring appSettings.units.time_format
+// entirely - there is no attribute to force 12h/24h on them. So the export
+// range fields are built from a plain date input plus hand-rolled hour/minute
+// (+ AM/PM when the app is in 12h mode) inputs instead, kept in sync with
+// TimeFormatter._is12h() like every other time display in this file.
+function buildExportDateTimeFieldHtml(idPrefix, date) {
+    const pad = n => String(n).padStart(2, '0');
+    const dateValue = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+    const hour24 = date.getHours();
+    const minute = date.getMinutes();
+
+    if (TimeFormatter._is12h()) {
+        const { am, pm } = getExportAmPmLabels();
+        const isPm = hour24 >= 12;
+        let hour12 = hour24 % 12;
+        if (hour12 === 0) hour12 = 12;
+
+        return `
+            <div class="export-datetime-row">
+                <input type="date" id="${idPrefix}Date" value="${dateValue}" class="export-date-input">
+                <input type="number" id="${idPrefix}Hour" min="1" max="12" value="${hour12}" class="export-time-input" aria-label="${escapeHtml(window.I18N.t('nodes.hour'))}">
+                <span class="export-time-sep">:</span>
+                <input type="number" id="${idPrefix}Minute" min="0" max="59" value="${pad(minute)}" class="export-time-input" aria-label="${escapeHtml(window.I18N.t('nodes.minute'))}">
+                <select id="${idPrefix}Ampm" class="export-ampm-select">
+                    <option value="${escapeHtml(am)}" ${!isPm ? 'selected' : ''}>${escapeHtml(am)}</option>
+                    <option value="${escapeHtml(pm)}" ${isPm ? 'selected' : ''}>${escapeHtml(pm)}</option>
+                </select>
+            </div>
+        `;
+    }
+
+    return `
+        <div class="export-datetime-row">
+            <input type="date" id="${idPrefix}Date" value="${dateValue}" class="export-date-input">
+            <input type="number" id="${idPrefix}Hour" min="0" max="23" value="${pad(hour24)}" class="export-time-input" aria-label="${escapeHtml(window.I18N.t('nodes.hour'))}">
+            <span class="export-time-sep">:</span>
+            <input type="number" id="${idPrefix}Minute" min="0" max="59" value="${pad(minute)}" class="export-time-input" aria-label="${escapeHtml(window.I18N.t('nodes.minute'))}">
+        </div>
+    `;
+}
+
+// Reads an idPrefix's date + hour/minute(+AM/PM) fields back into a Date,
+// mirroring the encoding buildExportDateTimeFieldHtml() rendered them in.
+function readExportDateTime(idPrefix) {
+    const dateStr = document.getElementById(`${idPrefix}Date`)?.value;
+    const hourInput = document.getElementById(`${idPrefix}Hour`);
+    const minuteInput = document.getElementById(`${idPrefix}Minute`);
+    const ampmSelect = document.getElementById(`${idPrefix}Ampm`);
+
+    if (!dateStr || !hourInput || !minuteInput) return null;
+
+    const [year, month, day] = dateStr.split('-').map(Number);
+    let hour = parseInt(hourInput.value, 10);
+    const minute = parseInt(minuteInput.value, 10);
+
+    if (![year, month, day, hour, minute].every(Number.isFinite)) return null;
+
+    if (ampmSelect) {
+        const { pm } = getExportAmPmLabels();
+        const isPm = ampmSelect.value === pm;
+        hour = hour % 12;
+        if (isPm) hour += 12;
+    }
+
+    return new Date(year, month - 1, day, hour, minute);
 }
 
 function getTelemetryRangeLabel(minutes) {
@@ -10564,16 +10633,16 @@ function runCustomTelemetryExport() {
     }
 
     if (mode === 'custom') {
-        const startValue = document.getElementById('exportStartDate')?.value;
-        const endValue = document.getElementById('exportEndDate')?.value;
+        const startDate = readExportDateTime('exportStart');
+        const endDate = readExportDateTime('exportEnd');
 
-        if (!startValue || !endValue) {
+        if (!startDate || !endDate) {
             alert(window.I18N.t('nodes.select_start_end_date'));
             return;
         }
 
-        const startTs = Math.floor(new Date(startValue).getTime() / 1000);
-        const endTs = Math.floor(new Date(endValue).getTime() / 1000);
+        const startTs = Math.floor(startDate.getTime() / 1000);
+        const endTs = Math.floor(endDate.getTime() / 1000);
 
         if (!startTs || !endTs || startTs >= endTs) {
             alert(window.I18N.t('nodes.invalid_date_range'));

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -844,6 +844,8 @@
     "custom_range": "Benutzerdefinierter Zeitraum",
     "date_from": "Von",
     "date_to": "Bis",
+    "hour": "Stunde",
+    "minute": "Minute",
     "series": "Reihen",
     "no_series_selected": "Keine Reihe ausgewählt",
     "format": "Format",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -844,6 +844,8 @@
     "custom_range": "Custom range",
     "date_from": "From",
     "date_to": "To",
+    "hour": "Hour",
+    "minute": "Minute",
     "series": "Series",
     "no_series_selected": "No series selected",
     "format": "Format",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -844,6 +844,8 @@
     "custom_range": "Произвольный период",
     "date_from": "С",
     "date_to": "По",
+    "hour": "Час",
+    "minute": "Минута",
     "series": "Ряды",
     "no_series_selected": "Ряды не выбраны",
     "format": "Формат",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -844,6 +844,8 @@
     "custom_range": "Довільний період",
     "date_from": "Від",
     "date_to": "До",
+    "hour": "Година",
+    "minute": "Хвилина",
     "series": "Ряди",
     "no_series_selected": "Ряди не вибрано",
     "format": "Формат",

--- a/static/style.css
+++ b/static/style.css
@@ -3116,6 +3116,40 @@ body {
     font-size: 13px;
 }
 
+.export-datetime-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.export-date-input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.export-time-input {
+    width: 48px;
+    flex: 0 0 auto;
+    text-align: center;
+    padding: 9px 4px;
+    border: 1px solid #d7dce5;
+    border-radius: 10px;
+    font-size: 13px;
+}
+
+.export-time-sep {
+    color: #6b7280;
+    font-weight: 600;
+}
+
+.export-ampm-select {
+    flex: 0 0 auto;
+    padding: 9px 6px;
+    border: 1px solid #d7dce5;
+    border-radius: 10px;
+    font-size: 13px;
+}
+
 .export-series-summary {
     background: #f5f7fb;
     border: 1px solid #e5e8ec;
@@ -14335,11 +14369,16 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     color: #d9e7f5;
 }
 [data-theme="dark"] .export-date-grid input,
+[data-theme="dark"] .export-time-input,
+[data-theme="dark"] .export-ampm-select,
 [data-theme="dark"] .export-format-option,
 [data-theme="dark"] .custom-export-cancel {
     background: #132334;
     border-color: #385068;
     color: #e5eff8;
+}
+[data-theme="dark"] .export-time-sep {
+    color: #9eb3c8;
 }
 [data-theme="dark"] .export-series-summary {
     background: #16283a;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2027,7 +2027,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260817-voltage-chart-scale"></script>
+<script src="/static/chat.js?v=20260817-export-time-format"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
- The telemetry Export → "Custom range" date/time fields used native `<input type="datetime-local">`, whose picker always renders in the browser/OS locale's hour format — there's no attribute to force 12h/24h, so it never matched `appSettings.units.time_format` even though every other time display in the app (`TimeFormatter`) already does.
- Replaced it with a plain date input plus hand-rolled hour/minute (+ AM/PM in 12h mode) inputs, driven by `TimeFormatter._is12h()`, same as the rest of the app. AM/PM labels are derived from `Intl.DateTimeFormat` for the active locale rather than hardcoded English.
- Added `nodes.hour` / `nodes.minute` to all four i18n catalogs (en/de/ru/uk).

## Test plan
- [x] Verified on dev (192.168.2.104) in 24h mode: hour field range 0–23, no AM/PM selector.
- [x] Verified on dev in 12h mode: hour field range 1–12 with AM/PM selector; 19:18 correctly displayed as 7:18 PM.
- [x] Verified round-trip conversion back to 24h internally for export timestamps, including boundary cases: 12 AM → 0h, 12 PM → 12h, 1 AM → 1h, 1 PM → 13h.
- [x] No new console errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)