### PR TITLE
fix: install.sh no longer ships a placeholder LOCAL_NODE_ID (P1 installer parity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
               bash -n "$script"
             done
           fi
+          if [ -d installer ]; then
+            find installer -name '*.sh' -print0 | while IFS= read -r -d '' script; do
+              echo "bash -n $script"
+              bash -n "$script"
+            done
+          fi
 
       - name: JavaScript syntax check (node --check)
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,6 +107,23 @@ INSTALL_CAMERA=yes
 >
 > Times above don't include the ~30s reboot at the end.
 
+### e-Paper display support
+
+Off by default (matching `EPAPER_ENABLED = False` in config.py) - there's no
+auto-detection for this the way there is for a camera, since a HAT can't be
+probed the same way. To install its packages (`python3-gpiozero` +
+`python3-spidev`), add this to the same `meshcenter-options` file on the
+bootfs drive:
+
+```
+INSTALL_EPAPER=yes
+```
+
+You'll still need to set `EPAPER_ENABLED = True` in `config.py` afterwards
+to actually turn the feature on. For the manual installer
+(`install.sh`), set the same-named environment variable instead:
+`INSTALL_EPAPER=yes curl -sSL .../install.sh | bash`.
+
 ### Step 6 — Open MeshCenter
 
 Once installation completes and the Pi has rebooted, open in your browser:

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,12 @@
 # MeshCenter Installer
 # https://github.com/FlintUA/MeshCenter
 #
-# Usage (automatic):
-#   Placed on SD card as firstrun.sh — runs on first Pi boot
+# This is the manual installer (curl | bash, or run locally). For
+# unattended provisioning via Raspberry Pi Imager's cloud-init user-data,
+# see meshcenter-firstboot.sh instead - it discovers the radio and
+# generates config.py before starting the service, without any prompts.
 #
-# Usage (manual):
+# Usage:
 #   curl -sSL https://raw.githubusercontent.com/FlintUA/MeshCenter/main/install.sh | bash
 #   or: bash install.sh
 #
@@ -280,6 +282,18 @@ step_system_packages() {
         warn "python3-picamera2 not available on this system — camera feature will be unavailable."
     fi
 
+    # e-Paper display support (gpiozero/spidev) — optional and off by default,
+    # matching EPAPER_ENABLED=False in config.example.py: not every install
+    # has a HAT wired up, so this isn't installed unless explicitly requested.
+    # To enable: INSTALL_EPAPER=yes curl -sSL .../install.sh | bash
+    if [[ "${INSTALL_EPAPER:-no}" == "yes" ]]; then
+        log "Installing e-Paper display packages (python3-gpiozero + python3-spidev)..."
+        sudo apt-get install -y python3-gpiozero python3-spidev --no-install-recommends -qq \
+            || warn "e-Paper packages failed to install — e-Paper display feature will be unavailable."
+    else
+        log "e-Paper support skipped (set INSTALL_EPAPER=yes to install python3-gpiozero/python3-spidev)"
+    fi
+
     log "System packages installed ✓"
 }
 
@@ -341,23 +355,12 @@ step_venv() {
     log "Python dependencies installed ✓"
 }
 
-# ─── Step 6: Config ───────────────────────────────────────────────────────────
-step_config() {
-    progress "6/9 Configuring MeshCenter..."
-
-    mkdir -p "${INSTALL_DIR}/data"
-
-    if [[ ! -f "${INSTALL_DIR}/config.py" ]]; then
-        cp "${INSTALL_DIR}/config.example.py" "${INSTALL_DIR}/config.py"
-        log "config.py created from template ✓"
-    else
-        log "config.py already exists — not overwritten ✓"
-    fi
-}
-
-# ─── Step 7: Detect radio ─────────────────────────────────────────────────────
+# ─── Step 6: Detect radio ─────────────────────────────────────────────────────
+# Runs before step_config() (swapped from the original 6/7 order) so a
+# connected radio can actually be queried for real config values below -
+# it needs the venv's `meshtastic` CLI from step_venv either way.
 step_detect_radio() {
-    progress "7/9 Detecting Meshtastic radio..."
+    progress "6/9 Detecting Meshtastic radio..."
 
     # Add user to dialout for serial access
     sudo usermod -a -G dialout "$USER" 2>/dev/null || true
@@ -377,6 +380,114 @@ step_detect_radio() {
         log "No Meshtastic device detected. Connect it later via Settings."
     fi
 }
+
+# ─── Step 7: Config ───────────────────────────────────────────────────────────
+step_config() {
+    progress "7/9 Configuring MeshCenter..."
+
+    mkdir -p "${INSTALL_DIR}/data"
+
+    if [[ -f "${INSTALL_DIR}/config.py" ]]; then
+        log "config.py already exists — not overwritten ✓"
+        return 0
+    fi
+
+    if [[ -n "$RADIO_PORT" ]] && step_config_from_detected_radio; then
+        return 0
+    fi
+
+    # No radio, or it didn't respond usefully - this has always been a
+    # supported path (see step_detect_radio's own tolerance for "not found")
+    # so fall back exactly like before this change, just with a clearer
+    # pointer to where to fix it up afterwards.
+    cp "${INSTALL_DIR}/config.example.py" "${INSTALL_DIR}/config.py"
+    log "config.py created from template ✓"
+    warn "LOCAL_NODE_ID is still the config.example.py placeholder (!xxxxxxxx)."
+    warn "Set your real node ID/name later via MeshCenter's Settings, or edit"
+    warn "${INSTALL_DIR}/config.py directly (LOCAL_NODE_ID/LOCAL_NODE_NAME)."
+}
+
+# Attempts to query the radio detected by step_detect_radio() and generate a
+# real config.py from it (shared logic - see installer/common.sh, also used
+# by meshcenter-firstboot.sh). Returns non-zero on any failure - step_config()
+# falls back to the config.example.py placeholder in that case, this must
+# never abort the install.
+#
+# The whole body runs in a subshell with `set +e` and the global ERR trap
+# cleared: several commands below (source, mktemp, the python3 -c calls) are
+# plain statements, not the direct condition of an `if`/`&&` - under the
+# main script's `set -euo pipefail` + `trap ... ERR`, any one of those
+# failing would abort the *entire install* immediately, before this
+# function ever got a chance to `return 1` and let step_config() fall back.
+# Scoping the relaxation to a subshell keeps the rest of install.sh exactly
+# as strict as before.
+step_config_from_detected_radio() (
+    set +e
+    trap - ERR
+
+    log "Querying Meshtastic radio at ${RADIO_PORT}..."
+
+    # shellcheck source=installer/common.sh
+    source "${INSTALL_DIR}/installer/common.sh"
+
+    local info_file
+    info_file="$(mktemp)"
+
+    # sudo usermod -a -G dialout in step_detect_radio only takes effect on a
+    # new login session, not this already-running script - `sg dialout -c`
+    # applies that group membership immediately, without needing to
+    # re-login. Falls back to a direct attempt if `sg` isn't available
+    # (works if the user was already in dialout from a previous run).
+    local probe_ok=0
+    if command -v sg &>/dev/null; then
+        if timeout 30 sg dialout -c "meshtastic --port '$RADIO_PORT' --info" >"$info_file" 2>&1; then
+            probe_ok=1
+        fi
+    else
+        if timeout 30 meshtastic --port "$RADIO_PORT" --info >"$info_file" 2>&1; then
+            probe_ok=1
+        fi
+    fi
+
+    if [[ "$probe_ok" -ne 1 ]] || ! grep -q '"myNodeNum"' "$info_file" || ! grep -q '^Owner:' "$info_file"; then
+        log "Radio at ${RADIO_PORT} did not return a valid Meshtastic identity."
+        rm -f "$info_file"
+        return 1
+    fi
+
+    local identity_json node_id long_name short_name hw_model
+    if ! identity_json="$(parse_meshtastic_identity_from_info "$info_file" "$RADIO_PORT")"; then
+        log "Could not parse Meshtastic identity from ${RADIO_PORT}."
+        rm -f "$info_file"
+        return 1
+    fi
+    rm -f "$info_file"
+
+    node_id="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["node_id"])' "$identity_json")"
+    long_name="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["long_name"])' "$identity_json")"
+    short_name="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["short_name"])' "$identity_json")"
+    hw_model="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["hardware"])' "$identity_json")"
+
+    if [[ ! "$node_id" =~ ^![0-9a-fA-F]{8}$ ]]; then
+        log "Detected node ID is invalid: $node_id"
+        return 1
+    fi
+
+    # No chown needed (install.sh already runs as the owning user, unlike
+    # firstboot's root-then-handoff-to-target-user flow) and no runner
+    # prefix for validation - step_venv already activated the venv in this
+    # same shell, so plain `python3` already resolves inside it.
+    if ! generate_config_from_radio \
+        "${INSTALL_DIR}/config.example.py" "${INSTALL_DIR}/config.py" \
+        "$node_id" "$long_name" "$short_name" "$hw_model" "$RADIO_PORT" \
+        "" python3; then
+        log "Could not generate config.py from the detected radio."
+        return 1
+    fi
+
+    log "config.py created with detected radio: $node_id ($long_name) ✓"
+    return 0
+)
 
 # ─── Step 8: systemd service ──────────────────────────────────────────────────
 step_systemd() {
@@ -488,8 +599,8 @@ main() {
     step_swap
     step_clone
     step_venv
-    step_config
     step_detect_radio
+    step_config
     step_systemd
     step_cleanup
     step_done

--- a/installer/common.sh
+++ b/installer/common.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# Shared installer logic for install.sh and meshcenter-firstboot.sh.
+#
+# Both scripts need to turn a physically connected Meshtastic radio's
+# `--info` output into a real config.py (LOCAL_NODE_ID/LOCAL_NODE_NAME/
+# KNOWN_NODES/KNOWN_NODE_INFO/MESHTASTIC_PORT), instead of shipping the
+# `!xxxxxxxx` placeholder from config.example.py. meshcenter-firstboot.sh
+# already did this correctly; install.sh used to just `cp
+# config.example.py config.py` and leave the placeholder in - see git log
+# for the fix that extracted this file.
+#
+# This file only holds the parts that are identical between the two
+# callers (parsing `--info` text, writing+validating config.py). It does
+# NOT own the "wait for a radio to appear" loop or its failure policy -
+# meshcenter-firstboot.sh waits up to RADIO_WAIT_SECONDS and fails the
+# whole install if no radio shows up (automatic/unattended provisioning,
+# a radio is expected to be plugged in); install.sh tries once and falls
+# back to the config.example.py placeholder with a warning (the manual
+# path has always allowed installing before a radio is connected - see
+# its step_detect_radio()). That policy difference is exactly the kind of
+# thing that shouldn't live in a shared function.
+#
+# Not meant to be executed directly - source it:
+#   # shellcheck source=installer/common.sh
+#   source "$(dirname "${BASH_SOURCE[0]}")/installer/common.sh"
+
+# parse_meshtastic_identity_from_info <info_file> <port>
+#
+# Reads a captured `meshtastic --port <port> --info` transcript and prints
+# a single-line JSON object {node_id, long_name, short_name, hardware, port}
+# to stdout, or returns non-zero with a message on stderr.
+#
+# node_id is derived from myNodeNum (stable, doesn't depend on the order
+# the node database happens to print in).
+parse_meshtastic_identity_from_info() {
+    local info_file="$1" port="$2"
+
+    python3 - "$info_file" "$port" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+port = sys.argv[2]
+text = path.read_text(errors="replace")
+
+m_num = re.search(r'"myNodeNum"\s*:\s*(\d+)', text)
+if not m_num:
+    raise SystemExit("myNodeNum not found")
+
+node_num = int(m_num.group(1))
+if not 0 <= node_num <= 0xFFFFFFFF:
+    raise SystemExit(f"myNodeNum is outside uint32 range: {node_num}")
+
+node_id = f"!{node_num:08x}"
+
+m_owner = re.search(r'^Owner:\s*(.*?)\s+\(([^()]*)\)\s*$', text, re.MULTILINE)
+if m_owner:
+    long_name = m_owner.group(1).strip()
+    short_name = m_owner.group(2).strip()
+else:
+    m_owner = re.search(r'^Owner:\s*(.*?)\s*$', text, re.MULTILINE)
+    if not m_owner:
+        raise SystemExit("Owner line not found")
+    long_name = m_owner.group(1).strip()
+    short_name = ""
+
+m_hw = re.search(r'"hwModel"\s*:\s*"([^"]+)"', text)
+hardware = (m_hw.group(1) if m_hw else "").strip()
+
+if not long_name:
+    long_name = node_id
+if not short_name:
+    short_name = node_id[-4:].upper()
+
+print(json.dumps({
+    "node_id": node_id,
+    "long_name": long_name,
+    "short_name": short_name,
+    "hardware": hardware,
+    "port": port,
+}, ensure_ascii=False))
+PY
+}
+
+# generate_config_from_radio <template> <output> <node_id> <long_name> \
+#     <short_name> <hw_model> <radio_port> <chown_owner> <validate_python_bin> \
+#     [validate_runner...]
+#
+# Writes config.py from config.example.py with the detected radio's values
+# substituted in, then re-imports the generated file to confirm the exact
+# values server.py would see match what was requested.
+#
+# <chown_owner> is passed straight to `chown` (e.g. "user:group") right
+# after writing, before validation - pass "" to skip (install.sh already
+# owns the files it writes; firstboot runs as root and needs to hand the
+# file to the target user before that user's venv can read it back).
+#
+# <validate_python_bin> is the python interpreter used only for the final
+# re-import check (the write step itself is plain stdlib and always uses
+# `python3` directly - it doesn't need the project's venv). Passing the
+# venv's python for validation is what makes that check mean something -
+# checking config.py imports cleanly under a bare system python wouldn't
+# prove anything about how server.py will actually load it.
+#
+# Any extra arguments after <validate_python_bin> are treated as a command
+# prefix to run the validation python through (e.g. `runuser -u someuser
+# --` on firstboot, where the install runs as root but the venv belongs to
+# a different target user) - install.sh passes none, since it already runs
+# as the owning user.
+generate_config_from_radio() {
+    local template="$1" output="$2" node_id="$3" long_name="$4"
+    local short_name="$5" hw_model="$6" radio_port="$7" chown_owner="$8"
+    local validate_python_bin="$9"
+    shift 9
+    local validate_runner=("$@")
+
+    [[ -f "$template" ]] || { echo "Missing template: $template" >&2; return 1; }
+    [[ ! -e "$output" ]] || { echo "$output already exists" >&2; return 1; }
+
+    python3 - \
+        "$template" \
+        "$output" \
+        "$node_id" \
+        "$long_name" \
+        "$short_name" \
+        "$hw_model" \
+        "$radio_port" <<'PY'
+import ast
+import re
+import sys
+from pathlib import Path
+
+template = Path(sys.argv[1])
+output = Path(sys.argv[2])
+node_id, long_name, short_name, hw_model, radio_port = sys.argv[3:8]
+
+text = template.read_text(encoding="utf-8")
+
+def replace_simple_assignment(source: str, name: str, value) -> str:
+    replacement = f"{name} = {value!r}"
+    pattern = rf"(?m)^{re.escape(name)}\s*=.*$"
+    new, count = re.subn(pattern, replacement, source, count=1)
+    if count != 1:
+        raise RuntimeError(f"Could not find assignment for {name}")
+    return new
+
+def replace_top_level_assignment_block(source: str, name: str, replacement: str) -> str:
+    tree = ast.parse(source)
+    target = None
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            names = []
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name):
+                        names.append(t.id)
+            elif isinstance(node.target, ast.Name):
+                names.append(node.target.id)
+            if name in names:
+                target = node
+                break
+    if target is None or not hasattr(target, "end_lineno"):
+        raise RuntimeError(f"Could not find top-level assignment for {name}")
+    lines = source.splitlines()
+    start = target.lineno - 1
+    end = target.end_lineno
+    lines[start:end] = replacement.splitlines()
+    return "\n".join(lines) + ("\n" if source.endswith("\n") else "")
+
+text = replace_simple_assignment(text, "MESHTASTIC_PORT", radio_port)
+text = replace_simple_assignment(text, "LOCAL_NODE_ID", node_id)
+text = replace_simple_assignment(text, "LOCAL_NODE_NAME", long_name)
+
+known_nodes = (
+    "KNOWN_NODES = {\n"
+    f"    {node_id!r}: {long_name!r},\n"
+    "}"
+)
+text = replace_top_level_assignment_block(text, "KNOWN_NODES", known_nodes)
+
+known_node_info = (
+    "KNOWN_NODE_INFO = {\n"
+    f"    {node_id!r}: {{'short_name': {short_name!r}, 'hw_model': {hw_model!r}}},\n"
+    "}"
+)
+text = replace_top_level_assignment_block(text, "KNOWN_NODE_INFO", known_node_info)
+
+# Validate generated Python before writing.
+ast.parse(text)
+
+output.write_text(text, encoding="utf-8")
+PY
+    local write_status=$?
+    if [[ $write_status -ne 0 ]]; then
+        echo "Failed to generate $output from $template" >&2
+        return 1
+    fi
+
+    if [[ -n "$chown_owner" ]]; then
+        chown "$chown_owner" "$output"
+        chmod 0644 "$output"
+    fi
+
+    # Validate the exact values that will be imported by server.py.
+    "${validate_runner[@]}" "$validate_python_bin" - "$output" "$node_id" "$long_name" "$radio_port" <<'PY'
+import importlib.util
+import sys
+
+path, expected_id, expected_name, expected_port = sys.argv[1:5]
+spec = importlib.util.spec_from_file_location("meshcenter_generated_config", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+checks = {
+    "LOCAL_NODE_ID": (module.LOCAL_NODE_ID, expected_id),
+    "LOCAL_NODE_NAME": (module.LOCAL_NODE_NAME, expected_name),
+    "MESHTASTIC_PORT": (module.MESHTASTIC_PORT, expected_port),
+}
+bad = [f"{key}: {actual!r} != {expected!r}"
+       for key, (actual, expected) in checks.items() if actual != expected]
+if bad:
+    raise SystemExit("; ".join(bad))
+PY
+    if [[ $? -ne 0 ]]; then
+        echo "Generated $output failed validation" >&2
+        rm -f "$output"
+        return 1
+    fi
+
+    return 0
+}

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -47,6 +47,18 @@ SERVICE_WAIT_SECONDS=30
 #   echo "INSTALL_CAMERA=yes" > /boot/firmware/meshcenter-options
 INSTALL_CAMERA=no
 
+# ─── e-Paper display support ──────────────────────────────────────────────────
+# python3-gpiozero and python3-spidev back the e-Paper display driver
+# (modules/display/) - off by default, matching EPAPER_ENABLED=False in
+# config.example.py (this hardware is opt-in, not every install has a HAT
+# wired up). No auto-detection exists for it the way vcgencmd detects a
+# camera, so this is manual-only.
+#
+# To install e-Paper support, create meshcenter-options on bootfs:
+#   echo "INSTALL_EPAPER=yes" > /boot/firmware/meshcenter-options
+# (remember to also set EPAPER_ENABLED=True in config.py afterwards)
+INSTALL_EPAPER=no
+
 PROGRESS_PORT=80
 PROGRESS_FILE="/tmp/meshcenter-progress.txt"
 PROGRESS_PID=""
@@ -328,6 +340,7 @@ if [[ "$INSTALL_CAMERA" == "no" ]]; then
 fi
 
 log "Camera support: $INSTALL_CAMERA"
+log "e-Paper support: $INSTALL_EPAPER"
 
 # ---------------------------------------------------------------------------
 # 1. Resolve the normal user created by Raspberry Pi Imager
@@ -363,6 +376,7 @@ log "Install directory: $INSTALL_DIR"
 # ---------------------------------------------------------------------------
 export DEBIAN_FRONTEND=noninteractive
 
+wait_for_apt_lock
 apt-get update -qq
 wait_for_apt_lock
 apt-get install -y --no-install-recommends \
@@ -401,6 +415,7 @@ update_progress 2 "Installing system packages"
 
 log "Installing MeshCenter system dependencies..."
 
+wait_for_apt_lock
 apt-get update -qq
 wait_for_apt_lock
 apt-get install -y --no-install-recommends \
@@ -436,6 +451,20 @@ else
     log "To enable: create meshcenter-options on bootfs with INSTALL_CAMERA=yes"
 fi
 
+# gpiozero/spidev back the e-Paper display driver - optional, off by default
+# (see EPAPER_ENABLED in config.example.py).
+if [[ "$INSTALL_EPAPER" == "yes" ]]; then
+    log "Installing e-Paper display packages (python3-gpiozero + python3-spidev)..."
+    wait_for_apt_lock
+    apt-get install -y --no-install-recommends \
+        python3-gpiozero \
+        python3-spidev \
+        || log "WARNING: e-Paper packages could not be installed; continuing without e-Paper support."
+else
+    log "e-Paper support skipped (INSTALL_EPAPER=no)"
+    log "To enable: create meshcenter-options on bootfs with INSTALL_EPAPER=yes"
+fi
+
 # Add the normal user to useful hardware groups that actually exist.
 for group in dialout video render gpio i2c spi; do
     if getent group "$group" >/dev/null 2>&1; then
@@ -461,6 +490,11 @@ runuser -u "$TARGET_USER" -- \
 
 [[ -d "$INSTALL_DIR/.git" ]] || fail "Repository clone did not create $INSTALL_DIR/.git"
 log "MeshCenter repository cloned."
+
+# Shared radio-identity-parsing/config-generation logic (also used by
+# install.sh) - only available now that the repo has actually been cloned.
+# shellcheck source=installer/common.sh
+source "$INSTALL_DIR/installer/common.sh"
 
 # ---------------------------------------------------------------------------
 # 6. Create Python virtual environment and install requirements
@@ -571,58 +605,11 @@ RADIO_INFO_FILE="$(cut -d'|' -f2- "$VALID_RADIOS_FILE")"
 
 log "Using Meshtastic radio: $RADIO_PORT"
 
-# Parse identity with Python.
+# Parse identity (shared with install.sh - see installer/common.sh).
 # node_id is derived from myNodeNum because it is stable and avoids relying on
 # the order/content of the node database printed by --info.
-IDENTITY_JSON="$(
-python3 - "$RADIO_INFO_FILE" "$RADIO_PORT" <<'PY'
-import json
-import re
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-port = sys.argv[2]
-text = path.read_text(errors="replace")
-
-m_num = re.search(r'"myNodeNum"\s*:\s*(\d+)', text)
-if not m_num:
-    raise SystemExit("myNodeNum not found")
-
-node_num = int(m_num.group(1))
-if not 0 <= node_num <= 0xFFFFFFFF:
-    raise SystemExit(f"myNodeNum is outside uint32 range: {node_num}")
-
-node_id = f"!{node_num:08x}"
-
-m_owner = re.search(r'^Owner:\s*(.*?)\s+\(([^()]*)\)\s*$', text, re.MULTILINE)
-if m_owner:
-    long_name = m_owner.group(1).strip()
-    short_name = m_owner.group(2).strip()
-else:
-    m_owner = re.search(r'^Owner:\s*(.*?)\s*$', text, re.MULTILINE)
-    if not m_owner:
-        raise SystemExit("Owner line not found")
-    long_name = m_owner.group(1).strip()
-    short_name = ""
-
-m_hw = re.search(r'"hwModel"\s*:\s*"([^"]+)"', text)
-hardware = (m_hw.group(1) if m_hw else "").strip()
-
-if not long_name:
-    long_name = node_id
-if not short_name:
-    short_name = node_id[-4:].upper()
-
-print(json.dumps({
-    "node_id": node_id,
-    "long_name": long_name,
-    "short_name": short_name,
-    "hardware": hardware,
-    "port": port,
-}, ensure_ascii=False))
-PY
-)" || fail "Could not parse Meshtastic identity."
+IDENTITY_JSON="$(parse_meshtastic_identity_from_info "$RADIO_INFO_FILE" "$RADIO_PORT")" \
+    || fail "Could not parse Meshtastic identity."
 
 NODE_ID="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["node_id"])' "$IDENTITY_JSON")"
 LONG_NAME="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["long_name"])' "$IDENTITY_JSON")"
@@ -654,106 +641,22 @@ LIVE_CONFIG="$INSTALL_DIR/config.py"
 
 log "Creating production config.py from config.example.py..."
 
-python3 - \
-    "$TEMPLATE_CONFIG" \
-    "$LIVE_CONFIG" \
-    "$NODE_ID" \
-    "$LONG_NAME" \
-    "$SHORT_NAME" \
-    "$HW_MODEL" \
-    "$RADIO_PORT" <<'PY'
-import ast
-import json
-import re
-import sys
-from pathlib import Path
-
-template = Path(sys.argv[1])
-output = Path(sys.argv[2])
-node_id, long_name, short_name, hw_model, radio_port = sys.argv[3:8]
-
-text = template.read_text(encoding="utf-8")
-
-def replace_simple_assignment(source: str, name: str, value) -> str:
-    replacement = f"{name} = {value!r}"
-    pattern = rf"(?m)^{re.escape(name)}\s*=.*$"
-    new, count = re.subn(pattern, replacement, source, count=1)
-    if count != 1:
-        raise RuntimeError(f"Could not find assignment for {name}")
-    return new
-
-def replace_top_level_assignment_block(source: str, name: str, replacement: str) -> str:
-    tree = ast.parse(source)
-    target = None
-    for node in tree.body:
-        if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            names = []
-            if isinstance(node, ast.Assign):
-                for t in node.targets:
-                    if isinstance(t, ast.Name):
-                        names.append(t.id)
-            elif isinstance(node.target, ast.Name):
-                names.append(node.target.id)
-            if name in names:
-                target = node
-                break
-    if target is None or not hasattr(target, "end_lineno"):
-        raise RuntimeError(f"Could not find top-level assignment for {name}")
-    lines = source.splitlines()
-    start = target.lineno - 1
-    end = target.end_lineno
-    lines[start:end] = replacement.splitlines()
-    return "\n".join(lines) + ("\n" if source.endswith("\n") else "")
-
-text = replace_simple_assignment(text, "MESHTASTIC_PORT", radio_port)
-text = replace_simple_assignment(text, "LOCAL_NODE_ID", node_id)
-text = replace_simple_assignment(text, "LOCAL_NODE_NAME", long_name)
-
-known_nodes = (
-    "KNOWN_NODES = {\n"
-    f"    {node_id!r}: {long_name!r},\n"
-    "}"
-)
-text = replace_top_level_assignment_block(text, "KNOWN_NODES", known_nodes)
-
-known_node_info = (
-    "KNOWN_NODE_INFO = {\n"
-    f"    {node_id!r}: {{'short_name': {short_name!r}, 'hw_model': {hw_model!r}}},\n"
-    "}"
-)
-text = replace_top_level_assignment_block(text, "KNOWN_NODE_INFO", known_node_info)
-
-# Validate generated Python before writing.
-ast.parse(text)
-
-output.write_text(text, encoding="utf-8")
-PY
-
-chown "$TARGET_USER:$TARGET_USER" "$LIVE_CONFIG"
-chmod 0644 "$LIVE_CONFIG"
-
-# Validate the exact values that will be imported by server.py.
-runuser -u "$TARGET_USER" -- \
-    env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" \
-    "$INSTALL_DIR/venv/bin/python" - "$LIVE_CONFIG" "$NODE_ID" "$LONG_NAME" "$RADIO_PORT" <<'PY'
-import importlib.util
-import sys
-
-path, expected_id, expected_name, expected_port = sys.argv[1:5]
-spec = importlib.util.spec_from_file_location("meshcenter_generated_config", path)
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
-
-checks = {
-    "LOCAL_NODE_ID": (module.LOCAL_NODE_ID, expected_id),
-    "LOCAL_NODE_NAME": (module.LOCAL_NODE_NAME, expected_name),
-    "MESHTASTIC_PORT": (module.MESHTASTIC_PORT, expected_port),
+# Shared with install.sh - see installer/common.sh. The write step always
+# runs as plain `python3` (stdlib-only, no venv needed); only the final
+# re-import validation uses the target user's venv python via runuser,
+# same as before this was extracted.
+run_as_target() {
+    runuser -u "$TARGET_USER" -- \
+        env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" \
+        "$@"
 }
-bad = [f"{key}: {actual!r} != {expected!r}"
-       for key, (actual, expected) in checks.items() if actual != expected]
-if bad:
-    raise SystemExit("; ".join(bad))
-PY
+
+generate_config_from_radio \
+    "$TEMPLATE_CONFIG" "$LIVE_CONFIG" \
+    "$NODE_ID" "$LONG_NAME" "$SHORT_NAME" "$HW_MODEL" "$RADIO_PORT" \
+    "$TARGET_USER:$TARGET_USER" \
+    "$INSTALL_DIR/venv/bin/python" run_as_target \
+    || fail "Could not generate production config.py."
 
 log "Production config.py created and validated."
 


### PR DESCRIPTION
## Summary

Four related installer-only fixes.

### 1. The main bug (p.8): install.sh's placeholder LOCAL_NODE_ID

`install.sh::step_config()` used to just `cp config.example.py config.py`, leaving `LOCAL_NODE_ID = "!xxxxxxxx"` on every manual install. `meshcenter-firstboot.sh` already did this correctly (detect radio → `meshtastic --info` → parse → generate `config.py`), so that logic is now extracted into **`installer/common.sh`** (`parse_meshtastic_identity_from_info()`, `generate_config_from_radio()`) and reused by both scripts - no literal duplication.

- `step_detect_radio()` now runs *before* `step_config()` (it already needed the venv's `meshtastic` CLI from `step_venv`, same as the new config generation).
- `step_config()` tries the shared flow when a radio was detected, and falls back to the `config.example.py` placeholder - with a clear warning pointing at Settings - on **any** failure: no radio, `meshtastic --info` times out/errors, or the response doesn't parse. Never aborts the install, matching the manual path's existing tolerance for installing before a radio is connected.
- **A real bug I caught while writing this**: `set -euo pipefail` + install.sh's global `trap ... ERR` meant a failure *inside* the new detection/generation code (several plain, non-`if`-guarded statements - `source`, `mktemp`, the `python3 -c` field extractions) would abort the *whole install*, not just the attempt, before ever reaching the intended fallback. `step_config_from_detected_radio()` now runs as a subshell function `name() ( ... )` with `set +e` and the ERR trap cleared for its body, so any internal failure is caught and turned into "fall back to placeholder" as intended - the rest of the script keeps its original strictness untouched.
- `meshcenter-firstboot.sh`'s control flow is unchanged - same fail-hard-with-a-message behavior on any failure (wait loop, single-radio requirement, chown-then-runuser-validate order), just calling the now-shared functions instead of inlining the same Python twice.

### 2. apt-lock race (p.9)

Fixed the `apt-get update` → `wait_for_apt_lock` ordering (should be `wait_for_apt_lock` → `apt-get update` → `wait_for_apt_lock` → `apt-get install`) in both places it occurred in `meshcenter-firstboot.sh` (SSH bootstrap step, main system-packages step). Right after boot, `apt-get update` can lose the race against cloud-init's own apt usage before the lock-wait ever runs. The camera-packages `apt-get install` already had `wait_for_apt_lock` correctly placed immediately before it - didn't need changing.

### 3. Optional e-Paper packages (p.10)

Added an `INSTALL_EPAPER` opt-in flag (default off, matching `EPAPER_ENABLED=False` in `config.example.py`) to both scripts - installs `python3-gpiozero`/`python3-spidev` only when requested. Same `meshcenter-options` file mechanism as the existing `INSTALL_CAMERA` flag in firstboot; an env var (`INSTALL_EPAPER=yes curl ... | bash`) for `install.sh`. Documented in `INSTALL.md` next to the camera section.

**Left camera packages unchanged**, as the task allowed if I explained why: both scripts already gate camera installation (`INSTALL_CAMERA` flag in firstboot; an `apt-cache show python3-picamera2` existence check with a graceful warning in install.sh) - there was nothing missing to add there.

### 4. Stale `firstrun.sh` reference (p.11)

`install.sh`'s header comment referenced "firstrun.sh" - a name this project doesn't use. Comment only, no logic touched.

## Testing (no physical Pi/radio available)

- `bash -n` on `install.sh`, `meshcenter-firstboot.sh`, `installer/common.sh` - all clean (also now covered by CI: `installer/*.sh` added to the workflow's sweep).
- **Traced both `install.sh::step_config()` scenarios by hand**:
  - (a) radio connected and responsive → `step_detect_radio` finds the device → `step_config_from_detected_radio` queries it, parses identity, generates a real `config.py`, validates it via re-import.
  - (b) no radio / `meshtastic --info` times out or returns something unparseable → every failure point returns 1 from within the `set +e`-scoped subshell → `step_config()` falls through to the `config.example.py` placeholder + warning → install continues normally either way, never aborts.
- **Dry-run of the extracted shared functions** (not a pytest test - ran directly in bash, using the same fake-CLI-output idea as `tests/conftest.py::_write_fake_config`): sourced `installer/common.sh`, fed `parse_meshtastic_identity_from_info()` a synthetic `--info` transcript (`Owner:` line + `myNodeNum`/`hwModel` JSON), confirmed the expected identity JSON came out, fed that into `generate_config_from_radio()`, and confirmed the resulting `config.py` had real `LOCAL_NODE_ID`/`LOCAL_NODE_NAME`/`KNOWN_NODES`/`KNOWN_NODE_INFO`/`MESHTASTIC_PORT` values substituted correctly and passed the re-import validation. Also confirmed the invalid-identity rejection (missing `myNodeNum`/`Owner` markers) is caught before ever reaching the parser.
- Full pytest suite (50 tests, unrelated to this change) stayed green after every edit.
- This PR's own CI run is the real end-to-end syntax check on GitHub's runner (same as PR #64).

## Confirmation: meshcenter-firstboot.sh behavior is unchanged

Same `RADIO_WAIT_SECONDS` wait loop, same mandatory-single-radio requirement, same fail-hard-with-ERR-trap semantics on any failure, same chown-then-runuser-validate order - only the identity-parsing and config-writing Python moved into `installer/common.sh`, byte-for-byte, nothing about *when* or *how* it runs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)