### PR TITLE
fix: Updates card version numbers invisible in dark theme

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14541,6 +14541,27 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 [data-theme="dark"] .export-time-sep {
     color: #9eb3c8;
 }
+[data-theme="dark"] .updates-version-row {
+    color: #9eb3c8;
+}
+[data-theme="dark"] .updates-version-row strong {
+    color: #e5eff8;
+}
+[data-theme="dark"] .updates-status-text,
+[data-theme="dark"] .updates-changelog-toggle {
+    color: #d9e7f5;
+}
+[data-theme="dark"] .updates-changelog-panel {
+    background: rgba(255, 255, 255, 0.04);
+    color: #c3d3e2;
+}
+[data-theme="dark"] .updates-result-panel {
+    background: #16283a;
+}
+[data-theme="dark"] .updates-rollback-command {
+    background: #0f1c2a;
+    color: #e5eff8;
+}
 [data-theme="dark"] .custom-export-footer {
     background: #16283a;
     border-top-color: #344b61;


### PR DESCRIPTION
## Summary

`.updates-version-row strong` used `#1f2937` (near-black) with no dark-theme override - `.system-card` has no blanket dark-theme handling in this project, so a hardcoded dark-on-light color goes silently invisible against the dark card background rather than erroring. Added the missing `[data-theme="dark"]` overrides for the whole Updates card's custom classes while in there (version numbers, status text, changelog panel, result panel, rollback command), not just the one reported element.

**Note for later**: `.system-row strong` (`#0f172a`) has the same class of bug across the rest of the System workspace (Hostname, Model, OS, Kernel, etc.) - pre-existing, wider than this card, deliberately left alone here since it wasn't what was reported and fixing it means touching every system-card in the app, not just this one.

## Test plan
- [x] Verified live on dev: computed color of `.updates-version-row strong` in dark theme is `rgb(229, 239, 248)` (the new override), not the old invisible `#1f2937`.
- [x] Confirmed the same CSS is deployed on camtest and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)