### PR TITLE
test: add pytest suite + minimal CI (P1 safety net)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt
+
+      - name: Byte-compile all Python sources
+        run: python -m compileall -q .
+
+      - name: Shell script syntax check (bash -n)
+        run: |
+          set -e
+          for script in install.sh meshcenter-firstboot.sh deploy.sh; do
+            echo "bash -n $script"
+            bash -n "$script"
+          done
+          if [ -d tools ]; then
+            find tools -name '*.sh' -print0 | while IFS= read -r -d '' script; do
+              echo "bash -n $script"
+              bash -n "$script"
+            done
+          fi
+          if [ -d scripts ]; then
+            find scripts -name '*.sh' -print0 | while IFS= read -r -d '' script; do
+              echo "bash -n $script"
+              bash -n "$script"
+            done
+          fi
+
+      - name: JavaScript syntax check (node --check)
+        run: |
+          set -e
+          for script in static/chat.js static/i18n.js static/media.js static/weather.js; do
+            echo "node --check $script"
+            node --check "$script"
+          done
+
+      - name: Run pytest
+        run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.pytest_cache/
 
 # Local configuration
 config.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -ra

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Dev/CI-only dependencies - never installed on a production Pi (see
+# CLAUDE.md: production installs `pip install -r requirements.txt` only).
+-r requirements.txt
+pytest>=7.4,<9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,180 @@
+"""Shared fixtures for importing server.py in a hardware-free CI/dev environment.
+
+server.py does real work at *module import time* (git describe, Meshtastic
+CLI/serial-port resolution, instance/profile bootstrap, camera route
+registration) - it was written to run on a Raspberry Pi with a real radio
+attached, not to be imported by a test runner. To test the parsing/validation
+functions that live inside it (the actual point of this test suite - see
+CLAUDE.md's "fragile by nature" note on the CLI-output parsers) without a Pi,
+this fixture:
+
+  1. Synthesizes a throwaway config.py (all required_vars + the extra
+     variables server.py reads unconditionally at import time, e.g. the
+     WEATHER_* block) pointed at a temp DATA_DIR, and puts it first on
+     sys.path so `from config import *` resolves to it instead of any real
+     config.py a developer might have locally.
+  2. Points MESHTASTIC_CMD/MESHTASTIC_PORT at a fake-but-real executable
+     file and a fake-but-real regular file, so
+     meshsrv.runtime_identity.resolve_meshtastic_cli()/resolve_serial_port()
+     succeed without any actual radio or `meshtastic` CLI install.
+  3. Stubs `libcamera` in sys.modules - camera/camera.py does
+     `from libcamera import Transform, controls` at module level, and that
+     package only exists on a Pi with libcamera's Python bindings built
+     against --system-site-packages (see CLAUDE.md). The stub only needs to
+     exist for the import to succeed; actual camera capture is never
+     exercised by these tests.
+  4. Imports server exactly once per test session (re-importing a module
+     this size, with this many module-level side effects, per test would be
+     slow and is not needed - individual tests reset the bits of shared
+     state they touch instead).
+
+None of this changes server.py itself - it is pure test-side setup.
+"""
+
+import os
+import stat
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+class _AutoVivifyingStub:
+    """Returns another instance of itself for any attribute access, so code
+    like `libcamera.controls.AwbModeEnum.Auto` resolves to *something*
+    without needing to enumerate every enum libcamera happens to define -
+    camera.py only ever reads these as opaque values to pass back into the
+    (also absent) Picamera2 API, never inspects them."""
+
+    def __getattr__(self, name):
+        return _AutoVivifyingStub()
+
+    def __call__(self, *args, **kwargs):
+        return _AutoVivifyingStub()
+
+
+def _stub_libcamera():
+    if "libcamera" in sys.modules:
+        return
+    fake = types.ModuleType("libcamera")
+    fake.Transform = _AutoVivifyingStub()
+    fake.controls = _AutoVivifyingStub()
+    sys.modules["libcamera"] = fake
+
+
+def _write_fake_config(config_dir: Path, data_dir: Path, fake_meshtastic_cli: Path, fake_serial_port: Path) -> None:
+    config_source = f'''
+"""Synthetic config.py for the test suite - see tests/conftest.py."""
+from pathlib import Path
+
+APP_HOST = "127.0.0.1"
+APP_PORT = 5000
+
+MESHTASTIC_CMD = {str(fake_meshtastic_cli)!r}
+MESHTASTIC_PORT = {str(fake_serial_port)!r}
+
+LOCAL_NODE_ID = "!aabbccdd"
+LOCAL_NODE_NAME = "Test Local Node"
+INSTANCE_NAME = "test-instance"
+
+DATA_DIR = {str(data_dir)!r}
+HISTORY_FILE = str(Path(DATA_DIR) / "messages.json")
+NODES_FILE = str(Path(DATA_DIR) / "nodes.json")
+SENSORS_FILE = str(Path(DATA_DIR) / "sensors.json")
+CHATS_FILE = str(Path(DATA_DIR) / "chats.json")
+
+MAX_HISTORY_MESSAGES = 1000
+CHANNEL_CHAT_ID = "channel"
+CHANNEL_CHAT_NAME = "LongFast"
+
+KNOWN_NODES = {{}}
+KNOWN_NODE_INFO = {{}}
+
+OPENWEATHER_API_KEY = ""
+WEATHERAPI_API_KEY = ""
+WEATHER_PROVIDER = "openweather"
+WEATHER_LATITUDE = None
+WEATHER_LONGITUDE = None
+WEATHER_LOCATION_NAME = ""
+WEATHER_LANGUAGE = "en"
+WEATHER_CACHE_SECONDS = 600
+
+EPAPER_ENABLED = False
+AUTH_ENABLED = False
+AUTH_PASSWORD_HASH = ""
+'''
+    (config_dir / "config.py").write_text(config_source, encoding="utf-8")
+
+
+@pytest.fixture(scope="session")
+def server_module(tmp_path_factory):
+    """Import server.py once, against a synthetic config/data dir. Returns the module."""
+    sandbox = tmp_path_factory.mktemp("meshcenter_sandbox")
+    config_dir = sandbox / "config_pkg"
+    config_dir.mkdir()
+    data_dir = sandbox / "data"
+    data_dir.mkdir()
+
+    fake_meshtastic_cli = sandbox / "fake_meshtastic"
+    fake_meshtastic_cli.write_text("#!/bin/sh\necho fake meshtastic cli\n", encoding="utf-8")
+    fake_meshtastic_cli.chmod(fake_meshtastic_cli.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    fake_serial_port = sandbox / "fake_serial_port"
+    fake_serial_port.write_text("", encoding="utf-8")
+
+    _write_fake_config(config_dir, data_dir, fake_meshtastic_cli, fake_serial_port)
+
+    _stub_libcamera()
+
+    sys.path.insert(0, str(config_dir))
+    # A real config.py, if one exists in the repo root (a developer's local
+    # install), must not shadow the synthetic one - config_dir was just
+    # inserted ahead of it, but drop any cached "config" module too in case
+    # something already imported it in this interpreter.
+    sys.modules.pop("config", None)
+    sys.modules.pop("server", None)
+
+    try:
+        import server as server_module_  # noqa: PLC0415
+    finally:
+        sys.path.remove(str(config_dir))
+
+    return server_module_
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_state(request):
+    """Snapshot/restore server.py's mutable module-level dicts around every
+    test that uses server_module, so tests can't leak node/chat/message state
+    into each other."""
+    if "server_module" not in request.fixturenames:
+        yield
+        return
+
+    server = request.getfixturevalue("server_module")
+    snapshots = {}
+    for name in ("nodes", "chats", "messages", "settings", "seen_ids", "seen_recent_texts"):
+        value = getattr(server, name, None)
+        if isinstance(value, dict):
+            snapshots[name] = dict(value)
+        elif isinstance(value, list):
+            snapshots[name] = list(value)
+        elif isinstance(value, set):
+            snapshots[name] = set(value)
+
+    yield
+
+    for name, snapshot in snapshots.items():
+        current = getattr(server, name)
+        current.clear()
+        if isinstance(current, dict):
+            current.update(snapshot)
+        elif isinstance(current, list):
+            current.extend(snapshot)
+        elif isinstance(current, set):
+            current.update(snapshot)

--- a/tests/fixtures/cli_output_synthetic.py
+++ b/tests/fixtures/cli_output_synthetic.py
@@ -1,0 +1,135 @@
+"""SYNTHETIC fixtures for `meshtastic` CLI output parsing tests.
+
+These strings are NOT captured from a real radio - no real `--listen`/`--info`
+session was recorded for this test suite. They were constructed to match the
+shape the parsers in server.py actually expect (Python dict-repr lines for
+`--listen`, a `Nodes in mesh: {...}` JSON block for `--info`), based on
+reading server.py's own parsing code (process_received_nodeinfo_line,
+parse_telemetry_from_listen_line, parse_nodes_from_info). If the real CLI's
+output format ever drifts from what's encoded here, these tests will not
+catch that - see CLAUDE.md's note that the CLI's human-readable log format is
+the actual fragile dependency. Prefer replacing these with real captured
+output (`meshtastic --listen`/`--info` logs) if/when it's convenient to grab
+some from an actual node.
+"""
+
+# A "--listen" line for a remote node's periodic TELEMETRY_APP packet
+# (deviceMetrics only - the common case).
+LISTEN_LINE_DEVICE_TELEMETRY = (
+    "DEBUG file:1179 Received: {'from': 2181570266, 'to': 4294967295, "
+    "'decoded': {'portnum': 'TELEMETRY_APP', 'payload': b'...', "
+    "'telemetry': {'time': 1755000000, 'deviceMetrics': "
+    "{'batteryLevel': 85, 'voltage': 4.055, 'channelUtilization': 3.5, "
+    "'airUtilTx': 1.2, 'uptimeSeconds': 12345}}}, 'id': 123456789, "
+    "'rxTime': 1755000000, 'rxSnr': 7.5, 'hopLimit': 3, 'rxRssi': -60, "
+    "'fromId': '!820af75a', 'toId': '^all'}"
+)
+LISTEN_LINE_DEVICE_TELEMETRY_EXPECTED = {
+    "node_id": "!820af75a",
+    "values": {
+        "temperature": None,
+        "humidity": None,
+        "pressure": None,
+        "voltage": 4.055,
+        "current": None,
+        "battery_level": 85.0,
+        "channel_utilization": 3.5,
+        "air_util_tx": 1.2,
+        "uptime_seconds": 12345,
+        "power_channels": None,
+    },
+}
+
+# A "--listen" line for a remote node's ENVIRONMENT_METRICS_APP packet
+# (BME280-style sensor: temperature/humidity/pressure, no device metrics).
+LISTEN_LINE_ENVIRONMENT_TELEMETRY = (
+    "DEBUG file:1179 Received: {'from': 2181570266, 'to': 4294967295, "
+    "'decoded': {'portnum': 'TELEMETRY_APP', 'payload': b'...', "
+    "'telemetry': {'time': 1755000100, 'environmentMetrics': "
+    "{'temperature': 21.4, 'relativeHumidity': 55.2, "
+    "'barometricPressure': 1013.25}}}, 'id': 123456790, "
+    "'rxTime': 1755000100, 'rxSnr': 6.25, 'hopLimit': 3, 'rxRssi': -58, "
+    "'fromId': '!820af75a', 'toId': '^all'}"
+)
+LISTEN_LINE_ENVIRONMENT_TELEMETRY_EXPECTED = {
+    "node_id": "!820af75a",
+    "values": {
+        "temperature": 21.4,
+        "humidity": 55.2,
+        "pressure": 1013.25,
+        "voltage": None,
+        "current": None,
+        "battery_level": None,
+        "channel_utilization": None,
+        "air_util_tx": None,
+        "uptime_seconds": None,
+        "power_channels": None,
+    },
+}
+
+# A "--listen" line with no telemetry markers at all (a plain text message) -
+# parse_telemetry_from_listen_line() must return None, not misparse it.
+LISTEN_LINE_TEXT_MESSAGE = (
+    "DEBUG file:1179 Received: {'from': 2181570266, 'to': 4294967295, "
+    "'decoded': {'portnum': 'TEXT_MESSAGE_APP', 'payload': b'hello', "
+    "'text': 'hello'}, 'id': 123456791, 'fromId': '!820af75a', "
+    "'toId': '^all'}"
+)
+
+# A "Received nodeinfo: {...}" line, the shape process_received_nodeinfo_line()
+# expects (a Python dict literal parsed via ast.literal_eval, not JSON - note
+# the b'' bytes literal and single quotes, which JSON can't represent).
+RECEIVED_NODEINFO_LINE = (
+    "Received nodeinfo: {'num': 2181570266, 'user': {'id': '!820af75a', "
+    "'longName': \"Flint's Test Node\", 'shortName': 'FTN1', "
+    "'hwModel': 'RAK4631', 'role': 'CLIENT'}, "
+    "'position': {'latitude': 52.520008, 'longitude': 13.404954, "
+    "'altitude': 34, 'time': 1755000200}, "
+    "'lastHeard': 1755000200, 'snr': 5.75, 'hopsAway': 2, "
+    "'deviceMetrics': {'batteryLevel': 72, 'voltage': 3.98, "
+    "'channelUtilization': 2.1, 'airUtilTx': 0.8, 'uptimeSeconds': 54321}}"
+)
+
+# A minimal "--info" output excerpt containing the "Nodes in mesh: {...}"
+# JSON block parse_nodes_from_info() looks for (real `--info` output has a
+# lot more text around this - only the parsed block matters here).
+INFO_OUTPUT_NODES_IN_MESH = """
+Connected to radio
+Owner: Test Local Node (TEST)
+Nodes in mesh: {
+  "!820af75a": {
+    "num": 2181570266,
+    "user": {
+      "id": "!820af75a",
+      "longName": "Flint's Test Node",
+      "shortName": "FTN1",
+      "hwModel": "RAK4631",
+      "role": "CLIENT"
+    },
+    "snr": 5.75,
+    "lastHeard": 1755000200,
+    "hopsAway": 2
+  },
+  "!aabbccdd": {
+    "num": 2864434397,
+    "user": {
+      "id": "!aabbccdd",
+      "longName": "Test Local Node",
+      "shortName": "TEST",
+      "hwModel": "RAK4631",
+      "role": "ROUTER"
+    }
+  },
+  "!00000000": {
+    "num": 0,
+    "user": {
+      "id": "!00000000",
+      "longName": "Unknown",
+      "shortName": "UNK",
+      "hwModel": "UNSET",
+      "role": "CLIENT"
+    }
+  }
+}
+Preferences: {...}
+"""

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,68 @@
+"""Tests for api/api_auth.py's load_auth_state()/is_protected() - the
+bootstrap and lockout-avoidance logic behind the optional password
+protection feature added in PR #63. No server.py import needed; this module
+has no hardware/CLI dependencies of its own.
+"""
+
+import json
+
+from werkzeug.security import generate_password_hash
+
+from api.api_auth import is_protected, load_auth_state
+
+
+def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
+    auth_file = tmp_path / "auth.json"  # does not exist yet
+    state = load_auth_state(str(auth_file))
+    assert state == {"enabled": False, "password_hash": ""}
+
+
+def test_load_auth_state_bootstrap_enabled_without_hash_stays_disabled(tmp_path):
+    # config.py's AUTH_ENABLED=True with an empty AUTH_PASSWORD_HASH must
+    # never result in a locked, password-less app - this is the exact
+    # scenario config.example.py's own comment warns about.
+    auth_file = tmp_path / "auth.json"
+    state = load_auth_state(str(auth_file), bootstrap_enabled=True, bootstrap_password_hash="")
+    assert state["enabled"] is False
+
+
+def test_load_auth_state_bootstrap_enabled_with_hash_is_enabled(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    password_hash = generate_password_hash("correct horse battery staple")
+    state = load_auth_state(str(auth_file), bootstrap_enabled=True, bootstrap_password_hash=password_hash)
+    assert state == {"enabled": True, "password_hash": password_hash}
+
+
+def test_load_auth_state_existing_file_ignores_bootstrap_args(tmp_path):
+    # Once auth.json exists (set via the Settings UI), it's the source of
+    # truth - config.py's AUTH_ENABLED/AUTH_PASSWORD_HASH must not override
+    # a value the user already changed at runtime.
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(json.dumps({"enabled": True, "password_hash": "stored-hash"}), encoding="utf-8")
+
+    state = load_auth_state(str(auth_file), bootstrap_enabled=False, bootstrap_password_hash="")
+    assert state == {"enabled": True, "password_hash": "stored-hash"}
+
+
+def test_load_auth_state_tolerates_corrupt_file(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text("{not valid json", encoding="utf-8")
+
+    # safe_read_json() falls back to {} on a JSON decode error - load_auth_state()
+    # must then treat that the same as "no file yet" (bootstrap path), not crash.
+    state = load_auth_state(str(auth_file))
+    assert state == {"enabled": False, "password_hash": ""}
+
+
+def test_is_protected_requires_both_enabled_and_a_real_hash():
+    assert is_protected({"enabled": True, "password_hash": "somehash"}) is True
+    assert is_protected({"enabled": True, "password_hash": ""}) is False
+    assert is_protected({"enabled": True, "password_hash": "   "}) is False  # whitespace-only
+    assert is_protected({"enabled": False, "password_hash": "somehash"}) is False
+    assert is_protected({"enabled": False, "password_hash": ""}) is False
+
+
+def test_is_protected_tolerates_missing_keys():
+    assert is_protected({}) is False
+    assert is_protected({"enabled": True}) is False
+    assert is_protected({"password_hash": "somehash"}) is False

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -1,0 +1,100 @@
+"""Tests for server.py's `meshtastic` CLI stdout parsers.
+
+Fixture strings live in tests/fixtures/cli_output_synthetic.py and are
+explicitly marked as synthetic (constructed from reading the parsing code,
+not captured from a real radio) - see that file's docstring.
+"""
+
+from fixtures.cli_output_synthetic import (
+    INFO_OUTPUT_NODES_IN_MESH,
+    LISTEN_LINE_DEVICE_TELEMETRY,
+    LISTEN_LINE_DEVICE_TELEMETRY_EXPECTED,
+    LISTEN_LINE_ENVIRONMENT_TELEMETRY,
+    LISTEN_LINE_ENVIRONMENT_TELEMETRY_EXPECTED,
+    LISTEN_LINE_TEXT_MESSAGE,
+    RECEIVED_NODEINFO_LINE,
+)
+
+
+def test_parse_telemetry_device_metrics(server_module):
+    result = server_module.parse_telemetry_from_listen_line(LISTEN_LINE_DEVICE_TELEMETRY)
+    assert result == LISTEN_LINE_DEVICE_TELEMETRY_EXPECTED
+
+
+def test_parse_telemetry_environment_metrics(server_module):
+    result = server_module.parse_telemetry_from_listen_line(LISTEN_LINE_ENVIRONMENT_TELEMETRY)
+    assert result == LISTEN_LINE_ENVIRONMENT_TELEMETRY_EXPECTED
+
+
+def test_parse_telemetry_ignores_non_telemetry_lines(server_module):
+    assert server_module.parse_telemetry_from_listen_line(LISTEN_LINE_TEXT_MESSAGE) is None
+
+
+def test_parse_telemetry_battery_level_clamped_to_100(server_module):
+    # deviceMetrics.batteryLevel can report >100 for a plugged-in/charging
+    # node (observed live) - parse_telemetry_from_listen_line() clamps it.
+    line = LISTEN_LINE_DEVICE_TELEMETRY.replace("'batteryLevel': 85", "'batteryLevel': 101")
+    result = server_module.parse_telemetry_from_listen_line(line)
+    assert result["values"]["battery_level"] == 100.0
+
+
+def test_process_received_nodeinfo_line_updates_node_state(server_module):
+    handled = server_module.process_received_nodeinfo_line(RECEIVED_NODEINFO_LINE)
+    assert handled is True
+
+    node = server_module.nodes["!820af75a"]
+    assert node["name"] == "Flint's Test Node"
+    assert node["short_name"] == "FTN1"
+    assert node["hw_model"] == "RAK4631"
+    assert node["role"] == "CLIENT"
+    assert node["snr"] == 5.75
+    assert node["hop_start"] == "2"
+    assert node["position"]["latitude"] == 52.520008
+    assert node["position"]["longitude"] == 13.404954
+
+
+def test_process_received_nodeinfo_line_ignores_unrelated_lines(server_module):
+    assert server_module.process_received_nodeinfo_line("some unrelated log line") is False
+
+
+def test_process_received_nodeinfo_line_ignores_malformed_payload(server_module):
+    # Payload present but not a valid Python literal - must not raise.
+    assert server_module.process_received_nodeinfo_line("Received nodeinfo: {not valid python") is False
+
+
+def test_extract_json_block_balances_nested_braces(server_module):
+    text = 'Nodes in mesh: {"a": {"b": 1}, "c": 2} trailing text'
+    block = server_module.extract_json_block(text, text.find("Nodes in mesh:"))
+    assert block == '{"a": {"b": 1}, "c": 2}'
+
+
+def test_extract_json_block_returns_none_without_opening_brace(server_module):
+    assert server_module.extract_json_block("no braces here", 0) is None
+
+
+def test_parse_nodes_from_info_imports_known_nodes(server_module):
+    changed = server_module.parse_nodes_from_info(INFO_OUTPUT_NODES_IN_MESH)
+    assert changed is True
+
+    node = server_module.nodes["!820af75a"]
+    assert node["name"] == "Flint's Test Node"
+    assert node["short_name"] == "FTN1"
+    assert node["hop_start"] == "2"
+
+
+def test_parse_nodes_from_info_skips_local_node(server_module):
+    server_module.parse_nodes_from_info(INFO_OUTPUT_NODES_IN_MESH)
+    # LOCAL_NODE_ID ("!aabbccdd" in the test config) must never be imported
+    # as if it were a remote node.
+    assert "!aabbccdd" not in server_module.nodes
+
+
+def test_parse_nodes_from_info_skips_unknown_placeholder_name(server_module):
+    server_module.parse_nodes_from_info(INFO_OUTPUT_NODES_IN_MESH)
+    # longName "Unknown" is a Meshtastic placeholder for an undiscovered
+    # node - importing it would create a permanent "Unknown" chat entry.
+    assert "!00000000" not in server_module.nodes
+
+
+def test_parse_nodes_from_info_returns_false_without_marker(server_module):
+    assert server_module.parse_nodes_from_info("no nodes-in-mesh marker here") is False

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -1,0 +1,80 @@
+"""Tests for node ID format validation.
+
+server.py has its own is_valid_node_id()/is_valid_chat_id()/normalize_node_id()
+(the ones actually wired into every route) - utils/helpers.py has a second,
+textually similar but NOT equivalent copy that nothing currently imports
+(only utils.helpers.now() is actually used elsewhere, by telemetry.py).
+Both are tested here: the real, enforced server.py behavior is the main
+target of task item (c); the utils/helpers.py copy is covered too so its
+looser behavior is pinned down and visible next to it, rather than silently
+diverging further - see test_is_valid_node_id_utils_helpers_is_looser below.
+"""
+
+import utils.helpers as helpers
+
+
+def test_is_valid_node_id_accepts_well_formed_ids(server_module):
+    assert server_module.is_valid_node_id("!aabbccdd") is True
+    assert server_module.is_valid_node_id("!00000000") is True
+    assert server_module.is_valid_node_id("!ABCDEF12") is True
+
+
+def test_is_valid_node_id_rejects_malformed_ids(server_module):
+    assert server_module.is_valid_node_id("aabbccdd") is False  # missing "!"
+    assert server_module.is_valid_node_id("!aabbcc") is False  # too short
+    assert server_module.is_valid_node_id("!aabbccddee") is False  # too long
+    assert server_module.is_valid_node_id("!aabbccdg") is False  # non-hex char
+    assert server_module.is_valid_node_id("!aabb ccdd") is False  # embedded space
+    assert server_module.is_valid_node_id("") is False
+    assert server_module.is_valid_node_id(None) is False
+
+
+def test_is_valid_node_id_rejects_injection_attempts(server_module):
+    # The strict full-match regex is what stands between free-form input
+    # reaching a node-id-shaped code path (file paths, CLI args, etc.) - a
+    # few adversarial shapes worth pinning down explicitly.
+    assert server_module.is_valid_node_id("!aabbccdd; rm -rf /") is False
+    assert server_module.is_valid_node_id("!aabbccdd/../../etc/passwd") is False
+    assert server_module.is_valid_node_id("!aabbccdd\x00") is False
+
+
+def test_is_valid_chat_id_accepts_channel_and_node_shapes(server_module):
+    assert server_module.is_valid_chat_id("channel") is True  # CHANNEL_CHAT_ID
+    assert server_module.is_valid_chat_id("channel:0") is True
+    assert server_module.is_valid_chat_id("channel:7") is True
+    assert server_module.is_valid_chat_id("!aabbccdd") is True
+
+
+def test_is_valid_chat_id_rejects_out_of_range_channel_index(server_module):
+    assert server_module.is_valid_chat_id("channel:8") is False
+    assert server_module.is_valid_chat_id("channel:-1") is False
+    assert server_module.is_valid_chat_id("channel:") is False
+
+
+def test_normalize_node_id_accepts_bare_hex(server_module):
+    assert server_module.normalize_node_id("aabbccdd") == "!aabbccdd"
+
+
+def test_normalize_node_id_passes_through_well_formed_id(server_module):
+    assert server_module.normalize_node_id("!aabbccdd") == "!aabbccdd"
+
+
+def test_normalize_node_id_returns_none_for_empty_input(server_module):
+    assert server_module.normalize_node_id("") is None
+    assert server_module.normalize_node_id(None) is None
+
+
+def test_is_valid_node_id_utils_helpers_is_looser(server_module):
+    """Documents a real gap: utils/helpers.py's is_valid_node_id() only
+    checks a "!" prefix and a minimum length, not that the rest is 8 hex
+    digits - server.py's own version (tested above) is the strict one
+    actually enforced on every route. Nothing currently imports the
+    utils/helpers.py copy, so this isn't exploitable today, but the two
+    functions silently disagree, which is exactly the kind of drift a
+    future refactor (consolidating validation into one place) should
+    resolve rather than papering over.
+    """
+    # Rejected by server.py's strict regex (see test above)...
+    assert server_module.is_valid_node_id("!aabbccdg") is False
+    # ...but accepted by utils/helpers.py's loose prefix+length check.
+    assert helpers.is_valid_node_id("!aabbccdg") is True

--- a/tests/test_normalize_settings.py
+++ b/tests/test_normalize_settings.py
@@ -1,0 +1,125 @@
+"""Tests for api/api_settings.py's normalize_settings() - the single place
+that turns a possibly-malformed settings.json (or a partial POST /api/settings
+body) into a fully-shaped, safe-to-use dict. No server.py import needed here -
+this module has no hardware/CLI dependencies of its own.
+"""
+
+from api.api_settings import normalize_settings
+
+
+def test_empty_input_returns_full_default_shape():
+    result = normalize_settings({})
+    assert result["language"] == "auto"
+    assert result["units"]["temperature"] == "c"
+    assert result["maps"]["provider"] == "osm"
+    assert result["weather"]["provider"] == "openweather"
+    assert result["waypoints"]["last_duration_seconds"] == 3600
+    assert result["updates"]["interval"] == 86400
+
+
+def test_non_dict_input_treated_as_empty():
+    for bad_input in (None, [], "not a dict", 42):
+        result = normalize_settings(bad_input)
+        assert result["language"] == "auto"
+
+
+def test_invalid_language_falls_back_to_auto():
+    assert normalize_settings({"language": "xx"})["language"] == "auto"
+    assert normalize_settings({"language": "EN"})["language"] == "en"
+
+
+def test_invalid_unit_values_fall_back_to_defaults():
+    result = normalize_settings({
+        "units": {"temperature": "kelvin", "pressure": "bar", "wind": "knots", "time_format": "36"},
+    })
+    assert result["units"] == {"temperature": "c", "pressure": "hpa", "wind": "ms", "time_format": "24"}
+
+
+def test_valid_unit_values_pass_through():
+    result = normalize_settings({
+        "units": {"temperature": "f", "pressure": "mmhg", "wind": "kmh", "time_format": "12"},
+    })
+    assert result["units"] == {"temperature": "f", "pressure": "mmhg", "wind": "kmh", "time_format": "12"}
+
+
+def test_battery_capacity_clamped_to_valid_range():
+    assert normalize_settings({"power": {"battery_capacity_mah": 50}})["power"]["battery_capacity_mah"] == 100
+    assert normalize_settings({"power": {"battery_capacity_mah": 999999}})["power"]["battery_capacity_mah"] == 50000
+    assert normalize_settings({"power": {"battery_capacity_mah": "not a number"}})["power"]["battery_capacity_mah"] == 3000
+
+
+def test_listener_autorecovery_rejects_arbitrary_delay():
+    result = normalize_settings({"listener_autorecovery": {"enabled": True, "delay": 45}})
+    assert result["listener_autorecovery"]["enabled"] is True
+    # 45 isn't one of the allowed steps (30/60/90/120/180/300) - falls back.
+    assert result["listener_autorecovery"]["delay"] == 60
+
+
+def test_map_and_weather_provider_reject_unknown_values():
+    result = normalize_settings({"maps": {"provider": "bing"}, "weather": {"provider": "accuweather"}})
+    assert result["maps"]["provider"] == "osm"
+    assert result["weather"]["provider"] == "openweather"
+
+
+def test_reference_location_coordinates_out_of_range_become_none():
+    result = normalize_settings({
+        "reference_location": {"mode": "manual", "manual": {"latitude": 200, "longitude": -200}},
+    })
+    assert result["reference_location"]["manual"]["latitude"] is None
+    assert result["reference_location"]["manual"]["longitude"] is None
+
+
+def test_reference_location_backward_compat_flat_coordinates():
+    # Old shape: latitude/longitude directly on reference_location, not nested
+    # under "manual" - normalize_settings() must still pick them up.
+    result = normalize_settings({
+        "reference_location": {"mode": "manual", "latitude": 52.5, "longitude": 13.4},
+    })
+    assert result["reference_location"]["manual"]["latitude"] == 52.5
+    assert result["reference_location"]["manual"]["longitude"] == 13.4
+
+
+def test_waypoint_channel_index_and_duration_clamped():
+    result = normalize_settings({
+        "waypoints": {"last_channel_index": 99, "last_duration_seconds": 12345},
+    })
+    assert result["waypoints"]["last_channel_index"] == 7
+    # 12345 isn't an allowed duration step - falls back to the default.
+    assert result["waypoints"]["last_duration_seconds"] == 3600
+
+
+def test_waypoint_profile_defaults_drop_invalid_profile_ids():
+    result = normalize_settings({
+        "waypoints": {
+            "profile_defaults": {
+                "valid-id_1": {"last_channel_index": 2},
+                "Invalid ID With Spaces!": {"last_channel_index": 3},
+            },
+        },
+    })
+    assert "valid-id_1" in result["waypoints"]["profile_defaults"]
+    assert "Invalid ID With Spaces!" not in result["waypoints"]["profile_defaults"]
+    assert result["waypoints"]["profile_defaults"]["valid-id_1"]["last_channel_index"] == 2
+
+
+def test_timer_target_type_and_channel_index_normalized():
+    result = normalize_settings({"timers": {"target_type": "satellite", "channel_index": -5}})
+    assert result["timers"]["target_type"] == "node"
+    assert result["timers"]["channel_index"] == 0
+
+
+def test_updates_interval_floored_at_five_minutes():
+    result = normalize_settings({"updates": {"interval": 10}})
+    assert result["updates"]["interval"] == 300
+
+
+def test_browser_notifications_categories_fill_in_missing_keys_with_defaults():
+    result = normalize_settings({
+        "browser_notifications": {"enabled": True, "categories": {"timer": False}},
+    })
+    assert result["browser_notifications"]["enabled"] is True
+    assert result["browser_notifications"]["categories"]["timer"] is False
+    # Untouched categories keep DEFAULT_SETTINGS' own defaults, not True/False
+    # picked arbitrarily - dm_message defaults True, channel_message False.
+    assert result["browser_notifications"]["categories"]["dm_message"] is True
+    assert result["browser_notifications"]["categories"]["channel_message"] is False

--- a/tests/test_sanitize_text.py
+++ b/tests/test_sanitize_text.py
@@ -1,0 +1,49 @@
+"""Tests for server.py's sanitize_text() (server.py:877 as of this writing).
+
+sanitize_text() only strips ASCII control characters and truncates to 500
+chars - it does NOT strip quotes, angle brackets, or any HTML/JS-meaningful
+characters. That's a deliberate, narrow purpose (stripping control chars that
+would corrupt terminal/log output or JSON), not an XSS defense - escaping for
+HTML/JS-string contexts is escapeHtml()/escapeJsString()'s job in
+static/chat.js (see the recent stored-XSS fix). These tests pin down the
+current behavior in both directions: what IS stripped, and - just as
+importantly, since it was the exact gap behind that XSS bug - what is NOT.
+"""
+
+
+def test_sanitize_text_empty_and_none_return_empty_string(server_module):
+    assert server_module.sanitize_text("") == ""
+    assert server_module.sanitize_text(None) == ""
+
+
+def test_sanitize_text_strips_ascii_control_characters(server_module):
+    result = server_module.sanitize_text("hello\x00\x01\x08world\x0b\x0c\x0e\x1f\x7fend")
+    assert result == "helloworldend"
+
+
+def test_sanitize_text_preserves_tab_newline_and_carriage_return(server_module):
+    # \x09 (tab), \x0a (LF), \x0d (CR) fall outside the stripped ranges
+    # (\x00-\x08, \x0b-\x0c, \x0e-\x1f, \x7f) - deliberately preserved since
+    # multi-line message text needs them.
+    text = "line1\ttabbed\nline2\r\n"
+    assert server_module.sanitize_text(text) == text
+
+
+def test_sanitize_text_truncates_to_500_characters(server_module):
+    text = "a" * 600
+    result = server_module.sanitize_text(text)
+    assert len(result) == 500
+    assert result == "a" * 500
+
+
+def test_sanitize_text_does_not_strip_quotes_or_html_characters(server_module):
+    # Regression guard tied to the stored-XSS fix: sanitize_text() runs on
+    # incoming mesh text (node names, messages) upstream of where it later
+    # gets rendered - if this function ever started stripping quotes, it
+    # would be masking the real fix (escapeJsString() in static/chat.js)
+    # rather than duplicating it, and any test asserting quotes-survive here
+    # would need updating in lockstep with that call site. Today it
+    # correctly does nothing about HTML/JS-meaningful characters - that's
+    # by design, not an oversight.
+    text = """<script>alert('xss')</script> "quoted" 'single' & <tag>"""
+    assert server_module.sanitize_text(text) == text

--- a/tests/test_smoke_import.py
+++ b/tests/test_smoke_import.py
@@ -1,0 +1,10 @@
+"""Sanity check that server.py imports cleanly under the test sandbox (see
+tests/conftest.py). Not testing behavior - just that the import shim works,
+so a broken conftest fails fast and obviously instead of masquerading as
+unrelated failures in every other test file.
+"""
+
+
+def test_server_module_imports(server_module):
+    assert server_module.LOCAL_NODE_ID == "!aabbccdd"
+    assert callable(server_module.sanitize_text)


### PR DESCRIPTION
## Summary

MeshCenter had zero automated backend tests - only hardware-oriented `tools/test_*.py` scripts (e-Paper/GPIO) that need physical hardware and can't run in CI. Before any refactor of `server.py`/`chat.js`, this adds a minimal regression-safety net: not full coverage, but 50 focused tests on the most regression- and security-sensitive logic, plus a CI workflow that runs them on every PR.

## The hard part: importing server.py without a Pi

`server.py` does real work at *module import time* - `git describe`, Meshtastic CLI/serial-port resolution, and (via `camera/camera.py`'s unconditional `from libcamera import Transform, controls`) a hard dependency on `libcamera`'s Python bindings, which only exist on a Pi built with `--system-site-packages` against the OS's `libcamera` package (see CLAUDE.md). It was written to run on a Pi with a radio attached, not to be imported by a test runner.

`tests/conftest.py` makes `import server` succeed anyway, without touching `server.py` itself:
- Synthesizes a throwaway `config.py` (all `required_vars` + the `WEATHER_*` block server.py reads unconditionally) pointed at a temp `DATA_DIR`, inserted first on `sys.path` so it can't be shadowed by - or shadow - a developer's real local `config.py`.
- Points `MESHTASTIC_CMD`/`MESHTASTIC_PORT` at a fake-but-real executable file and a fake-but-real regular file, so `resolve_meshtastic_cli()`/`resolve_serial_port()` succeed without any actual radio.
- Stubs `libcamera` in `sys.modules` with an auto-vivifying dummy (returns itself for any attribute access) so `camera.py`'s enum lookups resolve to *something* without enumerating libcamera's real API - actual camera capture is never exercised.
- Imports `server` once per test session; an autouse fixture snapshots/restores `nodes`/`chats`/`messages`/`settings` around every test that uses it so tests can't leak state into each other.

## What's tested (50 tests, all passing locally)

- **`tests/test_cli_parsing.py`** (13): `parse_telemetry_from_listen_line()`, `process_received_nodeinfo_line()`, `extract_json_block()`, `parse_nodes_from_info()` - against `tests/fixtures/cli_output_synthetic.py`, explicitly marked **SYNTHETIC** in its own docstring (constructed from reading the parser code, no real radio was captured for this). Covers device + environment telemetry, non-telemetry lines correctly ignored, battery-level clamping, malformed nodeinfo payloads, local-node and "Unknown" placeholder skip logic in `--info` parsing.
- **`tests/test_normalize_settings.py`** (15): `api/api_settings.py`'s `normalize_settings()` - missing fields, wrong types, out-of-range values, invalid enums, backward-compat flat lat/lon shape, malformed `profile_defaults` keys.
- **`tests/test_node_id_validation.py`** (9): `server.py`'s actual enforced `is_valid_node_id()`/`is_valid_chat_id()`/`normalize_node_id()` (strict `!` + 8 hex regex), including a few adversarial shapes.
- **`tests/test_sanitize_text.py`** (5): what `sanitize_text()` strips (ASCII control chars, truncates at 500) and - just as important given the recent XSS fix - what it does **not** strip (quotes, angle brackets). Direct regression guard: that exact gap is what made `escapeHtml()`-in-`onclick` unsafe.
- **`tests/test_api_auth.py`** (7): `api/api_auth.py`'s `load_auth_state()`/`is_protected()` from PR #63 - first-run bootstrap, empty-hash-never-blocks, enabled-without-hash-not-protected, an existing `auth.json` overriding bootstrap args, corrupt-file tolerance.

## A real finding, not fixed here (flagged per the task's instructions)

`utils/helpers.py` has its own `is_valid_node_id()` - textually similar to `server.py`'s but **not equivalent**: it only checks a `!` prefix and minimum length, not that the rest is 8 hex digits. Nothing currently imports it (only `utils.helpers.now()` is used elsewhere, by `telemetry.py`), so it's dead code, not exploitable today - but it's exactly the kind of silent drift a future refactor consolidating validation should resolve. Documented in `test_node_id_validation.py`'s own docstring and pinned down by `test_is_valid_node_id_utils_helpers_is_looser`. Left as-is per this task's scope (test infra only).

## Skipped (per the task's "don't force a fragile test" guidance)

Message-queue retry/dedup and `ProfileManager` identity match/mismatch both need non-trivial serial/radio mocking beyond what's proportionate for this pass - not attempted, noted here as a follow-up rather than forced into a brittle test.

## CI (`.github/workflows/ci.yml`, new - doesn't touch `release-assets.yml`)

Triggers on `pull_request` and `push` to `main`:
1. `python -m compileall -q .`
2. `bash -n` over `install.sh`, `meshcenter-firstboot.sh`, `deploy.sh`, and everything under `tools/*.sh`/`scripts/*.sh`
3. `node --check` over `static/chat.js`, `static/i18n.js`, `static/media.js`, `static/weather.js` (not the vendored `chart.umd.min.js`)
4. `pytest`

No linters (ruff/eslint) added - explicitly out of scope for this task.

## Local verification

- `python -m compileall -q .` - clean, no output.
- `bash -n` on all 5 shell scripts (`install.sh`, `meshcenter-firstboot.sh`, `deploy.sh`, `scripts/build-release.sh`, `scripts/verify-install.sh`) - all OK.
- `node --check` on all 4 non-vendored JS files - all OK.
- `python -m pytest -v` - **50 passed, 0 failed**, ~1.2s.
- CI YAML: no `actionlint` available in this environment, so validated by loading it with `yaml.safe_load()` (parses cleanly, same shape as the existing `release-assets.yml`) plus a manual read-through.
- This is the first PR to actually exercise the new CI workflow - its own run against this PR is the real end-to-end check that setup-python/setup-node/the job steps work on GitHub's ubuntu-latest runner, since only Windows was available locally.

## Confirmation

Every added file is new (`tests/`, `pytest.ini`, `requirements-dev.txt`, `.github/workflows/ci.yml`) except `.gitignore` (added `.pytest_cache/`) - no existing application file's behavior changed. `requirements-dev.txt` is `-r requirements.txt` plus `pytest`, kept separate from `requirements.txt` so a production Pi install (`install.sh`/`meshcenter-firstboot.sh`, both unchanged) never pulls in pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)