### PR TITLE
fix: export dialog's custom-range date field collapsed to ~22px, invisible

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3122,12 +3122,21 @@ body {
     gap: 6px;
 }
 
-.export-date-input {
+/* Both qualified with .export-date-grid to out-specificity the generic
+   ".export-date-grid input { width: 100% }" rule above, written for the
+   old single-input-per-field layout - without this, that rule's (class +
+   type) specificity beats these (class-only) ones regardless of source
+   order, stretching the hour/minute boxes to the full column width
+   (flex-shrink:0 lets them overflow instead of shrinking back) and
+   crushing the date input - which has no competing width of its own - to
+   near-zero trying to compensate. */
+.export-date-grid .export-date-input {
     flex: 1 1 auto;
     min-width: 0;
+    width: auto;
 }
 
-.export-time-input {
+.export-date-grid .export-time-input {
     width: 48px;
     flex: 0 0 auto;
     text-align: center;

--- a/static/style.css
+++ b/static/style.css
@@ -3097,7 +3097,11 @@ body {
 
 .export-date-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    /* Single column, not side-by-side: each row now holds date + hour +
+       minute (+ AM/PM select in 12h mode) - four fields don't fit two
+       abreast at this dialog's width without clipping the second ("To")
+       field off the edge, as happened with the old 1fr 1fr layout. */
+    grid-template-columns: 1fr;
     gap: 12px;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -3027,7 +3027,7 @@ body {
 }
 
 .custom-export-dialog {
-    width: min(520px, 100%);
+    width: min(380px, 100%);
     background: #ffffff;
     border-radius: 16px;
     box-shadow: 0 18px 45px rgba(0, 0, 0, 0.25);
@@ -3123,6 +3123,7 @@ body {
 .export-datetime-row {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 6px;
 }
 
@@ -3135,9 +3136,12 @@ body {
    crushing the date input - which has no competing width of its own - to
    near-zero trying to compensate. */
 .export-date-grid .export-date-input {
-    flex: 1 1 auto;
-    min-width: 0;
-    width: auto;
+    /* Sized to content (a native date input's natural rendered width),
+       not flex-grown to fill the row - stretching it to match the row's
+       full width just wasted space the dialog didn't need to be that
+       wide for in the first place. */
+    flex: 0 0 auto;
+    width: 140px;
 }
 
 .export-date-grid .export-time-input {
@@ -3174,6 +3178,7 @@ body {
 
 .export-format-row {
     display: flex;
+    flex-direction: column;
     gap: 10px;
 }
 
@@ -3213,16 +3218,6 @@ body {
     border: 1px solid #1a73e8;
     background: #1a73e8;
     color: white;
-}
-
-@media (max-width: 600px) {
-    .export-date-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .export-format-row {
-        flex-direction: column;
-    }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Three fixes on this branch, all found live during the same testing pass on the telemetry export "Custom range" dialog:

### 1. Date field collapsed to ~22px, effectively invisible
`.export-date-grid input { width: 100% }` (written for the old single `datetime-local` input this replaced) has higher CSS specificity (class+type) than `.export-date-input`/`.export-time-input` (class-only), regardless of source order - it silently overrode both. Fixed by requalifying both selectors with the `.export-date-grid` ancestor to win on specificity.

### 2. "From"/"To" rows overflowed the dialog side-by-side
After fix #1 restored real field sizes, the two-column `1fr 1fr` layout couldn't fit four fields (date + hour + minute + AM/PM in 12h mode) per column - the "To" row got clipped off the edge. Switched to a single column, "From" stacked above "To".

### 3. Dialog was wider than its content needed
The date input was still flex-grown to fill the row's remaining width, and CSV/JSON sat side by side - both pushed the dialog wider than necessary. Date input now sized to content (140px, a native date input's natural width), format options stacked into one column, dialog width reduced 520px → 380px to match. Also removed the now-dead max-width:600px media query overrides for both, since their behavior is the unconditional default now.

## Test plan
- [x] Verified live on dev, camtest, and prod across all three fixes.
- [x] Final state (12h mode, worst case): dialog 380px, date field 140px, each date/time row 338px (comfortably fits including the AM/PM select), format options stacked vertically with distinct Y positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)