### PR TITLE
feat: optional whole-app password protection (P0, off by default)

### DIFF
--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -1,0 +1,173 @@
+"""Optional whole-app password protection.
+
+Off by default (see config.example.py's AUTH_ENABLED / AUTH_PASSWORD_HASH).
+Single shared password, no usernames/roles - a Flask session cookie is set
+on successful login and checked in a before_request hook. State (enabled
+flag + password hash) lives in its own data/auth.json rather than
+settings.json, so it can never be silently wiped by the generic
+POST /api/settings merge-and-replace in api_settings.py, and the hash is
+never included in a settings.json snapshot handed back to the browser.
+"""
+
+from urllib.parse import quote
+
+from flask import jsonify, redirect, request, render_template, session
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from storage.json_store import safe_read_json, safe_write_json
+
+MIN_PASSWORD_LENGTH = 4
+
+# Paths that must stay reachable without a session so the login page itself
+# (and the assets it needs) can render.
+_EXEMPT_PATH_PREFIXES = ("/static/",)
+_EXEMPT_PATHS = ("/login",)
+
+
+def load_auth_state(auth_file, bootstrap_enabled=False, bootstrap_password_hash=""):
+    data = safe_read_json(auth_file, default=None)
+    if isinstance(data, dict) and ("password_hash" in data or "enabled" in data):
+        return {
+            "enabled": bool(data.get("enabled", False)),
+            "password_hash": str(data.get("password_hash") or ""),
+        }
+
+    # First run: seed from config.py's bootstrap values (both off/empty by
+    # default), same pattern as WEATHER_PROVIDER's config->settings.json handoff.
+    bootstrap_password_hash = str(bootstrap_password_hash or "")
+    return {
+        "enabled": bool(bootstrap_enabled) and bool(bootstrap_password_hash.strip()),
+        "password_hash": bootstrap_password_hash,
+    }
+
+
+def is_protected(auth_state):
+    # An enabled flag with no usable hash never blocks access - avoids a
+    # misconfigured/corrupted auth.json permanently locking out the UI.
+    return bool(auth_state.get("enabled")) and bool(str(auth_state.get("password_hash") or "").strip())
+
+
+def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, resolve_ui_language=None):
+    def _save():
+        with state_lock:
+            safe_write_json(auth_file, auth_state)
+
+    def _ui_language():
+        if resolve_ui_language is None:
+            return "en"
+        try:
+            return resolve_ui_language()
+        except Exception:
+            return "en"
+
+    @app.before_request
+    def _enforce_auth():
+        path = request.path
+        if path in _EXEMPT_PATHS or path.startswith(_EXEMPT_PATH_PREFIXES):
+            return None
+
+        with state_lock:
+            protected = is_protected(auth_state)
+
+        if not protected or session.get("authenticated"):
+            return None
+
+        if path.startswith("/api/"):
+            return jsonify({
+                "ok": False,
+                "error": "Authentication required",
+                "error_code": "auth_required",
+            }), 401
+
+        return redirect("/login?next=" + quote(path, safe=""))
+
+    @app.route("/login", methods=["GET", "POST"])
+    def login():
+        with state_lock:
+            protected = is_protected(auth_state)
+            password_hash = str(auth_state.get("password_hash") or "")
+
+        if not protected:
+            return redirect("/")
+
+        next_url = request.values.get("next") or "/"
+        if not next_url.startswith("/") or next_url.startswith("//"):
+            next_url = "/"
+
+        error = None
+        if request.method == "POST":
+            password = request.form.get("password", "")
+            if password and check_password_hash(password_hash, password):
+                session.clear()
+                session.permanent = True
+                session["authenticated"] = True
+                return redirect(next_url)
+            error = "login_error"
+
+        return render_template(
+            "login.html",
+            error=error,
+            next=next_url,
+            ui_language=_ui_language(),
+        )
+
+    @app.route("/api/logout", methods=["POST"])
+    @handle_errors
+    def api_logout():
+        session.clear()
+        return jsonify({"ok": True})
+
+    @app.route("/api/security", methods=["GET"])
+    @handle_errors
+    def api_get_security():
+        with state_lock:
+            return jsonify({
+                "ok": True,
+                "enabled": bool(auth_state.get("enabled", False)),
+                "password_set": bool(str(auth_state.get("password_hash") or "").strip()),
+            })
+
+    @app.route("/api/security", methods=["POST"])
+    @handle_errors
+    def api_update_security():
+        data = request.get_json(force=True) or {}
+
+        with state_lock:
+            new_password = data.get("password")
+            if new_password:
+                new_password = str(new_password)
+                if len(new_password) < MIN_PASSWORD_LENGTH:
+                    return jsonify({
+                        "ok": False,
+                        "error": f"Password must be at least {MIN_PASSWORD_LENGTH} characters",
+                        "error_code": "password_too_short",
+                    }), 400
+                auth_state["password_hash"] = generate_password_hash(new_password)
+
+            if "enabled" in data:
+                enabled = bool(data["enabled"])
+                if enabled and not str(auth_state.get("password_hash") or "").strip():
+                    return jsonify({
+                        "ok": False,
+                        "error": "Set a password before enabling protection",
+                        "error_code": "no_password_set",
+                    }), 400
+                auth_state["enabled"] = enabled
+                if enabled:
+                    # Whoever just flipped this on did so from an already-open
+                    # (until now unauthenticated-because-there-was-nothing-to-
+                    # authenticate-against) session - grant it now, otherwise
+                    # the very next request from the same browser would
+                    # immediately get bounced to /login with no prior chance
+                    # to sign in.
+                    session.permanent = True
+                    session["authenticated"] = True
+
+            _save()
+            response = {
+                "ok": True,
+                "enabled": bool(auth_state.get("enabled", False)),
+                "password_set": bool(str(auth_state.get("password_hash") or "").strip()),
+            }
+
+        return jsonify(response)

--- a/config.example.py
+++ b/config.example.py
@@ -80,3 +80,17 @@ WEATHER_CACHE_SECONDS = 600
 # Waveshare 2.13" e-Paper HAT (G) actually wired up - see the e-Paper Stage
 # 1 plan and modules/display/ for details.
 EPAPER_ENABLED = False
+
+# ===== OPTIONAL PASSWORD PROTECTION =====
+# Off by default - MeshCenter is intended for a trusted local network, but a
+# guest Wi-Fi/VPN/accidental port-forward can expose it, so a single shared
+# password is available as an opt-in layer. AUTH_PASSWORD_HASH is only ever
+# used to seed data/auth.json the first time MeshCenter starts (it becomes
+# the source of truth afterwards, editable from Settings -> Security in the
+# web UI) - once auth.json exists these two variables are ignored.
+# Leave AUTH_PASSWORD_HASH empty to keep protection off even if
+# AUTH_ENABLED=True, so a stray "True" here can never lock you out with no
+# password set. Generate a hash with:
+#   python3 -c "from werkzeug.security import generate_password_hash; print(generate_password_hash('your-password'))"
+AUTH_ENABLED = False
+AUTH_PASSWORD_HASH = ""

--- a/server.py
+++ b/server.py
@@ -17,10 +17,11 @@ import csv
 import uuid
 import ast
 import sqlite3
+import secrets
 from pathlib import Path
 from contextlib import contextmanager
 from collections import defaultdict, deque
-from datetime import datetime
+from datetime import datetime, timedelta
 from camera import camera
 from camera.camera_manager import build_camera_manager
 from telemetry import telemetry
@@ -39,6 +40,7 @@ from api.api_chat import register_chat_routes
 from api.api_settings import register_settings_routes, normalize_settings, SUPPORTED_LANGUAGES
 from api.api_system import register_system_routes
 from api.api_updates import register_updates_routes
+from api.api_auth import register_auth_routes, load_auth_state
 from system_log import log_system_event
 from storage.waypoint_store import WaypointStore
 from storage.profile_manager import ProfileManager
@@ -71,6 +73,13 @@ required_vars = [
 # Experimental (feature/epaper-display branch), off unless a local config.py
 # explicitly opts in - see config.example.py.
 EPAPER_ENABLED = globals().get("EPAPER_ENABLED", False)
+
+# Bootstrap-only defaults for the optional password protection feature - see
+# config.example.py. Off unless a local config.py explicitly opts in; only
+# consulted the very first time MeshCenter starts (data/auth.json is the
+# source of truth after that).
+AUTH_ENABLED = globals().get("AUTH_ENABLED", False)
+AUTH_PASSWORD_HASH = globals().get("AUTH_PASSWORD_HASH", "")
 
 SETTINGS_FILE = os.path.join(DATA_DIR, "settings.json")
 # Radio-scoped paths are resolved after the accepted instance identity loads.
@@ -326,6 +335,42 @@ if not os.path.exists(SCREENSHOTS_DIR):
 
 app = Flask(__name__)
 waypoint_store = WaypointStore(WAYPOINTS_DB_FILE)
+
+# Flask session cookies (used by the optional password protection below)
+# require a SECRET_KEY. Generated once and persisted to disk - like
+# instance.json/auth.json, instance-scoped rather than per-radio-profile -
+# so sessions survive a restart instead of invalidating on every deploy.
+SECRET_KEY_FILE = os.path.join(DATA_DIR, "secret_key.txt")
+
+def _load_or_create_secret_key(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            key = f.read().strip()
+        if key:
+            return key
+    except OSError:
+        pass
+    key = secrets.token_hex(32)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(key)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except OSError as error:
+        print(f"[AUTH] Could not persist secret key: {error}", flush=True)
+    return key
+
+app.secret_key = _load_or_create_secret_key(SECRET_KEY_FILE)
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=7)
+
+# Optional whole-app password protection - see api/api_auth.py and
+# config.example.py's AUTH_ENABLED/AUTH_PASSWORD_HASH. Off by default;
+# data/auth.json (not settings.json) is the source of truth after the
+# first run, so a generic settings.json save can never silently wipe it.
+AUTH_FILE = os.path.join(DATA_DIR, "auth.json")
+auth_state = load_auth_state(AUTH_FILE, AUTH_ENABLED, AUTH_PASSWORD_HASH)
 
 def handle_errors(f):
     """Декоратор для обработки ошибок в API"""
@@ -4263,6 +4308,11 @@ def resolve_ui_language():
 
     supported = [lang for lang in SUPPORTED_LANGUAGES if lang != "auto"]
     return request.accept_languages.best_match(supported, default="en")
+
+# Registered here (rather than alongside the other register_*_routes calls
+# near app = Flask(__name__)) because it needs state_lock/resolve_ui_language,
+# both defined above this point but not yet when app/auth_state were created.
+register_auth_routes(app, state_lock, auth_state, AUTH_FILE, handle_errors, resolve_ui_language=resolve_ui_language)
 
 # Each provider owns its own ui.language -> provider-language-code mapping
 # (see WeatherProvider.LANGUAGE_MAP in weather/providers/base.py) since that

--- a/static/chat.js
+++ b/static/chat.js
@@ -13672,6 +13672,7 @@ function switchMainTab(tab) {
         loadInstanceInfo();
         loadRadioHealth();
         loadUpdatesStatus();
+        loadSecurityStatus();
 
     } else if (tab === 'map') {
         MapLayout.state.mode = 'full';
@@ -15127,6 +15128,115 @@ async function toggleUpdatesAutoCheck(checked) {
     } catch (error) {
         alert(window.I18N.t('settings.unable_to_save_settings', { reason: error.message }));
     }
+}
+
+// ===== Security (optional password protection) =====
+
+async function loadSecurityStatus() {
+    try {
+        const response = await fetch('/api/security');
+        const data = await response.json();
+        if (data.ok) renderSecurityStatus(data);
+    } catch (error) {
+        console.warn('Security status load failed:', error);
+    }
+}
+
+function renderSecurityStatus(data) {
+    const enabledToggle = document.getElementById('securityEnabled');
+    if (enabledToggle) enabledToggle.checked = !!data.enabled;
+
+    const statusEl = document.getElementById('securityPasswordStatus');
+    if (statusEl) {
+        statusEl.textContent = data.password_set
+            ? window.I18N.t('system.security_password_set_note')
+            : window.I18N.t('system.security_password_not_set_note');
+    }
+
+    const saveBtn = document.getElementById('securitySavePasswordBtn');
+    if (saveBtn) {
+        saveBtn.textContent = data.password_set
+            ? window.I18N.t('system.security_change_password_btn')
+            : window.I18N.t('system.security_set_password_btn');
+    }
+}
+
+function renderSecurityResult(message, isError) {
+    const el = document.getElementById('securitySaveResult');
+    if (!el) return;
+    el.textContent = message;
+    el.style.color = isError ? '#e14d68' : '';
+}
+
+async function toggleSecurityEnabled(checked) {
+    try {
+        const response = await fetch('/api/security', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled: checked })
+        });
+        const data = await response.json();
+        if (data.ok) {
+            renderSecurityStatus(data);
+            renderSecurityResult(window.I18N.t('system.security_saved'), false);
+        } else {
+            const enabledToggle = document.getElementById('securityEnabled');
+            if (enabledToggle) enabledToggle.checked = !checked;
+            const message = data.error_code === 'no_password_set'
+                ? window.I18N.t('system.security_enable_requires_password')
+                : window.I18N.t('system.security_save_failed', { reason: data.error || window.I18N.t('errors.unknown_error') });
+            renderSecurityResult(message, true);
+        }
+    } catch (error) {
+        const enabledToggle = document.getElementById('securityEnabled');
+        if (enabledToggle) enabledToggle.checked = !checked;
+        renderSecurityResult(window.I18N.t('system.security_save_failed', { reason: error.message }), true);
+    }
+}
+
+async function saveSecurityPassword() {
+    const newPasswordInput = document.getElementById('securityNewPassword');
+    const confirmInput = document.getElementById('securityConfirmPassword');
+    const newPassword = newPasswordInput?.value || '';
+    const confirmPassword = confirmInput?.value || '';
+
+    if (newPassword.length < 4) {
+        renderSecurityResult(window.I18N.t('system.security_password_too_short'), true);
+        return;
+    }
+    if (newPassword !== confirmPassword) {
+        renderSecurityResult(window.I18N.t('system.security_password_mismatch'), true);
+        return;
+    }
+
+    try {
+        const response = await fetch('/api/security', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: newPassword })
+        });
+        const data = await response.json();
+        if (data.ok) {
+            renderSecurityStatus(data);
+            renderSecurityResult(window.I18N.t('system.security_saved'), false);
+            if (newPasswordInput) newPasswordInput.value = '';
+            if (confirmInput) confirmInput.value = '';
+        } else {
+            renderSecurityResult(data.error || window.I18N.t('errors.unknown_error'), true);
+        }
+    } catch (error) {
+        renderSecurityResult(window.I18N.t('system.security_save_failed', { reason: error.message }), true);
+    }
+}
+
+async function securityLogout() {
+    try {
+        await fetch('/api/logout', { method: 'POST' });
+    } catch (error) {
+        // Best-effort - redirect regardless, /login itself is safe to load
+        // even if this request failed.
+    }
+    window.location.href = '/login';
 }
 
 function renderUpdatesResult(html) {

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -517,7 +517,26 @@
     "updates_preflight_up_to_date": "Bereits auf dem neuesten Commit dieses Branches.",
     "updates_preflight_no_upstream": "Für diesen Branch ist kein Upstream-Tracking-Branch konfiguriert.",
     "updates_preflight_fetch_failed": "GitHub konnte nicht erreicht werden, um die neuesten Commits zu holen.",
-    "updates_apply_confirm": "MeshCenter von {current} auf {latest} aktualisieren? Der Dienst startet automatisch neu."
+    "updates_apply_confirm": "MeshCenter von {current} auf {latest} aktualisieren? Der Dienst startet automatisch neu.",
+    "security_title": "Sicherheit",
+    "security_description": "Schütze dieses MeshCenter mit einem gemeinsamen Passwort.",
+    "security_mode_label": "Zugriffsmodus",
+    "security_mode_trusted": "Vertrauenswürdiges lokales Netzwerk",
+    "security_mode_protected": "Passwortgeschützt",
+    "security_password_label": "Passwort",
+    "security_password_placeholder": "Neues Passwort",
+    "security_password_confirm_placeholder": "Passwort bestätigen",
+    "security_set_password_btn": "Passwort festlegen",
+    "security_change_password_btn": "Passwort ändern",
+    "security_password_set_note": "Ein Passwort ist gesetzt.",
+    "security_password_not_set_note": "Noch kein Passwort gesetzt - lege eines fest, bevor du den Schutz aktivierst.",
+    "security_saved": "Gespeichert.",
+    "security_password_mismatch": "Die Passwörter stimmen nicht überein.",
+    "security_password_too_short": "Das Passwort muss mindestens 4 Zeichen lang sein.",
+    "security_enable_requires_password": "Lege ein Passwort fest, bevor du den Schutz aktivierst.",
+    "security_save_failed": "Konnte nicht gespeichert werden: {reason}",
+    "security_logout_btn": "Abmelden",
+    "security_logout_note": "Gilt nur für diese Browser-Sitzung."
   },
   "settings": {
     "title": "Einstellungen",
@@ -1062,5 +1081,12 @@
     "timer_reset": "Zurücksetzen",
     "timer_delete": "Entfernen",
     "timer_start": "▶ Start"
+  },
+  "auth": {
+    "login_title": "MeshCenter",
+    "login_subtitle": "Dieses MeshCenter ist passwortgeschützt.",
+    "password_label": "Passwort",
+    "login_error": "Falsches Passwort.",
+    "login_submit": "Anmelden"
   }
 }

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -517,7 +517,26 @@
     "updates_preflight_up_to_date": "Already on the latest commit for this branch.",
     "updates_preflight_no_upstream": "This branch has no upstream tracking branch configured.",
     "updates_preflight_fetch_failed": "Could not reach GitHub to fetch the latest commits.",
-    "updates_apply_confirm": "Update MeshCenter from {current} to {latest}? The service will restart automatically."
+    "updates_apply_confirm": "Update MeshCenter from {current} to {latest}? The service will restart automatically.",
+    "security_title": "Security",
+    "security_description": "Protect this MeshCenter with a single shared password.",
+    "security_mode_label": "Access mode",
+    "security_mode_trusted": "Local trusted network",
+    "security_mode_protected": "Password protected",
+    "security_password_label": "Password",
+    "security_password_placeholder": "New password",
+    "security_password_confirm_placeholder": "Confirm password",
+    "security_set_password_btn": "Set password",
+    "security_change_password_btn": "Change password",
+    "security_password_set_note": "A password is set.",
+    "security_password_not_set_note": "No password set yet - set one before enabling protection.",
+    "security_saved": "Saved.",
+    "security_password_mismatch": "Passwords do not match.",
+    "security_password_too_short": "Password must be at least 4 characters.",
+    "security_enable_requires_password": "Set a password before enabling protection.",
+    "security_save_failed": "Could not save: {reason}",
+    "security_logout_btn": "Sign out",
+    "security_logout_note": "Only applies to this browser session."
   },
   "settings": {
     "title": "Settings",
@@ -1062,5 +1081,12 @@
     "timer_reset": "Reset",
     "timer_delete": "Remove",
     "timer_start": "▶ Start"
+  },
+  "auth": {
+    "login_title": "MeshCenter",
+    "login_subtitle": "This MeshCenter is password protected.",
+    "password_label": "Password",
+    "login_error": "Incorrect password.",
+    "login_submit": "Sign in"
   }
 }

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -517,7 +517,26 @@
     "updates_preflight_up_to_date": "Уже на последнем коммите этой ветки.",
     "updates_preflight_no_upstream": "Для этой ветки не настроена отслеживаемая удалённая ветка.",
     "updates_preflight_fetch_failed": "Не удалось связаться с GitHub, чтобы получить последние коммиты.",
-    "updates_apply_confirm": "Обновить MeshCenter с {current} до {latest}? Сервис перезапустится автоматически."
+    "updates_apply_confirm": "Обновить MeshCenter с {current} до {latest}? Сервис перезапустится автоматически.",
+    "security_title": "Безопасность",
+    "security_description": "Защитите MeshCenter общим паролем.",
+    "security_mode_label": "Режим доступа",
+    "security_mode_trusted": "Доверенная локальная сеть",
+    "security_mode_protected": "Защищено паролем",
+    "security_password_label": "Пароль",
+    "security_password_placeholder": "Новый пароль",
+    "security_password_confirm_placeholder": "Подтвердите пароль",
+    "security_set_password_btn": "Установить пароль",
+    "security_change_password_btn": "Изменить пароль",
+    "security_password_set_note": "Пароль установлен.",
+    "security_password_not_set_note": "Пароль ещё не задан - задайте его перед включением защиты.",
+    "security_saved": "Сохранено.",
+    "security_password_mismatch": "Пароли не совпадают.",
+    "security_password_too_short": "Пароль должен содержать не менее 4 символов.",
+    "security_enable_requires_password": "Задайте пароль перед включением защиты.",
+    "security_save_failed": "Не удалось сохранить: {reason}",
+    "security_logout_btn": "Выйти",
+    "security_logout_note": "Действует только для этой сессии браузера."
   },
   "settings": {
     "title": "Настройки",
@@ -1062,5 +1081,12 @@
     "timer_reset": "Сброс",
     "timer_delete": "Удалить",
     "timer_start": "▶ Старт"
+  },
+  "auth": {
+    "login_title": "MeshCenter",
+    "login_subtitle": "Этот MeshCenter защищён паролем.",
+    "password_label": "Пароль",
+    "login_error": "Неверный пароль.",
+    "login_submit": "Войти"
   }
 }

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -517,7 +517,26 @@
     "updates_preflight_up_to_date": "Уже на останньому коміті цієї гілки.",
     "updates_preflight_no_upstream": "Для цієї гілки не налаштована відстежувана віддалена гілка.",
     "updates_preflight_fetch_failed": "Не вдалося зв'язатися з GitHub, щоб отримати останні коміти.",
-    "updates_apply_confirm": "Оновити MeshCenter з {current} до {latest}? Сервіс перезапуститься автоматично."
+    "updates_apply_confirm": "Оновити MeshCenter з {current} до {latest}? Сервіс перезапуститься автоматично.",
+    "security_title": "Безпека",
+    "security_description": "Захистіть MeshCenter спільним паролем.",
+    "security_mode_label": "Режим доступу",
+    "security_mode_trusted": "Довірена локальна мережа",
+    "security_mode_protected": "Захищено паролем",
+    "security_password_label": "Пароль",
+    "security_password_placeholder": "Новий пароль",
+    "security_password_confirm_placeholder": "Підтвердіть пароль",
+    "security_set_password_btn": "Встановити пароль",
+    "security_change_password_btn": "Змінити пароль",
+    "security_password_set_note": "Пароль встановлено.",
+    "security_password_not_set_note": "Пароль ще не задано - задайте його перед увімкненням захисту.",
+    "security_saved": "Збережено.",
+    "security_password_mismatch": "Паролі не збігаються.",
+    "security_password_too_short": "Пароль має містити щонайменше 4 символи.",
+    "security_enable_requires_password": "Задайте пароль перед увімкненням захисту.",
+    "security_save_failed": "Не вдалося зберегти: {reason}",
+    "security_logout_btn": "Вийти",
+    "security_logout_note": "Діє лише для цієї сесії браузера."
   },
   "settings": {
     "title": "Налаштування",
@@ -1062,5 +1081,12 @@
     "timer_reset": "Скинути",
     "timer_delete": "Видалити",
     "timer_start": "▶ Старт"
+  },
+  "auth": {
+    "login_title": "MeshCenter",
+    "login_subtitle": "Цей MeshCenter захищено паролем.",
+    "password_label": "Пароль",
+    "login_error": "Невірний пароль.",
+    "login_submit": "Увійти"
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1075,6 +1075,38 @@
 
                         </div>
 
+                            <!-- Security -->
+                            <div class="system-card">
+                                <div class="system-card-title">🔐 <span data-i18n="system.security_title">Security</span></div>
+                                <div class="system-card-text" data-i18n="system.security_description">
+                                    Protect this MeshCenter with a single shared password.
+                                </div>
+
+                                <div class="settings-option">
+                                    <span data-i18n="system.security_mode_protected">Password protected</span>
+                                    <label class="switch">
+                                        <input type="checkbox" id="securityEnabled" onchange="toggleSecurityEnabled(this.checked)">
+                                        <span class="slider round"></span>
+                                    </label>
+                                </div>
+
+                                <div id="securityPasswordStatus" class="settings-card-note"></div>
+
+                                <div class="settings-option-label" style="margin-top:10px;" data-i18n="system.security_password_label">Password</div>
+                                <div class="settings-inline-input" style="flex-direction:column;align-items:stretch;gap:8px;">
+                                    <input type="password" id="securityNewPassword" class="settings-number-input" autocomplete="new-password" data-i18n-placeholder="system.security_password_placeholder" placeholder="New password" style="width:100%;">
+                                    <input type="password" id="securityConfirmPassword" class="settings-number-input" autocomplete="new-password" data-i18n-placeholder="system.security_password_confirm_placeholder" placeholder="Confirm password" style="width:100%;">
+                                    <button type="button" class="btn btn-xs" id="securitySavePasswordBtn" onclick="saveSecurityPassword()" data-i18n="system.security_set_password_btn">Set password</button>
+                                </div>
+
+                                <div id="securitySaveResult" class="settings-card-note"></div>
+
+                                <div class="settings-card-text settings-card-note" data-i18n="system.security_logout_note">
+                                    Only applies to this browser session.
+                                </div>
+                                <button type="button" class="btn btn-xs" onclick="securityLogout()" data-i18n="system.security_logout_btn">Sign out</button>
+                            </div>
+
                         </div>
 
                     </div>
@@ -2101,7 +2133,7 @@
     // weather.js is untouched until those call I18N.t()/plural() directly.
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
-<script src="/static/chat.js?v=20260818-xss-fix-onclick-names"></script>
+<script src="/static/chat.js?v=20260818-security-card"></script>
 <script src="/static/media.js?v=20260806-stage9-i18n"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="{{ ui_language }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MeshCenter</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=20260817-session-a-ui-fixes">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
+    <style>
+        /* Standalone page - not part of the app shell, so override the
+           workspace-oriented body reset (fixed height, no text selection)
+           from style.css instead of fighting its specificity. */
+        html, body {
+            height: auto;
+            min-height: 100vh;
+            overflow: auto;
+            user-select: auto;
+            background: var(--theme-app-bg, #eef3f8);
+        }
+        .login-page {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+        .login-card {
+            width: 100%;
+            max-width: 340px;
+            background: var(--card-bg, #fff);
+            border: 1px solid var(--border-color, #d8e1ec);
+            border-radius: 14px;
+            box-shadow: var(--theme-shadow, 0 8px 24px rgba(29, 53, 87, .08));
+            padding: 28px 26px;
+        }
+        .login-title {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 19px;
+            font-weight: 600;
+            color: var(--text-primary, #172033);
+            margin-bottom: 6px;
+        }
+        .login-subtitle {
+            font-size: 13px;
+            color: var(--text-secondary, #506983);
+            margin-bottom: 20px;
+        }
+        .login-field label {
+            display: block;
+            font-size: 13px;
+            color: var(--text-secondary, #506983);
+            margin-bottom: 6px;
+        }
+        .login-field input[type="password"] {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid var(--border-color, #d8e1ec);
+            border-radius: 8px;
+            background: var(--theme-panel-bg, #fff);
+            color: var(--text-primary, #172033);
+            font-size: 15px;
+        }
+        .login-field input[type="password"]:focus {
+            outline: none;
+            border-color: var(--primary-color, #1769e0);
+        }
+        .login-error {
+            margin-top: 12px;
+            padding: 8px 10px;
+            border-radius: 8px;
+            background: color-mix(in srgb, #e14d68 12%, var(--card-bg, #fff));
+            color: #e14d68;
+            font-size: 13px;
+        }
+        .login-submit {
+            width: 100%;
+            margin-top: 18px;
+            padding: 10px 12px;
+            border: none;
+            border-radius: 8px;
+            background: var(--primary-color, #1769e0);
+            color: #fff;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .login-submit:hover { filter: brightness(1.05); }
+    </style>
+</head>
+<body>
+    <div class="login-page">
+        <div class="login-card">
+            <div class="login-title">🔒 <span data-i18n="auth.login_title">MeshCenter</span></div>
+            <div class="login-subtitle" data-i18n="auth.login_subtitle">This MeshCenter is password protected.</div>
+
+            <form method="post" action="/login">
+                <input type="hidden" name="next" value="{{ next }}">
+                <div class="login-field">
+                    <label for="loginPassword" data-i18n="auth.password_label">Password</label>
+                    <input type="password" id="loginPassword" name="password" autofocus autocomplete="current-password" required>
+                </div>
+
+                {% if error %}
+                <div class="login-error" data-i18n="auth.login_error">Incorrect password.</div>
+                {% endif %}
+
+                <button type="submit" class="login-submit" data-i18n="auth.login_submit">Sign in</button>
+            </form>
+        </div>
+    </div>
+
+    <script>
+        // Match whatever theme the user last picked in the app - avoids a
+        // light-mode flash for a dark-mode user landing here after a
+        // session expired mid-workflow.
+        (function () {
+            try {
+                var saved = JSON.parse(localStorage.getItem('meshcenter.workspace') || '{}');
+                var pref = saved.theme || 'system';
+                var resolved = pref === 'system'
+                    ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : pref;
+                document.documentElement.dataset.theme = resolved;
+            } catch (error) { /* default light theme */ }
+        })();
+    </script>
+    <script src="/static/i18n.js?v=20260806-6"></script>
+    <script>
+        window.I18N.init("{{ ui_language }}").then(function () { window.I18N.applyStaticDom(); });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

MeshCenter currently has **no authentication at all**. On a guest Wi-Fi/VPN/accidental port-forward this exposes: Wi-Fi management, `restart`/`reboot`/`poweroff` (`api/api_system.py`), camera control, settings, and message send/delete with zero access control. This adds a single shared password as an **opt-in** layer, disabled by default so existing installs are unaffected.

## What changed

- **`api/api_auth.py`** (new): `register_auth_routes()` following the project's DI-by-parameter-list pattern (like other `register_*_routes`). A `before_request` hook redirects unauthenticated browser requests to `/login` and returns 401 for `/api/*`; `/static/*` and `/login` itself stay reachable so the login page can render. Session auth via Flask's signed cookie; passwords hashed with `werkzeug.security.generate_password_hash`/`check_password_hash` (no custom hashing).
- **State storage**: `data/auth.json`, **not** `settings.json`. The generic `POST /api/settings` merge-and-replace in `api_settings.py` only ever persists keys `normalize_settings()` knows about — storing the hash there would risk it being silently wiped by an unrelated settings save, and risk it round-tripping into a `GET /api/settings` response to the browser. Keeping it in its own file sidesteps both.
- **`config.example.py`**: `AUTH_ENABLED = False`, `AUTH_PASSWORD_HASH = ""` — bootstrap values only, consulted once to seed `data/auth.json` on first start; `auth.json` is authoritative after that (editable from the UI). An empty hash forces protection off even if `AUTH_ENABLED=True`, so a stray misconfiguration can never lock out the UI with no password set.
- **`SECRET_KEY`**: generated once via `secrets.token_hex(32)`, persisted to `data/secret_key.txt` (`chmod 600`) — sessions survive a restart/deploy instead of invalidating on every process start.
- **`templates/login.html`** (new): standalone password-only page (no username/email — single shared password, not multi-user), reusing `style.css`'s theme tokens (light/dark) and the existing `localStorage` theme preference so it doesn't flash the wrong theme.
- **Settings UI**: new "Security" card in the System workspace (next to Wi-Fi Manager and restart/reboot/shutdown — same trust boundary). Toggle between local-trusted and password-protected mode, set/change password, sign out. Enabling protection from an already-open (previously unauthenticated-because-nothing-to-check) session auto-grants that session, so the person who just turned it on isn't immediately bounced to `/login` with no prior chance to sign in.
- **i18n**: new `auth.*` and `system.security_*` keys added to all four catalogs (en/de/ru/uk), key-parity verified via a flatten-and-diff check.

## Test plan (no automated frontend tests in this project - manual only)

All run against dev (192.168.2.104) via curl with a cookie jar, then repeated end-to-end in a real browser tab:

1. **`AUTH_ENABLED=False` (default state)** - `GET /`, `GET /api/security` both 200 without any cookie. No regression for any existing route.
2. Set password via `POST /api/security {"password": "..."}` -> `password_set: true`.
3. Enable via `POST /api/security {"enabled": true}` -> `enabled: true`.
4. Unauthenticated `GET /` -> `302` to `/login?next=%2F`.
5. Unauthenticated `GET /api/base_status` -> `401 {"error_code": "auth_required"}`.
6. `POST /login` with the wrong password -> `200`, stays on the login page, no session cookie set, translated error shown ("Неверный пароль.").
7. `POST /login` with the correct password -> `302`, session cookie set.
8. Authenticated `GET /`, `GET /api/base_status` -> both `200`.
9. `GET /static/favicon.png` without any session -> `200` (static assets stay reachable even when protected).
10. `POST /api/logout` -> session cleared; subsequent `GET /` -> `302` back to `/login`.
11. Full browser pass on dev: navigated to the app, opened System workspace, confirmed the Security card renders and reflects live state (`password_set`/`enabled`) in Russian (server-resolved UI language); temporarily re-enabled protection, navigated fresh -> real `/login` page rendered with translated strings; submitted wrong password -> translated inline error; submitted correct password -> landed back in the app shell.
12. Cleaned up: disabled protection and removed the test `auth.json` on dev after testing, confirmed `GET /` back to `200` with no cookie.
13. Deployed to camtest and prod; confirmed both healthy with `enabled: false, password_set: false` (fresh/never-configured state, matching a real upgrade with no local config.py changes).

## Confirmation

With `AUTH_ENABLED=False` (the default, and the state of every existing install unless a local `config.py` explicitly opts in) and no `data/auth.json` yet on disk, `is_protected()` is `False` and the `before_request` hook returns immediately for every request - **no existing route's behavior changes** for any current MeshCenter install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)