### PR TITLE
fix: wsgi.py now actually starts background workers (P2, lifecycle fix)

### DIFF
--- a/server.py
+++ b/server.py
@@ -5830,7 +5830,32 @@ def api_system_cpu_history():
 # ЗАПУСК
 # ============================================================
 
-if __name__ == "__main__":
+_runtime_started = False
+
+def start_runtime():
+    """Runs everything server.py needs before it can actually serve traffic:
+    radio identity verification, loading persisted state, starting every
+    background worker (listener, telemetry, radio health, CPU history,
+    update checks, schedule engine, time service, optionally e-Paper), and
+    building the camera driver if it's persisted on.
+
+    Historically all of this lived directly under `if __name__ ==
+    "__main__":` below, which meant `from server import app` (e.g. under
+    `gunicorn wsgi:app`) got working Flask routes but silently NO
+    background workers and no radio listener - see wsgi.py, which now
+    calls this at import time instead.
+
+    Safe to call at most once per process - a second call would start a
+    second set of listener/worker threads. `if __name__ == "__main__":`
+    calls this itself, so importing server.py alone (e.g. under pytest,
+    see tests/conftest.py) never triggers it.
+    """
+    global _runtime_started
+    if _runtime_started:
+        print("[INIT] start_runtime() already ran in this process - skipping.", flush=True)
+        return
+    _runtime_started = True
+
     # Verify the physical radio before loading or mutating radio-profile data.
     startup_info_output = verify_radio_identity()
     identity_status = RADIO_IDENTITY_RESULT.get("status", "NOT_CHECKED")
@@ -6050,5 +6075,8 @@ if __name__ == "__main__":
         f"    Photo: {camera.PHOTO_CONFIG['resolution']} preview, {camera.PHOTO_SAVE_CONFIG['resolution']} save\n"
     )
 
+
+if __name__ == "__main__":
+    start_runtime()
     app.run(host=APP_HOST, port=APP_PORT, debug=False, threaded=True)
 

--- a/tests/test_smoke_import.py
+++ b/tests/test_smoke_import.py
@@ -8,3 +8,15 @@ unrelated failures in every other test file.
 def test_server_module_imports(server_module):
     assert server_module.LOCAL_NODE_ID == "!aabbccdd"
     assert callable(server_module.sanitize_text)
+
+
+def test_start_runtime_exists_but_is_not_invoked_by_import(server_module):
+    # start_runtime() starts real background threads (radio listener,
+    # telemetry workers, ...) and must never run just because server.py was
+    # imported - that's the whole point of extracting it out of
+    # `if __name__ == "__main__":` (see wsgi.py, which calls it explicitly).
+    # This only checks it exists and hasn't run - it deliberately does NOT
+    # call it, since that would actually spin up those threads/radio
+    # attempts against the sandboxed fake CLI from conftest.py.
+    assert callable(server_module.start_runtime)
+    assert server_module._runtime_started is False

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,7 +2,22 @@
 """
 WSGI entry point for production servers (Gunicorn, uWSGI, etc.)
 """
-from server import app
+from server import app, start_runtime
+
+# `from server import app` alone only registers Flask routes - every
+# background worker (radio listener, telemetry, radio health, CPU history,
+# update checks, schedule engine, time service, ...) lives in start_runtime(),
+# which normally only runs under `if __name__ == "__main__":` in server.py
+# itself. A WSGI server imports this module without ever executing that
+# block, so it has to be called explicitly here instead.
+#
+# If gunicorn (or uwsgi) is run with more than one worker process, each
+# worker process runs this module-level code independently and would start
+# its own radio listener - only one process may own the serial port at a
+# time. Production deployment via gunicorn (not yet wired into
+# deploy/meshcenter.service - the systemd unit still runs `python server.py`
+# directly) must use exactly one worker: `gunicorn --workers 1 wsgi:app`.
+start_runtime()
 
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## Summary

`wsgi.py` was `from server import app` plus an unreachable `if __name__ == "__main__": app.run()`. Importing it (e.g. under `gunicorn wsgi:app`) got working Flask routes but **silently no background workers and no radio listener**, since all of that lived directly under `server.py`'s own `if __name__ == "__main__":` block, which only runs when `server.py` itself is executed as a script. Dormant today (production runs `python server.py` under systemd - `deploy/meshcenter.service`, unchanged by this PR), but misleading to anyone who tried a real WSGI server.

## What changed

- **`server.py`**: extracted the entire body of `if __name__ == "__main__":` (radio identity verification, loading messages/nodes/chats/settings, camera driver setup, starting every background worker - listener, telemetry, radio health, CPU history, update checks, schedule engine, time service, optional e-Paper) into a new top-level `start_runtime()`. Only `app.run(host=APP_HOST, port=APP_PORT, debug=False, threaded=True)` stays under `if __name__ == "__main__":`, which now calls `start_runtime()` first. **The move is byte-identical** - not a single line of the moved body's logic or ordering changed, only the enclosing header/footer (confirmed by the diff itself - see below).

- **The one real trap, checked carefully**: every bare module-level-looking reassignment inside the moved block (`startup_info_output`, `identity_status`, `identity_match`, `devices_data`, `active_camera_status`, `active_camera_id`, `detected_camera_model`, `cameras`, `stored_camera`, `detected_radio`, `banner_radio_name`, `banner_instance_name`, `banner_hostname`) was grepped against the whole file for a module-level collision. **None exist** - every one of these is a genuinely fresh local name, not a shadowed global. So **no `global` declarations were needed** for the moved code itself. Everything else in the block only mutates existing module-level objects in place (dict items, `.start()` on `Thread`/`Event` objects) - never needed `global` either.

- Added a `_runtime_started` module-level flag (with its own `global _runtime_started`) so a second `start_runtime()` call in the same process is a safe no-op instead of starting a second listener/worker set - cheap insurance, not something that currently happens.

- **`wsgi.py`**: now `from server import app, start_runtime; start_runtime()` at import time, so a real WSGI server actually gets working background workers. Documented that multiple gunicorn worker processes would each start their own radio listener - only one process may own the serial port, so a future gunicorn deployment (**not made in this change** - `deploy/meshcenter.service` still runs `python server.py` directly) must use `--workers 1`.

- **`tests/test_smoke_import.py`**: added a test confirming `start_runtime` exists and is callable, and that merely importing `server.py` (as `tests/conftest.py` does for every other test) does **not** set `_runtime_started` - i.e. importing `server.py` still starts zero background threads/radio attempts. Deliberately doesn't call `start_runtime()` itself inside the pytest suite (that's covered by a separate, real dry run - see below).

## Verification

- `python -m pytest`: **51 passed** (50 before + this one new test), 0 failed.
- `python -m compileall` on `server.py`/`wsgi.py`: clean.
- **The diff itself is the proof of "byte-identical move"**: `git diff server.py` shows only the new `def start_runtime():` header (with its docstring and the `_runtime_started` guard) inserted before the first moved line, and the `app.run(...)` line moved out to a new `if __name__ == "__main__":` at the end - every line in between is completely unchanged.
- **A real dry run, not just an import test**: built the same synthetic config/fake-CLI sandbox `tests/conftest.py` uses, then actually imported `wsgi.py` (triggering `start_runtime()` for real, not just checking that the module imports). It ran to completion: radio identity check (correctly fell back to "listener not started" against the fake CLI's non-Meshtastic output), camera detection attempt (failed gracefully - no `picamera2` in that sandbox, caught and logged, same as it would on non-Pi hardware), time service and schedule engine starting, and the final startup banner printing - then confirmed `server._runtime_started` was `True` and that calling `start_runtime()` again logged `"already ran in this process - skipping"` instead of starting a second listener.
- **Live-verified on real hardware** (dev + camtest, both currently on this branch): full restart on both, confirmed via `journalctl` that the startup sequence is identical to before this change - `[VERSION]` → `[INSTANCE]`/`[PROFILE]` → `[IDENTITY] ... Status: MATCH` → camera init → `[Schedule] Engine started` → banner (`URL: http://0.0.0.0:5000`, `Radio: ...`) → `Listener command: [...--listen]` with a real PID. Both nodes came back up healthy (`HTTP:200`) and are actively listening/parsing live mesh traffic post-restart.

## Confirmation

`python server.py` behaves exactly as before - same startup sequence, same log lines, same order, live-confirmed on two physical nodes, not just reasoned about. `wsgi.py` now genuinely initializes every background worker at import time, which is the actual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)