### PR TITLE
feat: export dialog series checkboxes + compact side-by-side format pills

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -1424,6 +1424,23 @@ let telemetryVisibleSeries = {
     }
 };
 
+const TELEMETRY_SERIES_KEYS = {
+    environment: ['temperature', 'humidity', 'pressure'],
+    power: ['voltage', 'current', 'power']
+};
+
+function telemetrySeriesLabel(key) {
+    const labels = {
+        temperature: window.I18N.t('node_panel.temperature'),
+        humidity: window.I18N.t('node_panel.humidity'),
+        pressure: window.I18N.t('node_panel.pressure'),
+        voltage: window.I18N.t('node_panel.voltage'),
+        current: window.I18N.t('node_panel.current'),
+        power: window.I18N.t('node_panel.power')
+    };
+    return labels[key] || key;
+}
+
 function celsiusToFahrenheit(c) {
     return (c * 9 / 5) + 32;
 }
@@ -10625,7 +10642,7 @@ function openCustomTelemetryExport() {
     const rangeMinutes = telemetryTimeRange || 1440;
     const from = new Date(now.getTime() - rangeMinutes * 60 * 1000);
 
-    const seriesText = getTelemetryVisibleSeriesText(type);
+    const seriesKeys = TELEMETRY_SERIES_KEYS[type] || [];
     const rangeLabel = getTelemetryRangeLabel(rangeMinutes);
 
     const overlay = document.createElement('div');
@@ -10674,7 +10691,14 @@ function openCustomTelemetryExport() {
 
                 <div class="export-section">
                     <div class="export-section-title">${escapeHtml(window.I18N.t('nodes.series'))}</div>
-                    <div class="export-series-summary">${escapeHtml(seriesText)}</div>
+                    <div class="export-series-checks" id="exportSeriesChecks">
+                        ${seriesKeys.map(key => `
+                            <label class="export-series-check">
+                                <input type="checkbox" value="${key}" ${telemetryVisibleSeries[type]?.[key] ? 'checked' : ''}>
+                                <span>${escapeHtml(telemetrySeriesLabel(key))}</span>
+                            </label>
+                        `).join('')}
+                    </div>
                 </div>
 
                 <div class="export-section">
@@ -10801,18 +10825,10 @@ function getTelemetryRangeLabel(minutes) {
 
 function getTelemetryVisibleSeriesText(type) {
     const visible = telemetryVisibleSeries[type] || {};
-    const labels = {
-        temperature: window.I18N.t('node_panel.temperature'),
-        humidity: window.I18N.t('node_panel.humidity'),
-        pressure: window.I18N.t('node_panel.pressure'),
-        voltage: window.I18N.t('node_panel.voltage'),
-        current: window.I18N.t('node_panel.current'),
-        power: window.I18N.t('node_panel.power')
-    };
 
     const active = Object.keys(visible)
         .filter(key => visible[key])
-        .map(key => labels[key] || key);
+        .map(telemetrySeriesLabel);
 
     return active.length > 0 ? active.join(' • ') : window.I18N.t('nodes.no_series_selected');
 }
@@ -10824,8 +10840,11 @@ function runCustomTelemetryExport() {
     const format = document.querySelector('input[name="exportFormat"]:checked')?.value || 'csv';
     const mode = document.querySelector('input[name="exportRangeMode"]:checked')?.value || 'visible';
 
-    const series = Object.keys(telemetryVisibleSeries[type] || {})
-        .filter(key => telemetryVisibleSeries[type][key])
+    // Read from the dialog's own checkboxes, not telemetryVisibleSeries -
+    // these are seeded from the chart's current toggle state when the
+    // dialog opens, but editable here without touching the chart itself.
+    const series = Array.from(document.querySelectorAll('#exportSeriesChecks input[type="checkbox"]:checked'))
+        .map(checkbox => checkbox.value)
         .join(',');
 
     const nodeId = modal?.dataset?.nodeId || '';

--- a/static/style.css
+++ b/static/style.css
@@ -3167,28 +3167,34 @@ body {
     font-size: 13px;
 }
 
-.export-series-summary {
-    background: #f5f7fb;
-    border: 1px solid #e5e8ec;
-    border-radius: 10px;
-    padding: 10px 12px;
+.export-series-checks {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.export-series-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 13px;
     color: #374151;
+    cursor: pointer;
 }
 
 .export-format-row {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 10px;
 }
 
 .export-format-option {
     flex: 1;
     border: 1px solid #d7dce5;
-    border-radius: 12px;
-    padding: 10px 12px;
+    border-radius: 10px;
+    padding: 7px 10px;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 13px;
 }
 
 .custom-export-footer {
@@ -14433,6 +14439,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 }
 [data-theme="dark"] .export-section-title,
 [data-theme="dark"] .export-radio-row,
+[data-theme="dark"] .export-series-check,
 [data-theme="dark"] .export-format-option {
     color: #d9e7f5;
 }
@@ -14447,11 +14454,6 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 }
 [data-theme="dark"] .export-time-sep {
     color: #9eb3c8;
-}
-[data-theme="dark"] .export-series-summary {
-    background: #16283a;
-    border-color: #2a3f54;
-    color: #d9e7f5;
 }
 [data-theme="dark"] .custom-export-footer {
     background: #16283a;


### PR DESCRIPTION
## Summary

### Series checkboxes, editable independent of the chart
`runCustomTelemetryExport()` used to read directly from the global `telemetryVisibleSeries[type]` state - whatever series were toggled on/off on the chart behind the dialog - while the dialog itself only showed a static read-only text summary of that state. Replaced the summary with checkboxes (one per series, seeded from the chart's current state when the dialog opens, but editable locally). A series can now be added to or removed from the export without closing the dialog to go toggle it on the chart first. Toggling in the dialog does **not** write back to `telemetryVisibleSeries` - verified live that the chart's own state is untouched after changing a checkbox in the dialog.

Applies to both the Environment and Power telemetry cards - both go through this same shared `openCustomTelemetryExport()`/`runCustomTelemetryExport()` pair.

### Compact side-by-side format pills
CSV/JSON go back to a single row of two pills instead of full-width stacked cards - a binary choice doesn't need a full row each, and the dialog is narrow enough now (380px, from the previous PR in this chain) that side-by-side fits without reintroducing the earlier overflow issue.

## Test plan
- [x] Verified live on dev: checkboxes correctly seed from `telemetryVisibleSeries` (turned off `humidity` on the chart, dialog opened with it unchecked).
- [x] Verified re-checking a series in the dialog changes what would be exported (`temperature,humidity,pressure`) while `telemetryVisibleSeries.environment.humidity` stays `false` - confirms no leak back to the chart.
- [x] Verified format pills render side by side, 164px each in the 338px row, no overflow.
- [x] Deployed and confirmed present on dev, camtest, and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)