### PR TITLE
fix: stored XSS via mesh node/channel names in inline onclick handlers

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -3787,7 +3787,7 @@ function renderChatItem(chat) {
 
     const clickHandler = isDemo
         ? `showToast(${JSON.stringify(window.I18N.t('chat.channel_not_configured_toast'))}, 'info')`
-        : `openChat('${escapeHtml(chat.id)}', '${escapeHtml(chat.name)}', '${escapeHtml(chat.type)}', 'chat')`;
+        : `openChat('${escapeHtml(chat.id)}', '${escapeJsString(chat.name)}', '${escapeHtml(chat.type)}', 'chat')`;
     const demoClass = isDemo ? 'demo-channel' : '';
     const displayName = chat.is_channel && Number.isInteger(chat.index)
         ? formatChannelIndexLabel(chat.name, chat.index)
@@ -7724,10 +7724,10 @@ function renderNodeDetails(node) {
     actionsMenu.style.display = 'none';
     actionsMenu.innerHTML = `
         <div class="node-actions-menu-inner">
-            <button onclick="openChat('${escapeHtml(nodeId)}', '${escapeHtml(displayName)}', 'dm')">📨 ${escapeHtml(window.I18N.t('nodes.send_message'))}</button>
-            <button onclick="runNodeTool('request_position', '${escapeHtml(nodeId)}', '${escapeHtml(displayName)}', this)">📍 ${escapeHtml(window.I18N.t('nodes.request_position'))}</button>
-            <button onclick="runNodeTool('request_telemetry', '${escapeHtml(nodeId)}', '${escapeHtml(displayName)}', this)">📊 ${escapeHtml(window.I18N.t('nodes.request_telemetry'))}</button>
-            <button onclick="runNodeTool('traceroute', '${escapeHtml(nodeId)}', '${escapeHtml(displayName)}', this)">🔍 ${escapeHtml(window.I18N.t('nodes.traceroute'))}</button>
+            <button onclick="openChat('${escapeHtml(nodeId)}', '${escapeJsString(displayName)}', 'dm')">📨 ${escapeHtml(window.I18N.t('nodes.send_message'))}</button>
+            <button onclick="runNodeTool('request_position', '${escapeHtml(nodeId)}', '${escapeJsString(displayName)}', this)">📍 ${escapeHtml(window.I18N.t('nodes.request_position'))}</button>
+            <button onclick="runNodeTool('request_telemetry', '${escapeHtml(nodeId)}', '${escapeJsString(displayName)}', this)">📊 ${escapeHtml(window.I18N.t('nodes.request_telemetry'))}</button>
+            <button onclick="runNodeTool('traceroute', '${escapeHtml(nodeId)}', '${escapeJsString(displayName)}', this)">🔍 ${escapeHtml(window.I18N.t('nodes.traceroute'))}</button>
             <button onclick="setNodeAsReference('${escapeHtml(nodeId)}')">📍 ${escapeHtml(window.I18N.t('nodes.set_as_reference'))}</button>
         </div>
     `;
@@ -7799,7 +7799,7 @@ function renderOverviewPane(node) {
                 <span class="last-msg-time">${escapeHtml(node.last_time || '')}</span>
             </div>` : ''}
             <div class="node-detail-quick-actions">
-                <button class="quick-action" onclick="openChat('${escapeHtml(node.node_id)}', '${escapeHtml(node.clean_name || node.name || node.node_id)}', 'dm')">💬 ${escapeHtml(window.I18N.t('nodes.message_button'))}</button>
+                <button class="quick-action" onclick="openChat('${escapeHtml(node.node_id)}', '${escapeJsString(node.clean_name || node.name || node.node_id)}', 'dm')">💬 ${escapeHtml(window.I18N.t('nodes.message_button'))}</button>
                 <button class="quick-action" onclick="openExternalNodeMap(${node.position?.latitude || 0}, ${node.position?.longitude || 0})" ${!hasPosition ? 'disabled' : ''}>🗺 ${escapeHtml(window.I18N.t('nodes.external_map'))}</button>
                 <button class="quick-action" onclick="toggleNodeActionsMenu(event)">⚡ ${escapeHtml(window.I18N.t('nodes.more'))}</button>
             </div>
@@ -7842,7 +7842,7 @@ function renderRadioPane(node) {
                 ${historyHtml}
             </div>
             <div class="radio-actions">
-                <button class="radio-action" onclick="runNodeTool('traceroute', '${escapeHtml(node.node_id)}', '${escapeHtml(node.clean_name || node.name || node.node_id)}', this)">🔍 ${escapeHtml(window.I18N.t('nodes.run_traceroute'))}</button>
+                <button class="radio-action" onclick="runNodeTool('traceroute', '${escapeHtml(node.node_id)}', '${escapeJsString(node.clean_name || node.name || node.node_id)}', this)">🔍 ${escapeHtml(window.I18N.t('nodes.run_traceroute'))}</button>
                 <button class="radio-action" onclick="refreshNodeMetrics('${escapeHtml(node.node_id)}')">↻ ${escapeHtml(window.I18N.t('common.refresh'))}</button>
             </div>
         </div>
@@ -7892,13 +7892,13 @@ function renderPositionPane(node) {
                 <button onclick='openNodeMap(${pos.latitude}, ${pos.longitude}, ${JSON.stringify(String(node.node_id || ""))})'>🗺 ${escapeHtml(window.I18N.t('nodes.locate_on_map'))}</button>
                 <button onclick="copyCoordinates('${pos.latitude}', '${pos.longitude}')">📋 ${escapeHtml(window.I18N.t('nodes.copy_coordinates'))}</button>
                 <button onclick="setNodeAsReference('${escapeHtml(node.node_id)}')">📍 ${escapeHtml(window.I18N.t('nodes.set_as_reference'))}</button>
-                <button onclick="runNodeTool('request_position', '${escapeHtml(node.node_id)}', '${escapeHtml(node.clean_name || node.name || node.node_id)}', this)">📡 ${escapeHtml(window.I18N.t('nodes.request_new_position'))}</button>
+                <button onclick="runNodeTool('request_position', '${escapeHtml(node.node_id)}', '${escapeJsString(node.clean_name || node.name || node.node_id)}', this)">📡 ${escapeHtml(window.I18N.t('nodes.request_new_position'))}</button>
             </div>
             <div class="position-reference">${escapeHtml(window.I18N.t('nodes.reference_prefix', { name: referenceName }))}</div>
             ` : `
             <div class="position-no-data">
                 <span>📍 ${escapeHtml(window.I18N.t('nodes.no_known_position'))}</span>
-                <button onclick="runNodeTool('request_position', '${escapeHtml(node.node_id)}', '${escapeHtml(node.clean_name || node.name || node.node_id)}', this)">${escapeHtml(window.I18N.t('nodes.request_position'))}</button>
+                <button onclick="runNodeTool('request_position', '${escapeHtml(node.node_id)}', '${escapeJsString(node.clean_name || node.name || node.node_id)}', this)">${escapeHtml(window.I18N.t('nodes.request_position'))}</button>
             </div>
             `}
         </div>
@@ -7988,7 +7988,10 @@ function renderDataPane(node) {
     const hasEnv = hasTemperature || hasHumidity || hasPressure;
     const hasPower = hasPowerVoltage || hasCurrent || hasPowerValue;
     const nodeId = escapeHtml(node.node_id);
-    const nodeName = escapeHtml(node.clean_name || node.name || node.node_id);
+    // Only ever used inside onclick="...('${nodeName}'...)" below (JS-string
+    // context, not HTML text) - escapeJsString(), not escapeHtml(), or a
+    // longName containing a single quote breaks out of the attribute.
+    const nodeName = escapeJsString(node.clean_name || node.name || node.node_id);
 
     const deviceRows = [
         hasBattery ? `<div><span class="label">${escapeHtml(window.I18N.t('node_panel.battery'))}</span><span class="value">${escapeHtml(formatBatteryPercent(node.battery_level))}%</span></div>` : '',

--- a/templates/index.html
+++ b/templates/index.html
@@ -2101,7 +2101,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260818-updates-card"></script>
+<script src="/static/chat.js?v=20260818-xss-fix-onclick-names"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary

**Vulnerability**: `escapeHtml()` (`static/chat.js`, via `textContent`→`innerHTML`) escapes `&`/`<`/`>` but does **not** escape single quotes — correct for plain HTML text content, but unsafe when the result is interpolated inside a single-quoted JS-string argument within an inline `onclick="...('${...}'...)"` attribute. A Meshtastic longName (`chat.name` / `node.clean_name` / `node.name` / `displayName`) containing a single quote can break out of the argument and inject arbitrary `onclick` JavaScript. This data arrives from the mesh network with no special-character sanitization on the way in.

**Fix**: `escapeJsString()` (backslash/quote/CR/LF escaping) already existed and was already used correctly in `buildMapPopup()` - this extends the same pattern to every other onclick site found via a full pass over `static/*.js` that interpolates a name-bearing (mesh-derived) field:

- `renderChatItem()`'s `clickHandler`: `chat.name`
- `renderNodeDetails()`'s action menu (`openChat`/`runNodeTool` x3): `displayName`
- `renderOverviewPane`/`renderRadioPane`/`renderPositionPane` (x4): `node.clean_name || node.name || node.node_id`
- `renderDataPane()`: `nodeName` (changed at its single definition point, since it's only ever used in `onclick`, never as HTML text)

**Left untouched, deliberately**:
- `escapeHtml()` used for the *same* values as on-screen text (`.chat-name`, `.node-detail-name` spans, etc.) - that usage is correct, unrelated to this bug.
- Every onclick site where the escaped value is a technical ID (node_id, schedule/timer/waypoint UUID, camera id, git SHA, tab id) - these can't structurally contain a quote; changing them would only widen the diff without a real fix.
- `static/media.js`'s `deleteMediaItem` button, which builds its onclick with `JSON.stringify()` inside a single-quoted attribute - same underlying bug class, but the filename source is server-generated (timestamp-based), not free text, so likely not exploitable in practice. Flagging for separate review rather than fixing here, to keep this diff scoped to the confirmed, exploitable mesh-data path.

## Test plan
- [x] `node --check static/chat.js` - no syntax errors.
- [x] `grep -n 'onclick="[^"]*escapeHtml'` re-run after the fix - every remaining match is a technical ID or a developer-controlled i18n string, none are name/text fields.
- [x] **Live exploit test on dev**: rendered `renderOverviewPane()` with a mock node whose `clean_name` is `"Evil'); alert('XSS'); //"`, inserted the real HTML into the live DOM, and clicked the actual button. `alert()` did **not** fire; the malicious string arrived at `openChat()` intact as inert *data* (its `name` argument), not as executed code.
- [x] **Live regression test on dev**: same flow with a normal node name (`"Flint TAP2"`) - `openChat()` receives the correct, unmangled name, confirming the fix doesn't affect the common case.
- [x] Deployed and confirmed present (byte-for-byte) on dev, camtest, and prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)