### PR TITLE
feat: timer pause/resume

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -474,6 +474,24 @@ def register_system_routes(app, get_cpu_temperature=None):
         t = create_timer(label, duration_s, notify_cfg)
         return jsonify(t), 201
 
+    @app.route("/api/timers/<tid>/pause", methods=["PATCH"])
+    def api_pause_timer(tid):
+        from meshsrv.timer_service import pause_timer
+
+        t = pause_timer(tid)
+        if t is None:
+            return jsonify({"error": "not found"}), 404
+        return jsonify(t)
+
+    @app.route("/api/timers/<tid>/resume", methods=["PATCH"])
+    def api_resume_timer(tid):
+        from meshsrv.timer_service import resume_timer
+
+        t = resume_timer(tid)
+        if t is None:
+            return jsonify({"error": "not found"}), 404
+        return jsonify(t)
+
     @app.route("/api/timers/<tid>/stop", methods=["PATCH"])
     def api_stop_timer(tid):
         from meshsrv.timer_service import stop_timer

--- a/meshsrv/timer_service.py
+++ b/meshsrv/timer_service.py
@@ -4,9 +4,15 @@ In-memory countdown/stopwatch timers. Session-scoped by design - do not
 survive a service restart (same lifetime class as
 meshsrv/notification_service.py's queue). The countdown itself ticks on
 the frontend (client-side setInterval reading TimeFormatter.now()); this
-module only tracks start/stop/finish bookkeeping so the backend can run
+module only tracks state/elapsed-time bookkeeping so the backend can run
 the finish notify-pipeline (push_notification + optional mesh send) when
 the frontend tells it a timer reached zero via POST /api/timers/<id>/finish.
+
+Elapsed time is derived, never accumulated tick-by-tick, to avoid drift:
+    elapsed(t) = t['accumulated_s'] + (now - t['segment_started_at']
+                                        if t['state'] == 'running' else 0)
+'accumulated_s' only changes at a state transition (pause/stop/finish),
+banking the just-completed running segment exactly once.
 """
 import time
 import uuid
@@ -18,14 +24,24 @@ _timers = {}
 
 def _make_timer(label: str, duration_s, notify_cfg) -> dict:
     return {
-        'id':          str(uuid.uuid4()),
-        'label':       label,
-        'duration_s':  duration_s,
-        'started_at':  int(time.time()),
-        'stopped_at':  None,
-        'finished':    False,
-        'notify':      notify_cfg or {},
+        'id':                 str(uuid.uuid4()),
+        'label':               label,
+        'duration_s':          duration_s,
+        'state':               'running',
+        'accumulated_s':       0,
+        'segment_started_at':  int(time.time()),
+        'notify':              notify_cfg or {},
     }
+
+
+def _bank_running_segment(t: dict, now: int):
+    """Fold the current running segment into accumulated_s and clear the
+    segment anchor. No-op unless t is actually running - callers use this
+    from every transition that leaves the running state, so it's always
+    safe to call unconditionally."""
+    if t['state'] == 'running' and t['segment_started_at'] is not None:
+        t['accumulated_s'] += now - t['segment_started_at']
+        t['segment_started_at'] = None
 
 
 def create_timer(label: str, duration_s=None, notify_cfg=None) -> dict:
@@ -45,11 +61,38 @@ def get_timer(timer_id: str):
         return _timers.get(timer_id)
 
 
-def stop_timer(timer_id: str):
+def pause_timer(timer_id: str):
+    """Freeze a running timer, resumable later from the same elapsed point."""
     with _lock:
         t = _timers.get(timer_id)
-        if t and t['stopped_at'] is None:
-            t['stopped_at'] = int(time.time())
+        if t and t['state'] == 'running':
+            _bank_running_segment(t, int(time.time()))
+            t['state'] = 'paused'
+        return t
+
+
+def resume_timer(timer_id: str):
+    """Continue a paused timer without losing the time already banked."""
+    with _lock:
+        t = _timers.get(timer_id)
+        if t and t['state'] == 'paused':
+            t['segment_started_at'] = int(time.time())
+            t['state'] = 'running'
+        return t
+
+
+def stop_timer(timer_id: str):
+    """Terminal freeze (only reset_timer can bring it back). Valid from
+    either running or paused - banks the live segment first if running,
+    so pause->stop and stop-while-running both land on the same elapsed
+    value regardless of which raced in first (both paths go through the
+    same lock, and _bank_running_segment() is a no-op once already
+    paused/stopped)."""
+    with _lock:
+        t = _timers.get(timer_id)
+        if t and t['state'] in ('running', 'paused'):
+            _bank_running_segment(t, int(time.time()))
+            t['state'] = 'stopped'
         return t
 
 
@@ -57,9 +100,9 @@ def reset_timer(timer_id: str):
     with _lock:
         t = _timers.get(timer_id)
         if t:
-            t['started_at'] = int(time.time())
-            t['stopped_at'] = None
-            t['finished'] = False
+            t['accumulated_s'] = 0
+            t['segment_started_at'] = int(time.time())
+            t['state'] = 'running'
         return t
 
 
@@ -72,11 +115,12 @@ def mark_finished(timer_id: str):
     with _lock:
         t = _timers.get(timer_id)
         if t:
-            t['finished'] = True
-            t['stopped_at'] = int(time.time())
+            _bank_running_segment(t, int(time.time()))
+            t['state'] = 'finished'
         return t
 
 
 def get_elapsed(t: dict) -> int:
-    end = t['stopped_at'] or int(time.time())
-    return end - t['started_at']
+    if t['state'] == 'running' and t['segment_started_at'] is not None:
+        return t['accumulated_s'] + (int(time.time()) - t['segment_started_at'])
+    return t['accumulated_s']

--- a/static/chat.js
+++ b/static/chat.js
@@ -960,30 +960,40 @@ function renderTimersList() {
   }
 
   list.innerHTML = _timers.map(t => {
-    const running = !t.stopped_at && !t.finished;
     const label = escapeHtml(t.label || 'Timer');
+    const nonTerminalControls = t.state === 'running'
+      ? `<button class="btn btn-xs" onclick="pauseTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_pause">${escapeHtml(window.I18N.t('time.timer_pause'))}</button>`
+      : `<button class="btn btn-xs" onclick="resumeTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_resume">${escapeHtml(window.I18N.t('time.timer_resume'))}</button>`;
+    const stopOrReset = (t.state === 'running' || t.state === 'paused')
+      ? `<button class="btn btn-xs" onclick="stopTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_stop">${escapeHtml(window.I18N.t('time.timer_stop'))}</button>`
+      : `<button class="btn btn-xs" onclick="resetTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_reset">${escapeHtml(window.I18N.t('time.timer_reset'))}</button>`;
     return `
-      <div class="timer-item ${t.finished ? 'timer-item--finished' : ''}" data-id="${escapeHtml(t.id)}">
+      <div class="timer-item ${t.state === 'finished' ? 'timer-item--finished' : ''}" data-id="${escapeHtml(t.id)}">
         <span class="timer-item-label">${label}</span>
         <span class="timer-display" id="timer-display-${escapeHtml(t.id)}">${_formatTimerDisplay(t)}</span>
         <div class="timer-controls">
-          ${running
-            ? `<button class="btn btn-xs" onclick="stopTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_stop">${escapeHtml(window.I18N.t('time.timer_stop'))}</button>`
-            : `<button class="btn btn-xs" onclick="resetTimer('${escapeHtml(t.id)}')" data-i18n="time.timer_reset">${escapeHtml(window.I18N.t('time.timer_reset'))}</button>`}
+          ${(t.state === 'running' || t.state === 'paused') ? nonTerminalControls : ''}
+          ${stopOrReset}
           <button class="btn btn-xs btn-danger" title="${escapeHtml(window.I18N.t('time.timer_delete'))}" onclick="deleteTimer('${escapeHtml(t.id)}')">✕</button>
         </div>
       </div>`;
   }).join('');
 
   _timers.forEach(t => {
-    if (!t.stopped_at && !t.finished) _startLocalTick(t);
+    if (t.state === 'running') _startLocalTick(t);
   });
+}
+
+function _timerElapsed(t, nowSeconds) {
+  if (t.state === 'running' && t.segment_started_at !== null) {
+    return t.accumulated_s + (nowSeconds - t.segment_started_at);
+  }
+  return t.accumulated_s;
 }
 
 function _formatTimerDisplay(t) {
   const now = Math.floor(TimeFormatter.now().getTime() / 1000);
-  const end = t.stopped_at || now;
-  const elapsed = end - t.started_at;
+  const elapsed = _timerElapsed(t, now);
   if (t.duration_s) {
     return _formatSeconds(Math.max(0, t.duration_s - elapsed));
   }
@@ -1008,13 +1018,13 @@ function _startLocalTick(timer) {
       return;
     }
     const now = Math.floor(TimeFormatter.now().getTime() / 1000);
-    const elapsed = now - timer.started_at;
+    const elapsed = _timerElapsed(timer, now);
 
     if (timer.duration_s) {
       const remaining = timer.duration_s - elapsed;
       el.textContent = _formatSeconds(Math.max(0, remaining));
-      if (remaining <= 0 && !timer.finished) {
-        timer.finished = true;
+      if (remaining <= 0 && timer.state !== 'finished') {
+        timer.state = 'finished';
         clearInterval(_timerTicks[timer.id]);
         delete _timerTicks[timer.id];
         _onTimerFinished(timer.id);
@@ -1029,6 +1039,18 @@ async function _onTimerFinished(id) {
   await fetch(`/api/timers/${encodeURIComponent(id)}/finish`, { method: 'POST' });
   await loadTimers();
   await pollNotifications();
+}
+
+async function pauseTimer(id) {
+  await fetch(`/api/timers/${encodeURIComponent(id)}/pause`, { method: 'PATCH' });
+  clearInterval(_timerTicks[id]);
+  delete _timerTicks[id];
+  await loadTimers();
+}
+
+async function resumeTimer(id) {
+  await fetch(`/api/timers/${encodeURIComponent(id)}/resume`, { method: 'PATCH' });
+  await loadTimers();
 }
 
 async function stopTimer(id) {

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1018,6 +1018,8 @@
     "minutes_short": "Min",
     "seconds_short": "Sek",
     "timer_notify": "Benachrichtigen",
+    "timer_pause": "Pause",
+    "timer_resume": "Fortsetzen",
     "timer_stop": "Stopp",
     "timer_reset": "Zurücksetzen",
     "timer_delete": "Entfernen",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1018,6 +1018,8 @@
     "minutes_short": "min",
     "seconds_short": "sec",
     "timer_notify": "Notify on finish",
+    "timer_pause": "Pause",
+    "timer_resume": "Resume",
     "timer_stop": "Stop",
     "timer_reset": "Reset",
     "timer_delete": "Remove",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -1018,6 +1018,8 @@
     "minutes_short": "мин",
     "seconds_short": "сек",
     "timer_notify": "Уведомить при завершении",
+    "timer_pause": "Пауза",
+    "timer_resume": "Продолжить",
     "timer_stop": "Стоп",
     "timer_reset": "Сброс",
     "timer_delete": "Удалить",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -1018,6 +1018,8 @@
     "minutes_short": "хв",
     "seconds_short": "с",
     "timer_notify": "Сповістити при завершенні",
+    "timer_pause": "Пауза",
+    "timer_resume": "Продовжити",
     "timer_stop": "Стоп",
     "timer_reset": "Скинути",
     "timer_delete": "Видалити",

--- a/templates/index.html
+++ b/templates/index.html
@@ -2027,7 +2027,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260817-export-time-format"></script>
+<script src="/static/chat.js?v=20260817-timer-pause-resume"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
- Timers previously only had a terminal Stop (freeze forever) and Reset (restart from zero) - no way to freeze and later continue from the same elapsed point.
- Replaces the `started_at`/`stopped_at` pair in `meshsrv/timer_service.py` with an explicit `state` (`running`/`paused`/`stopped`/`finished`) plus `accumulated_s` + `segment_started_at`, so elapsed time is derived from banked segments rather than accumulated tick-by-tick (no drift across repeated pause/resume cycles).
- `stop_timer()` banks the live segment whether called from `running` or `paused`, so a pause/stop race lands on the same elapsed value regardless of arrival order (both paths go through the same lock).
- Adds `PATCH /api/timers/<id>/pause` and `/resume`, and Pause/Resume buttons in the timer list UI next to the existing Stop/Reset/Delete controls.
- Adds `time.timer_pause`/`time.timer_resume` to all four i18n catalogs.

## Test plan
- [x] Verified on dev (192.168.2.104) via direct API calls with measured wall-clock segments: 3 pause/resume cycles (segments of ~7s, ~10s, and a precisely-measured 3s) accumulated to exactly `20s` - the tightly-measured final segment matched wall-clock time exactly.
- [x] Verified `accumulated_s` does not drift during a pause (unchanged across a 2s idle period).
- [x] Verified the pause→stop race: pausing then immediately stopping does not double-bank the segment.
- [x] Verified pause on an already-stopped timer is a no-op (guard pattern).
- [x] Verified UI button states across the full cycle: running `[Pause][Stop][✕]` → paused `[Resume][Stop][✕]` → running → stopped `[Reset][✕]`.
- [x] No new console errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)