### PR TITLE
feat: top-5 CPU processes panel in System Info card

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -180,6 +180,53 @@ def register_system_routes(app, get_cpu_temperature=None):
 
         return jsonify(result)
 
+    @app.route("/api/system/top-processes")
+    def api_system_top_processes():
+        """On-demand top-5 CPU consumers, system-wide (not just MeshCenter).
+
+        Stateless by design - no cross-request Process cache - so there's
+        nothing to prune when a process dies and no memory growth over time.
+        psutil.Process.cpu_percent(None) returns 0.0 on its first call per
+        Process object (no prior sample to diff against), so every call here
+        primes all handles, sleeps briefly, then samples again - the whole
+        cost is one blocking sleep inside this single request, not a
+        background loop, matching the "diagnostics you look at occasionally"
+        budget this endpoint is for (see the frontend's on-open-only polling).
+        """
+        import psutil
+
+        SAMPLE_WINDOW_S = 0.35
+
+        try:
+            procs = list(psutil.process_iter(["pid", "name"]))
+
+            for proc in procs:
+                try:
+                    proc.cpu_percent(None)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+
+            time.sleep(SAMPLE_WINDOW_S)
+
+            results = []
+            for proc in procs:
+                try:
+                    cpu = proc.cpu_percent(None)
+                    name = proc.info.get("name") or "?"
+                    results.append({
+                        "pid": proc.pid,
+                        "name": name,
+                        "cpu_percent": round(cpu, 1),
+                    })
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    continue
+
+            results.sort(key=lambda item: item["cpu_percent"], reverse=True)
+
+            return jsonify({"ok": True, "processes": results[:5]})
+        except Exception as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
     def get_saved_wifi_names():
         try:
             out = subprocess.check_output(

--- a/static/chat.js
+++ b/static/chat.js
@@ -13307,6 +13307,11 @@ function switchMainTab(tab) {
     if (nodeManagerView) nodeManagerView.style.display = 'none';
     if (photoView) photoView.style.display = 'none';
     if (systemView) systemView.style.display = 'none';
+    // The System workspace's top-processes panel polls only while visibly
+    // open (see toggleTopProcesses()) - systemView going display:none here
+    // doesn't stop a running setInterval on its own, so stop it explicitly
+    // on every tab switch rather than only on the panel's own toggle-close.
+    stopTopProcessesPolling();
     if (settingsView) settingsView.style.display = 'none';
     if (aboutView) aboutView.style.display = 'none';
     if (mapView) mapView.style.display = 'none';
@@ -14025,6 +14030,30 @@ function ensureCpuHistoryPanel() {
             <canvas id="cpuUsageHistoryCanvas"></canvas>
             <div id="cpuHistoryEmpty" class="cpu-history-empty">Collecting CPU data…</div>
         </div>
+        <div class="top-processes-section">
+            <button type="button"
+                    id="topProcessesToggle"
+                    class="top-processes-toggle"
+                    onclick="toggleTopProcesses()"
+                    aria-expanded="false"
+                    aria-controls="topProcessesPanel">
+                <span>${escapeHtml(window.I18N.t('system.top_processes_title'))}</span>
+                <span id="topProcessesArrow">▾</span>
+            </button>
+            <div id="topProcessesPanel" class="top-processes-panel" style="display:none;">
+                <table class="top-processes-table">
+                    <thead>
+                        <tr>
+                            <th>${escapeHtml(window.I18N.t('system.process_column'))}</th>
+                            <th>PID</th>
+                            <th>${escapeHtml(window.I18N.t('system.cpu_column'))}</th>
+                        </tr>
+                    </thead>
+                    <tbody id="topProcessesTbody"></tbody>
+                </table>
+                <div id="topProcessesUpdated" class="top-processes-updated"></div>
+            </div>
+        </div>
     `;
     systemCard.appendChild(panel);
 
@@ -14037,6 +14066,83 @@ function ensureCpuHistoryPanel() {
         });
         loadCpuHistory(true);
     });
+}
+
+// ─── Top processes (on-demand, System Info card) ──────────────────
+// Mirrors toggleRadioHealthHistory()'s disclosure pattern. Polling only
+// runs while the panel is visibly open (cleared on close) - this is
+// diagnostic-only data nobody needs updated in the background, and the
+// backend's own cost (a 0.35s psutil sample window) is meant to be paid
+// on-demand, not on a fixed timer regardless of whether anyone's looking.
+let topProcessesRefreshTimer = null;
+let topProcessesTickTimer = null;
+let topProcessesLastFetchMs = null;
+
+function stopTopProcessesPolling() {
+    clearInterval(topProcessesRefreshTimer);
+    clearInterval(topProcessesTickTimer);
+    topProcessesRefreshTimer = null;
+    topProcessesTickTimer = null;
+
+    const panel = document.getElementById('topProcessesPanel');
+    const arrow = document.getElementById('topProcessesArrow');
+    const button = document.getElementById('topProcessesToggle');
+    if (panel) panel.style.display = 'none';
+    if (arrow) arrow.textContent = '▾';
+    if (button) button.setAttribute('aria-expanded', 'false');
+}
+
+function toggleTopProcesses() {
+    const panel = document.getElementById('topProcessesPanel');
+    if (!panel) return;
+
+    const opening = panel.style.display === 'none';
+
+    if (!opening) {
+        stopTopProcessesPolling();
+        return;
+    }
+
+    const arrow = document.getElementById('topProcessesArrow');
+    const button = document.getElementById('topProcessesToggle');
+    panel.style.display = 'block';
+    if (arrow) arrow.textContent = '▴';
+    if (button) button.setAttribute('aria-expanded', 'true');
+
+    loadTopProcesses();
+    topProcessesRefreshTimer = setInterval(loadTopProcesses, 7000);
+    topProcessesTickTimer = setInterval(updateTopProcessesFreshness, 1000);
+}
+
+function updateTopProcessesFreshness() {
+    const el = document.getElementById('topProcessesUpdated');
+    if (!el || topProcessesLastFetchMs === null) return;
+    const seconds = Math.max(0, Math.round((Date.now() - topProcessesLastFetchMs) / 1000));
+    el.textContent = window.I18N.t('system.updated_seconds_ago', { seconds });
+}
+
+async function loadTopProcesses() {
+    const tbody = document.getElementById('topProcessesTbody');
+    if (!tbody) return;
+
+    try {
+        const response = await fetch('/api/system/top-processes');
+        const data = await response.json();
+        if (!data.ok || !Array.isArray(data.processes)) return;
+
+        tbody.innerHTML = data.processes.map(proc => `
+            <tr>
+                <td>${escapeHtml(proc.name)}</td>
+                <td>${escapeHtml(String(proc.pid))}</td>
+                <td>${escapeHtml(proc.cpu_percent.toFixed(1))}%</td>
+            </tr>
+        `).join('');
+
+        topProcessesLastFetchMs = Date.now();
+        updateTopProcessesFreshness();
+    } catch (e) {
+        console.warn('Top processes load failed:', e);
+    }
 }
 
 function cpuMetricClass(value, warning = 50, danger = 80) {

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -489,7 +489,11 @@
     "restarts_label": "Neustarts",
     "seconds_ago": "vor {seconds} s",
     "system_information_title": "Systeminformationen",
-    "uptime_label": "Laufzeit"
+    "uptime_label": "Laufzeit",
+    "top_processes_title": "Top-Prozesse",
+    "process_column": "Prozess",
+    "cpu_column": "CPU",
+    "updated_seconds_ago": "Aktualisiert vor {seconds} s"
   },
   "settings": {
     "title": "Einstellungen",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -489,7 +489,11 @@
     "restarts_label": "Restarts",
     "seconds_ago": "{seconds} s ago",
     "system_information_title": "System Information",
-    "uptime_label": "Uptime"
+    "uptime_label": "Uptime",
+    "top_processes_title": "Top processes",
+    "process_column": "Process",
+    "cpu_column": "CPU",
+    "updated_seconds_ago": "Updated {seconds} s ago"
   },
   "settings": {
     "title": "Settings",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -489,7 +489,11 @@
     "restarts_label": "Перезапуски",
     "seconds_ago": "{seconds} с назад",
     "system_information_title": "Информация о системе",
-    "uptime_label": "Время работы"
+    "uptime_label": "Время работы",
+    "top_processes_title": "Топ процессов",
+    "process_column": "Процесс",
+    "cpu_column": "CPU",
+    "updated_seconds_ago": "Обновлено {seconds} с назад"
   },
   "settings": {
     "title": "Настройки",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -489,7 +489,11 @@
     "restarts_label": "Перезапуски",
     "seconds_ago": "{seconds} с тому",
     "system_information_title": "Інформація про систему",
-    "uptime_label": "Час роботи"
+    "uptime_label": "Час роботи",
+    "top_processes_title": "Топ процесів",
+    "process_column": "Процес",
+    "cpu_column": "CPU",
+    "updated_seconds_ago": "Оновлено {seconds} с тому"
   },
   "settings": {
     "title": "Налаштування",

--- a/static/style.css
+++ b/static/style.css
@@ -6141,6 +6141,66 @@ body.context-chat-mode .settings-view {
     pointer-events: none;
 }
 
+.top-processes-section {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid #dfe4eb;
+}
+
+.top-processes-toggle {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    padding: 4px 2px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #34445f;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+}
+
+.top-processes-toggle:hover { color: #145fc6; }
+
+.top-processes-panel {
+    margin-top: 6px;
+}
+
+.top-processes-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+}
+
+.top-processes-table th {
+    text-align: left;
+    color: #8592a3;
+    font-weight: 600;
+    padding: 3px 6px;
+    border-bottom: 1px solid #dfe4eb;
+}
+
+.top-processes-table td {
+    padding: 4px 6px;
+    border-bottom: 1px solid #edf0f4;
+    font-variant-numeric: tabular-nums;
+}
+
+.top-processes-table td:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 140px;
+}
+
+.top-processes-updated {
+    margin-top: 6px;
+    color: #8592a3;
+    font-size: 10px;
+}
+
 #dockContextText {
     display: flex;
     align-items: center;

--- a/templates/index.html
+++ b/templates/index.html
@@ -2027,7 +2027,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260817-timer-pause-resume"></script>
+<script src="/static/chat.js?v=20260817-top-processes"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
- Adds an on-demand, collapsible "Top processes" section under the CPU Usage chart in the System Info card, showing the top-5 CPU consumers system-wide (not scoped to MeshCenter's own process).
- Backend: `GET /api/system/top-processes` uses `psutil` (already an unused dependency in requirements.txt) rather than shelling out to `ps aux` (subprocess spawn cost) or hand-rolling `/proc/[pid]/stat` delta tracking. Stateless per-request: prime every process's `cpu_percent()` handle, sleep 0.35s, sample again - the only cost is one blocking sleep inside a single on-demand request, not a background loop.
- Frontend: collapsed by default, mirrors the existing System Log disclosure pattern (`toggleRadioHealthHistory()`). Auto-refreshes every 7s only while visibly open, with a "seconds ago" freshness label reusing the established `system.seconds_ago` wording. Polling is explicitly stopped on every main-tab switch (`stopTopProcessesPolling()`), not just on manual collapse.

## Test plan
- [x] Verified live on dev (192.168.2.104, Pi Zero 2W): panel renders real data, freshness label ticks, ~815ms latency per open (acceptable one-off cost, no background load).
- [x] Verified live on prod (192.168.2.103, Pi Zero 2W): real system-wide diversity visible (`node-red`, `meshtastic` CLI subprocess, kernel threads alongside MeshCenter's own `python`), not just MeshCenter's own process.
- [x] Verified live on camtest (192.168.2.107, Pi 4B+): same behavior, uk locale freshness label renders correctly ("Оновлено N с тому").
- [x] Verified on all three: zero additional `/api/system/top-processes` requests in the 8-9s after switching away from the System tab, confirming the auto-refresh interval is actually cleared, not just visually hidden.
- [x] Confirmed `psutil` is present in each node's actual service venv (not just system Python) before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)