### PR TITLE
fix: media.js single-quote XSS gap, dead code cleanup, queue/ProfileManager tests

### DIFF
--- a/static/media.js
+++ b/static/media.js
@@ -16,7 +16,17 @@ function mediaEscapeHtml(value) {
 }
 
 function mediaFilenameForHandler(filename) {
-    return JSON.stringify(String(filename ?? ''));
+    // JSON.stringify() produces a valid double-quoted JS string literal but
+    // does NOT escape a single quote - it isn't special to JSON. The result
+    // is spliced into a single-quoted onclick='...' attribute
+    // (renderMediaItem() below), so a raw ' here would break out of that
+    // attribute and let arbitrary HTML/JS follow (e.g. an injected
+    // onmouseover=...). Filenames are currently server-generated from a
+    // timestamp, so this isn't reachable today, but nothing enforces that
+    // staying true - ' is valid both inside a JSON/JS string literal
+    // and has no special meaning in HTML attribute text, so this can never
+    // be broken out of regardless of what filename contains.
+    return JSON.stringify(String(filename ?? '')).replaceAll("'", '\\u0027');
 }
 
 async function loadMediaGallery(force = false) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2134,7 +2134,7 @@
     window.I18N.init("{{ ui_language }}").then(() => window.I18N.applyStaticDom());
 </script>
 <script src="/static/chat.js?v=20260818-security-card"></script>
-<script src="/static/media.js?v=20260806-stage9-i18n"></script>
+<script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 
 <div class="modal-overlay" id="wifiConnectModal" style="display:none;" onclick="closeWifiConnectModal()">

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -1,0 +1,131 @@
+"""Tests for the outgoing-message status state machine in server.py:
+add_message() (creation, status="pending" for the async send flow),
+update_message_status() (pending -> sent/failed, in place - never a new
+record), and reconcile_interrupted_sends() (fails out anything still
+"pending" after a restart).
+
+Deliberately does NOT drive this through api_chat.py's actual /api/send
+Flask route or its send_queue/background send_worker thread (see
+api/api_chat.py:register_chat_routes) - that thread is real (started
+unconditionally at import time, see api_chat.py:264) and talks to an
+actual SerialInterface once given a job, which would mean either mocking
+serial I/O deeply or letting a background thread attempt a real open()
+against the fake serial port from tests/conftest.py with no clean way to
+synchronize on/observe the outcome from the test. The state-transition
+primitives tested here are exactly what that route and worker are built
+on top of (see api_chat.py's own calls to add_message()/
+update_message_status()), so this covers the invariants task item 3a
+actually asks about - "pending" creation, transition without duplication,
+retry reusing the same record - without that risk.
+"""
+
+
+def test_add_message_with_pending_status_is_stored_as_pending(server_module):
+    before = len(server_module.messages)
+    msg = server_module.add_message(
+        "me", "Me", "hello there", node_id="!820af75a", status="pending",
+    )
+    assert msg["status"] == "pending"
+    assert len(server_module.messages) == before + 1
+    assert server_module.messages[-1]["id"] == msg["id"]
+
+
+def test_add_message_without_status_defaults_to_sent(server_module):
+    # Messages created outside the async /api/send flow (rx, system,
+    # waypoint notifications) are final immediately - see add_message()'s
+    # own comment on the "status" field.
+    msg = server_module.add_message("rx", "Flint TAP2", "hi", node_id="!820af75a")
+    assert msg["status"] == "sent"
+
+
+def test_update_message_status_transitions_in_place_without_duplicating(server_module):
+    msg = server_module.add_message(
+        "me", "Me", "will succeed", node_id="!820af75a", status="pending",
+    )
+    count_before = len(server_module.messages)
+
+    updated = server_module.update_message_status(
+        msg["id"], msg["chat_id"], "sent", packet_id=123456,
+    )
+
+    assert updated["status"] == "sent"
+    assert updated["packet_id"] == 123456
+    assert updated["id"] == msg["id"]
+    # No new message record was created - the same one was mutated in place.
+    assert len(server_module.messages) == count_before
+
+
+def test_update_message_status_records_failure_with_error(server_module):
+    msg = server_module.add_message(
+        "me", "Me", "will fail", node_id="!820af75a", status="pending",
+    )
+
+    updated = server_module.update_message_status(
+        msg["id"], msg["chat_id"], "failed", error="Radio busy",
+    )
+
+    assert updated["status"] == "failed"
+    assert updated["error"] == "Radio busy"
+
+
+def test_update_message_status_clears_stale_error_on_success(server_module):
+    msg = server_module.add_message(
+        "me", "Me", "retried message", node_id="!820af75a", status="pending",
+    )
+    server_module.update_message_status(msg["id"], msg["chat_id"], "failed", error="timeout")
+
+    # A subsequent successful send (e.g. the user hit Retry) must clear the
+    # stale error rather than leaving a "sent" bubble that still shows one.
+    updated = server_module.update_message_status(msg["id"], msg["chat_id"], "sent")
+
+    assert updated["status"] == "sent"
+    assert "error" not in updated
+
+
+def test_update_message_status_unknown_message_returns_none(server_module):
+    result = server_module.update_message_status("does-not-exist", "!820af75a", "sent")
+    assert result is None
+
+
+def test_retry_reuses_the_same_message_record_not_a_new_one(server_module):
+    # Mirrors exactly what api_chat.py's api_send_retry() route does with a
+    # failed message: flips its status back to "pending" and re-queues the
+    # same id - it never calls add_message() again. Asserting the message
+    # count is unchanged and the id is preserved is the actual "retry does
+    # not create a duplicate" invariant task item 3a asks about.
+    msg = server_module.add_message(
+        "me", "Me", "flaky send", node_id="!820af75a", status="pending",
+    )
+    server_module.update_message_status(msg["id"], msg["chat_id"], "failed", error="no ack")
+    count_before_retry = len(server_module.messages)
+
+    retried = server_module.update_message_status(msg["id"], msg["chat_id"], "pending")
+
+    assert retried["id"] == msg["id"]
+    assert retried["status"] == "pending"
+    assert len(server_module.messages) == count_before_retry
+
+
+def test_reconcile_interrupted_sends_fails_out_pending_messages(server_module):
+    msg = server_module.add_message(
+        "me", "Me", "in flight when the process died", node_id="!820af75a", status="pending",
+    )
+
+    server_module.reconcile_interrupted_sends()
+
+    updated = next(m for m in server_module.messages if m["id"] == msg["id"])
+    assert updated["status"] == "failed"
+    assert updated["error_code"] == "interrupted_by_restart"
+
+
+def test_reconcile_interrupted_sends_leaves_final_messages_untouched(server_module):
+    sent_msg = server_module.add_message("me", "Me", "already sent", node_id="!820af75a", status="sent")
+    failed_msg = server_module.add_message("me", "Me", "already failed", node_id="!820af75a", status="failed")
+
+    server_module.reconcile_interrupted_sends()
+
+    updated_sent = next(m for m in server_module.messages if m["id"] == sent_msg["id"])
+    updated_failed = next(m for m in server_module.messages if m["id"] == failed_msg["id"])
+    assert updated_sent["status"] == "sent"
+    assert updated_failed["status"] == "failed"
+    assert "error_code" not in updated_failed

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -1,16 +1,14 @@
-"""Tests for node ID format validation.
+"""Tests for node ID format validation - server.py's own
+is_valid_node_id()/is_valid_chat_id()/normalize_node_id(), the ones actually
+wired into every route.
 
-server.py has its own is_valid_node_id()/is_valid_chat_id()/normalize_node_id()
-(the ones actually wired into every route) - utils/helpers.py has a second,
-textually similar but NOT equivalent copy that nothing currently imports
-(only utils.helpers.now() is actually used elsewhere, by telemetry.py).
-Both are tested here: the real, enforced server.py behavior is the main
-target of task item (c); the utils/helpers.py copy is covered too so its
-looser behavior is pinned down and visible next to it, rather than silently
-diverging further - see test_is_valid_node_id_utils_helpers_is_looser below.
+utils/helpers.py used to have a second, textually similar but looser
+is_valid_node_id() that nothing imported - it was removed (see that file's
+git history) once confirmed unused; only utils.helpers.now() is actually
+used elsewhere, by telemetry.py. The test that documented the divergence
+between the two copies (test_is_valid_node_id_utils_helpers_is_looser) went
+with it, since there's no longer a second copy to diverge from.
 """
-
-import utils.helpers as helpers
 
 
 def test_is_valid_node_id_accepts_well_formed_ids(server_module):
@@ -62,19 +60,3 @@ def test_normalize_node_id_passes_through_well_formed_id(server_module):
 def test_normalize_node_id_returns_none_for_empty_input(server_module):
     assert server_module.normalize_node_id("") is None
     assert server_module.normalize_node_id(None) is None
-
-
-def test_is_valid_node_id_utils_helpers_is_looser(server_module):
-    """Documents a real gap: utils/helpers.py's is_valid_node_id() only
-    checks a "!" prefix and a minimum length, not that the rest is 8 hex
-    digits - server.py's own version (tested above) is the strict one
-    actually enforced on every route. Nothing currently imports the
-    utils/helpers.py copy, so this isn't exploitable today, but the two
-    functions silently disagree, which is exactly the kind of drift a
-    future refactor (consolidating validation into one place) should
-    resolve rather than papering over.
-    """
-    # Rejected by server.py's strict regex (see test above)...
-    assert server_module.is_valid_node_id("!aabbccdg") is False
-    # ...but accepted by utils/helpers.py's loose prefix+length check.
-    assert helpers.is_valid_node_id("!aabbccdg") is True

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -1,0 +1,84 @@
+"""Tests for storage/profile_manager.py's ProfileManager - keeps each
+accepted radio's data isolated under data/profiles/<node-id>/ (see
+CLAUDE.md's "Multi-radio profiles" section). Pure filesystem + dict logic,
+no server.py/hardware dependency of its own - takes a plain data_dir.
+"""
+
+import pytest
+
+from storage.profile_manager import ProfileManager
+
+
+def _radio(node_id="!75fea2aa", long_name="Flint TAP2", short_name="FTP2"):
+    return {
+        "node_id": node_id,
+        "long_name": long_name,
+        "short_name": short_name,
+        "hardware": "RAK4631",
+        "role": "CLIENT",
+        "port": "/dev/ttyACM0",
+    }
+
+
+def test_profile_id_from_node_id_normalizes_case():
+    assert ProfileManager.profile_id_from_node_id("!75FEA2AA") == "75fea2aa"
+
+
+def test_profile_id_from_node_id_rejects_malformed_ids():
+    for bad in ("not-a-node-id", "!short", "!toolong123456", "", None):
+        with pytest.raises(ValueError):
+            ProfileManager.profile_id_from_node_id(bad)
+
+
+def test_ensure_profile_creates_isolated_directory_per_radio(tmp_path):
+    manager = ProfileManager(tmp_path)
+
+    context = manager.ensure_profile(_radio(), migrate_legacy=False)
+
+    assert context["profile_id"] == "75fea2aa"
+    assert (tmp_path / "profiles" / "75fea2aa").is_dir()
+    assert (tmp_path / "profiles" / "75fea2aa" / "profile.json").is_file()
+    assert context["metadata"]["radio"]["node_id"] == "!75fea2aa"
+    assert context["metadata"]["radio"]["long_name"] == "Flint TAP2"
+
+
+def test_ensure_profile_two_different_radios_get_separate_profiles(tmp_path):
+    manager = ProfileManager(tmp_path)
+
+    context_a = manager.ensure_profile(_radio(node_id="!75fea2aa", long_name="Radio A"), migrate_legacy=False)
+    context_b = manager.ensure_profile(_radio(node_id="!aabbccdd", long_name="Radio B"), migrate_legacy=False)
+
+    assert context_a["profile_id"] != context_b["profile_id"]
+    assert context_a["profile_dir"] != context_b["profile_dir"]
+    # Confirms profiles are actually isolated, not sharing a data file.
+    assert context_a["paths"]["nodes"] != context_b["paths"]["nodes"]
+
+
+def test_ensure_profile_is_idempotent_and_preserves_created_at(tmp_path):
+    manager = ProfileManager(tmp_path)
+
+    first = manager.ensure_profile(_radio(), migrate_legacy=False)
+    second = manager.ensure_profile(_radio(), migrate_legacy=False)
+
+    assert first["profile_id"] == second["profile_id"]
+    # created_at must survive a repeat call (e.g. every server.py restart
+    # against the same accepted radio) - only last_used_at should move.
+    assert first["metadata"]["created_at"] == second["metadata"]["created_at"]
+
+
+def test_ensure_profile_rejects_invalid_radio_node_id(tmp_path):
+    manager = ProfileManager(tmp_path)
+
+    with pytest.raises(ValueError):
+        manager.ensure_profile(_radio(node_id="not-a-valid-id"), migrate_legacy=False)
+
+
+def test_create_clean_profile_initializes_empty_state_files(tmp_path):
+    manager = ProfileManager(tmp_path)
+
+    profile = manager.create_clean_profile(_radio())
+
+    profile_dir = tmp_path / "profiles" / "75fea2aa"
+    assert (profile_dir / "messages.json").read_text(encoding="utf-8").strip() == "[]"
+    assert (profile_dir / "nodes.json").read_text(encoding="utf-8").strip() == "{}"
+    assert profile["profile_id"] == "75fea2aa"

--- a/tests/test_radio_identity.py
+++ b/tests/test_radio_identity.py
@@ -1,0 +1,108 @@
+"""Tests for meshsrv/radio_identity.py's compare_radio_identity() - the
+protective check that decides whether server.py is allowed to start the
+listener and write into a radio profile: on the configured radio matching
+the physically detected one, or blocked on a mismatch (see server.py's
+verify_radio_identity()/start_runtime(), which gate listen_meshtastic() and
+parse_nodes_from_info() on `identity_status == "MATCH"`). No server.py
+import needed - this module only depends on meshsrv.meshsrv (subprocess
+wrapper, not called here) and meshsrv.runtime_identity, neither of which
+touch hardware at import time.
+"""
+
+from meshsrv.radio_identity import compare_radio_identity, parse_radio_identity
+
+
+def test_matching_node_id_is_a_match():
+    saved = {"node_id": "!820af75a"}
+    detected = {"node_id": "!820af75a"}
+    assert compare_radio_identity(saved, detected) == "MATCH"
+
+
+def test_matching_node_id_is_case_and_format_insensitive():
+    # The configured value may be stored with different casing/prefix
+    # conventions than what --info reports - both normalize through
+    # _normalize_node_id() before comparison.
+    saved = {"node_id": "!820AF75A"}
+    detected = {"node_id": "!820af75a"}
+    assert compare_radio_identity(saved, detected) == "MATCH"
+
+
+def test_different_node_id_is_a_mismatch():
+    saved = {"node_id": "!820af75a"}
+    detected = {"node_id": "!aabbccdd"}
+    assert compare_radio_identity(saved, detected) == "MISMATCH"
+
+
+def test_no_detected_radio_is_not_found():
+    # Nothing answered the --info probe - status is NOT_FOUND regardless of
+    # what's configured, distinct from a MISMATCH (a different radio
+    # answered) - server.py's verify_radio_identity() treats both as "do
+    # not start the listener", but the distinction matters for the message
+    # shown to the user.
+    saved = {"node_id": "!820af75a"}
+    detected = {}
+    assert compare_radio_identity(saved, detected) == "NOT_FOUND"
+
+
+def test_no_configured_radio_is_not_checked():
+    # First-ever run: nothing has been accepted/configured yet, but a radio
+    # did answer - MATCH/MISMATCH can't be decided yet.
+    saved = {}
+    detected = {"node_id": "!820af75a"}
+    assert compare_radio_identity(saved, detected) == "NOT_CHECKED"
+
+
+def test_neither_configured_nor_detected_is_not_found():
+    # detected_id emptiness is checked first - see compare_radio_identity()'s
+    # own order of checks.
+    assert compare_radio_identity({}, {}) == "NOT_FOUND"
+
+
+def test_parse_radio_identity_extracts_local_node_from_info_output():
+    info_output = (
+        'Connected to radio\n'
+        'Owner: Flint TAP2 (FTP2)\n'
+        '{"myNodeNum": 1979622058}\n'
+        'Nodes in mesh: {\n'
+        '  "!75fea2aa": {\n'
+        '    "num": 1979622058,\n'
+        '    "user": {\n'
+        '      "id": "!75fea2aa",\n'
+        '      "longName": "Flint TAP2",\n'
+        '      "shortName": "FTP2",\n'
+        '      "hwModel": "RAK4631",\n'
+        '      "role": "CLIENT"\n'
+        '    }\n'
+        '  }\n'
+        '}\n'
+        'Metadata: {"firmwareVersion": "2.5.20.abcdef"}\n'
+    )
+
+    identity = parse_radio_identity(info_output, serial_port="/dev/ttyACM0")
+
+    assert identity["node_id"] == "!75fea2aa"
+    assert identity["long_name"] == "Flint TAP2"
+    assert identity["short_name"] == "FTP2"
+    assert identity["hardware"] == "RAK4631"
+    assert identity["firmware_version"] == "2.5.20.abcdef"
+    assert identity["port"] == "/dev/ttyACM0"
+
+
+def test_parse_radio_identity_returns_empty_node_id_for_unrelated_output():
+    identity = parse_radio_identity("some unrelated CLI error output", serial_port="/dev/ttyACM0")
+    assert identity["node_id"] == ""
+
+
+def test_match_then_mismatch_end_to_end_with_parsed_output():
+    # A more end-to-end shape: parse two different --info outputs (a radio
+    # swap) and confirm the match/mismatch verdict follows the physically
+    # detected node, not the configured one.
+    configured = {"node_id": "!75fea2aa"}
+
+    same_radio_info = 'Owner: Flint TAP2 (FTP2)\n{"myNodeNum": 1979622058}\n'
+    same_radio = parse_radio_identity(same_radio_info)
+    assert compare_radio_identity(configured, same_radio) == "MATCH"
+
+    different_radio_info = 'Owner: Someone Else (SOME)\n{"myNodeNum": 2864434397}\n'
+    different_radio = parse_radio_identity(different_radio_info)
+    assert compare_radio_identity(configured, different_radio) == "MISMATCH"

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -76,14 +76,6 @@ def normalize_node_id_with_aliases(node_id):
     return normalize_node_id(node_id)
 
 
-def is_valid_node_id(node_id, channel_chat_id=None):
-    if not node_id:
-        return False
-    if channel_chat_id is not None and node_id == channel_chat_id:
-        return True
-    return node_id.startswith("!") and len(node_id) >= 5
-
-
 def sanitize_text(text):
     if not text:
         return ""


### PR DESCRIPTION
## Summary

Three small, independent backlog items in one PR.

### 1. `static/media.js` - same vulnerability class as PR #62's stored XSS

`mediaFilenameForHandler()` used `JSON.stringify()` to build the argument for a single-quoted `onclick='deleteMediaItem(...)'` attribute. `JSON.stringify()` produces a valid JS string literal but does **not** escape a single quote - not special to JSON - so a filename containing one would break out of the outer `onclick='...'` attribute, up to injecting a new HTML attribute (e.g. `onmouseover=...`). Currently low-probability (filenames are server-generated from a timestamp today), but nothing enforces that staying true.

Fixed by post-processing the `JSON.stringify()` output to replace every `'` with `\u0027` - valid inside both a JSON string and a JS string literal, mathematically impossible to break the outer attribute out of regardless of input. `deleteMediaItem()`'s signature and the rest of the delete logic are untouched - only how the `onclick` attribute string is built.

### 2. `utils/helpers.py` - removed dead `is_valid_node_id()`

Confirmed via grep that nothing imports or calls it (only `utils.helpers.now()` is used elsewhere, by `telemetry.py`). It was a second, looser copy of `server.py`'s own `is_valid_node_id()` (prefix+length only, not the strict 8-hex-digit regex actually enforced on every route) - flagged as a known gap when `tests/test_node_id_validation.py` was written (PR #64) rather than fixed then, since that task was test-infra-only.

`test_is_valid_node_id_utils_helpers_is_looser` existed specifically to document the divergence between the two versions - removed along with the `import utils.helpers as helpers` it needed, since there's no longer a second copy to diverge from.

### 3. Tests for message queue + radio identity/ProfileManager (deferred in PR #64)

- **`tests/test_message_queue.py`** (9 tests): `add_message()` creating a `"pending"` record for the async send flow, `update_message_status()` transitioning it **in place** (never creating a new record - the actual "retry doesn't duplicate" invariant), error set on failure and cleared on a later success, `reconcile_interrupted_sends()` failing out anything still `"pending"` after a restart.

  Deliberately tests these state-transition primitives directly rather than driving them through `api_chat.py`'s actual `/api/send` route - that route hands the job to a real background thread (started unconditionally at import time, `api_chat.py:264`) which opens a real `SerialInterface` against whatever port is configured. Reliably synchronizing on/observing that against the fake port from `tests/conftest.py` wasn't worth building for this pass. The primitives tested here are exactly what that route and worker are built on.

- **`tests/test_radio_identity.py`** (9 tests) + **`tests/test_profile_manager.py`** (7 tests): the actual protective mechanism - `meshsrv/radio_identity.py`'s `compare_radio_identity()` (MATCH/MISMATCH/NOT_FOUND/NOT_CHECKED, case/format-insensitive comparison, `parse_radio_identity()` extracting identity from `--info` text) and `storage/profile_manager.py`'s `ProfileManager` (isolated directory per accepted radio, idempotent across repeat calls, rejects malformed node IDs, two radios never share file paths). Neither module needs `server.py` or hardware/subprocess mocking - both take plain data.

  **Not covered, deliberately**: `server.py`'s own gating of `listen_meshtastic()`/`parse_nodes_from_info()` on `identity_status=="MATCH"` inside `start_runtime()` - exercising that branch means either calling `start_runtime()` for real (starts background threads/radio attempts) or refactoring further to expose it in isolation (out of scope). The decision function it depends on is fully covered instead.

## Verification

- `python -m pytest`: **75 passed** (was 51: -1 for the removed divergence test, +25 new: 9 message-queue + 9 radio-identity + 7 profile-manager).
- `node --check static/media.js`: clean.
- `python -m compileall`: clean.
- **Manual proof for the media.js fix** (no JS test infra exists yet): fed `mediaFilenameForHandler()` a filename containing `"'); alert('XSS'); //"`, built the resulting `onclick='...'` HTML fragment, simulated the browser's HTML-attribute parsing (regex-matched the single-quote-delimited attribute value), then actually **executed** that extracted attribute text as JS. Confirmed: the outer attribute is no longer broken (the whole call is captured, not truncated at the first quote), no injected code runs, `deleteMediaItem()` receives the exact original string back as an inert data argument. Also confirmed a normal filename still round-trips correctly. Bumped `media.js`'s cache-bust query string in `templates/index.html`.
- **Deployed and confirmed on all three nodes** (dev/camtest/prod): all healthy, all serving the patched `media.js` (byte-confirmed via `curl | grep u0027`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)