### PR TITLE
feat: move production deployment from Flask dev server to gunicorn

### DIFF
--- a/deploy/meshcenter.service
+++ b/deploy/meshcenter.service
@@ -9,7 +9,18 @@ User=__MESH_USER__
 WorkingDirectory=__MESH_HOME__/meshcenter
 Environment="PATH=__MESH_HOME__/meshcenter/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Environment="PYTHONUNBUFFERED=1"
-ExecStart=__MESH_HOME__/meshcenter/venv/bin/python __MESH_HOME__/meshcenter/server.py
+# Production WSGI server - see gunicorn.conf.py (workers/threads/timeout,
+# loaded automatically from WorkingDirectory above) and wsgi.py (calls
+# server.py's start_runtime() at import time, so gunicorn actually gets a
+# working radio listener + background workers, not just Flask routes).
+#
+# Rollback: if this ever needs to be reverted on a live node without a full
+# git revert, just change the line below back to:
+#   ExecStart=__MESH_HOME__/meshcenter/venv/bin/python __MESH_HOME__/meshcenter/server.py
+# then `sudo systemctl daemon-reload && sudo systemctl restart meshcenter` -
+# server.py's own `python server.py` direct-run path is unchanged and still
+# fully supported.
+ExecStart=__MESH_HOME__/meshcenter/venv/bin/gunicorn -c __MESH_HOME__/meshcenter/gunicorn.conf.py wsgi:app
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,72 @@
+"""Gunicorn configuration for MeshCenter (deploy/meshcenter.service runs
+`gunicorn -c gunicorn.conf.py wsgi:app`). Gunicorn loads this file
+automatically from the current directory when -c points at it - see
+WorkingDirectory in the systemd unit.
+
+config.py stays the single source of truth for host/port, same as when
+running `python server.py` directly - this file reads APP_HOST/APP_PORT
+from it rather than hardcoding them here or in the systemd unit.
+"""
+
+from config import APP_HOST, APP_PORT
+
+bind = f"{APP_HOST}:{APP_PORT}"
+
+# Exactly one worker process, always. This is not a performance choice -
+# MeshCenter's entire runtime state (nodes/chats/messages/settings) lives in
+# one process's memory behind server.py's state_lock, and start_runtime()
+# opens the Meshtastic radio's serial port exclusively. A second worker
+# process would run its own start_runtime() and try to open the SAME serial
+# port at the same time - a race for the device, not just wasted resources.
+# server.py's own _runtime_started flag (PR #66) only guards against calling
+# start_runtime() twice *within one process*; it can't see a second gunicorn
+# worker process at all, which is why start_runtime() also takes an
+# OS-level file lock (see server.py's RUNTIME_LOCK_FILE / _acquire_runtime_lock)
+# as a second, independent line of defense in case `workers` is ever
+# overridden by a stray CLI flag or a future config edit.
+workers = 1
+
+# gthread, not the sync default: /video_feed (api/api_camera.py) is a
+# long-lived MJPEG stream (multipart/x-mixed-replace) that stays open for as
+# long as someone's watching the camera. A sync worker handles exactly one
+# connection at a time for the whole worker process, so one person watching
+# the camera would block every other request - chat polling, node list,
+# telemetry, everything - until they closed the tab. gthread runs each
+# request in its own thread within the single worker process, so a live
+# video stream and ordinary API traffic can proceed concurrently. Verified
+# live on hardware, not just reasoned about - see the PR description.
+worker_class = "gthread"
+
+# MeshCenter is a LAN app for a handful of browser tabs, not an
+# internet-facing service - this isn't sized for high concurrency. It's
+# sized against chat.js's own polling behavior: a single open tab already
+# keeps several endpoints in flight on a short cycle (system info,
+# cpu-history, base_status, messages, chats, notifications, telemetry,
+# radio_health, system log, ...), and one of those "requests" can be the
+# long-lived /video_feed stream sitting in its own thread for minutes.  4
+# threads would mean one video viewer alone leaves only 3 threads for every
+# other request from every other tab; 8 gives real headroom for a couple of
+# people using MeshCenter at once without costing much - threads share the
+# single worker process's memory, they're not separate Python interpreters.
+threads = 8
+
+# Gunicorn's default (30s) is a heartbeat timeout for the whole worker
+# process, not a per-request cap - but a gthread worker's heartbeat loop can
+# still be starved if every thread is busy, and a slow/idle-but-open stream
+# was worth erring generous on rather than assuming the default is fine.
+# Bumped to 120s and verified live against a multi-minute real /video_feed
+# stream on hardware (see PR description for what was actually observed) -
+# adjust here if that ever changes.
+timeout = 120
+
+# Deliberately NOT set: max_requests / max_requests_jitter (gunicorn's
+# worker-recycling). That would restart the single worker process
+# periodically - including whatever the radio listener subprocess and
+# serial port were doing at that moment - and graceful reopen-of-serial-port
+# behavior across a recycle hasn't been tested. Revisit only as a deliberate
+# decision, not a default to silently turn on.
+
+# StandardOutput=journal / PYTHONUNBUFFERED=1 in the systemd unit already
+# get server.py's own print() logging into journalctl - gunicorn's own
+# access/error logs go to stderr by default, which the unit also captures,
+# so no separate logging config is added here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,10 @@ psutil>=5.9.0
 # PyPI as of 2026-08) - this range covers both without floating past 2.7.
 meshtastic>=2.7.9,<2.8.0
 v4l2py>=3.0.0
+# Production WSGI server (see gunicorn.conf.py / deploy/meshcenter.service).
+# Pinned to the 23.x line - gunicorn's own worker/arbiter internals (the
+# gthread worker class specifically, which /video_feed's long-lived MJPEG
+# stream depends on for not blocking the rest of the app - see
+# gunicorn.conf.py) are exactly the kind of thing a major version bump could
+# change without MeshCenter's own code ever noticing until it's live.
+gunicorn>=23.0.0,<24.0.0

--- a/server.py
+++ b/server.py
@@ -18,6 +18,14 @@ import uuid
 import ast
 import sqlite3
 import secrets
+try:
+    import fcntl  # POSIX only - always present on the Pi/Linux this app runs
+    # on in production. Absent on Windows, where a developer might still
+    # `import server` for tests (see tests/conftest.py) without ever
+    # actually running the service - _acquire_runtime_lock() below degrades
+    # to a no-op rather than crashing that import in that case.
+except ImportError:
+    fcntl = None
 from pathlib import Path
 from contextlib import contextmanager
 from collections import defaultdict, deque
@@ -371,6 +379,12 @@ app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(days=7)
 # first run, so a generic settings.json save can never silently wipe it.
 AUTH_FILE = os.path.join(DATA_DIR, "auth.json")
 auth_state = load_auth_state(AUTH_FILE, AUTH_ENABLED, AUTH_PASSWORD_HASH)
+
+# OS-level guard against two MeshCenter processes both running
+# start_runtime() at once - see that function's own acquire call and
+# _acquire_runtime_lock() near it below for why this exists alongside the
+# in-process _runtime_started flag.
+RUNTIME_LOCK_FILE = os.path.join(DATA_DIR, "runtime.lock")
 
 def handle_errors(f):
     """Декоратор для обработки ошибок в API"""
@@ -5831,6 +5845,54 @@ def api_system_cpu_history():
 # ============================================================
 
 _runtime_started = False
+_runtime_lock_handle = None
+
+def _acquire_runtime_lock():
+    """OS-level guard against two MeshCenter processes both calling
+    start_runtime() at once - e.g. gunicorn accidentally run with more than
+    one worker (see gunicorn.conf.py's own comment on why workers=1 is
+    mandatory, not a performance knob). Two processes each opening the same
+    Meshtastic serial port is a race for the device and for the in-memory
+    state every route reads/writes, not just wasted resources.
+
+    This is a second, independent line of defense: server.py's
+    _runtime_started flag above only stops a second call *within the same
+    process* (e.g. an accidental double-call) - it's a fresh False in every
+    new process, so it can't see a second gunicorn worker at all. An
+    exclusive, non-blocking flock() on a file under DATA_DIR can, because
+    the lock is visible across processes on the same machine.
+
+    Holds the lock for the lifetime of the process by keeping the file
+    descriptor open in the module-level _runtime_lock_handle - closing it
+    (including via garbage collection) would release the OS-level lock, so
+    it must not be allowed to go out of scope.
+    """
+    global _runtime_lock_handle
+    if fcntl is None:
+        print(
+            "[INIT] fcntl unavailable on this platform - OS-level runtime "
+            "lock skipped (expected only off Linux; production always runs "
+            "on the Pi).",
+            flush=True,
+        )
+        return
+
+    os.makedirs(DATA_DIR, exist_ok=True)
+    handle = open(RUNTIME_LOCK_FILE, "w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        print(
+            "[FATAL] Another MeshCenter process already holds the radio - "
+            "refusing to start a second listener.",
+            flush=True,
+        )
+        sys.exit(1)
+
+    handle.write(f"{os.getpid()}\n")
+    handle.flush()
+    _runtime_lock_handle = handle
 
 def start_runtime():
     """Runs everything server.py needs before it can actually serve traffic:
@@ -5854,6 +5916,7 @@ def start_runtime():
     if _runtime_started:
         print("[INIT] start_runtime() already ran in this process - skipping.", flush=True)
         return
+    _acquire_runtime_lock()
     _runtime_started = True
 
     # Verify the physical radio before loading or mutating radio-profile data.

--- a/tests/test_runtime_lock.py
+++ b/tests/test_runtime_lock.py
@@ -1,0 +1,72 @@
+"""Tests for server.py's OS-level runtime lock (_acquire_runtime_lock()) -
+the second, cross-process line of defense against two MeshCenter processes
+both calling start_runtime() at once (e.g. gunicorn misconfigured with more
+than one worker - see gunicorn.conf.py's own comment on why workers=1 is
+mandatory). The in-process `_runtime_started` guard added in PR #66 only
+stops a second call within the same process; it starts False again in every
+new process, so it can't see a second one.
+
+Skipped entirely where fcntl (POSIX flock) isn't available (e.g. a Windows
+dev box running the suite) - server.py itself degrades
+_acquire_runtime_lock() to a no-op there rather than crashing the import
+(this application only ever runs on Linux/the Pi in production).
+"""
+
+import os
+
+import pytest
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+
+pytestmark = pytest.mark.skipif(
+    fcntl is None, reason="fcntl (POSIX flock) is not available on this platform"
+)
+
+
+def test_acquire_runtime_lock_fails_loudly_when_already_held(server_module, capsys):
+    # Simulate a second MeshCenter process already holding the lock by
+    # locking the same file ourselves first, through a separate open file
+    # description. flock() (unlike fcntl's POSIX record locks, confusingly
+    # also reachable through the `fcntl` module) conflicts across distinct
+    # open file descriptions even within a single process - so this
+    # genuinely exercises the same contention a second real OS process
+    # would hit, not a fake stand-in for it.
+    os.makedirs(os.path.dirname(server_module.RUNTIME_LOCK_FILE), exist_ok=True)
+    blocker = open(server_module.RUNTIME_LOCK_FILE, "w")
+    fcntl.flock(blocker.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            server_module._acquire_runtime_lock()
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "FATAL" in captured.out
+        assert "Another MeshCenter process" in captured.out
+    finally:
+        fcntl.flock(blocker.fileno(), fcntl.LOCK_UN)
+        blocker.close()
+
+
+def test_acquire_runtime_lock_succeeds_when_free(server_module):
+    server_module._runtime_lock_handle = None
+    try:
+        server_module._acquire_runtime_lock()
+        assert server_module._runtime_lock_handle is not None
+        # Confirm it's a *real* held lock, not just a set variable - a
+        # second acquire attempt (simulating another process) must now
+        # fail exactly like the test above.
+        second_handle = open(server_module.RUNTIME_LOCK_FILE, "w")
+        try:
+            with pytest.raises(OSError):
+                fcntl.flock(second_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        finally:
+            second_handle.close()
+    finally:
+        if server_module._runtime_lock_handle:
+            server_module._runtime_lock_handle.close()
+            server_module._runtime_lock_handle = None

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,9 +14,12 @@ from server import app, start_runtime
 # If gunicorn (or uwsgi) is run with more than one worker process, each
 # worker process runs this module-level code independently and would start
 # its own radio listener - only one process may own the serial port at a
-# time. Production deployment via gunicorn (not yet wired into
-# deploy/meshcenter.service - the systemd unit still runs `python server.py`
-# directly) must use exactly one worker: `gunicorn --workers 1 wsgi:app`.
+# time. deploy/meshcenter.service now runs this under gunicorn with
+# `workers = 1` hardcoded in gunicorn.conf.py - never override that. As a
+# second, independent line of defense in case it ever is,
+# server.py's start_runtime() also takes an OS-level file lock
+# (_acquire_runtime_lock()) that makes a second worker process fail loudly
+# instead of silently racing the first one for the serial port.
 start_runtime()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`server.py` currently ends its `__main__` block with `app.run(...)` directly - the Werkzeug dev server, not intended for production - because `deploy/meshcenter.service` runs `python server.py`. `wsgi.py` has been import-ready for a real WSGI server since PR #66 (`start_runtime()` called explicitly at import time). This PR actually cuts systemd over to gunicorn.

## MeshCenter-specific constraints (not generic Flask+gunicorn advice)

- **Exactly one worker process, ever.** The radio listener owns the serial port exclusively and all runtime state (nodes/chats/messages/settings) lives in one process's memory behind `state_lock`. A second worker means a second `start_runtime()` racing the first for the same serial port.
- **`/video_feed`** (`api/api_camera.py`) is a long-lived MJPEG stream. gunicorn's default `sync` worker handles one connection at a time for the whole process - one camera viewer would block everyone else.
- **`_runtime_started`** (PR #66) only stops a second call *within one process* - it's blind to a second gunicorn worker entirely, hence the new OS-level lock below.

## Changes

- **`requirements.txt`**: `gunicorn>=23.0.0,<24.0.0`, pinned to the major line with a comment on why (gthread worker internals are exactly what a major bump could change under us).

- **`gunicorn.conf.py`** (new): `bind` reads `APP_HOST`/`APP_PORT` from `config.py` (single source of truth, unchanged from `python server.py`). `workers = 1` with an explicit in-file comment on why - a correctness requirement, not a performance choice - pointing at the OS-level lock as the second line of defense. `worker_class = "gthread"`, `threads = 8` - sized against `chat.js`'s own polling behavior (several endpoints in flight per open tab) rather than raw load, since this is a LAN app for a handful of browsers. `timeout = 120` - bumped from gunicorn's 30s default and **verified live** (see below). Deliberately did **not** add `max_requests`/`max_requests_jitter` (worker recycling) - restarting the one worker mid-operation would restart the radio listener, and graceful serial-port reopen across a recycle hasn't been tested; flagging as a future decision, not defaulting it on.

- **`server.py`**: `_acquire_runtime_lock()` - an OS-level exclusive non-blocking `flock()` on a new `data/runtime.lock`, called from `start_runtime()` right after the in-process `_runtime_started` check. A second process fails loudly: `[FATAL] Another MeshCenter process already holds the radio - refusing to start a second listener.` + `sys.exit(1)`. `import fcntl` is wrapped in try/except - `fcntl` is POSIX-only, and `tests/conftest.py`'s whole point is letting `import server` succeed without a Pi, including on a non-Linux dev box; the lock degrades to a logged no-op there instead of crashing that import.

- **`tests/test_runtime_lock.py`** (new, 2 tests, skipped on non-POSIX): simulates a second process holding the lock via a second, independent open file description on the same file - `flock()` conflicts across distinct open file descriptions even within one process (unlike `fcntl`'s POSIX record locks, confusingly reachable through the same module, which are per-process and would *not* self-conflict this way) - so this genuinely exercises the same contention a second real OS process would hit.

- **`deploy/meshcenter.service`**: `ExecStart` now runs `gunicorn -c .../gunicorn.conf.py wsgi:app`. `WorkingDirectory` (already set) is what makes gunicorn auto-load `gunicorn.conf.py` and resolve `wsgi:app`. **Rollback** is documented directly in the unit file as a one-line `ExecStart` edit back to `python .../server.py` + `daemon-reload` + restart - `server.py`'s direct-run path is untouched.

- **`wsgi.py`**: comment updated now that the systemd unit actually uses it.

## Verification on real hardware (dev = 192.168.2.104, all items performed, not simulated)

**(a) Concurrency** - started a `/video_feed` pull in the background, then fired API requests (`base_status`, `chats`, `nodes_management`, `messages`, `system/info`, `radio_health`, plus a `POST /api/toggle_favorite` write) while it was actively streaming. All API calls returned in **0.07-0.5s**, no blocking. Repeated on camtest too (0.009s for `base_status` while streaming).

**(b) Serial port release** - `systemctl stop`/`start` cycled **3 times** in a row. Each stop: `fuser /dev/ttyACM0` reported no process holding it (clean release). Each start: `[IDENTITY] Status: MATCH` + `HTTP:200` within ~8s, every time.

**(c) Multi-worker guard** - set `workers = 2` in `gunicorn.conf.py` on dev and restarted. Real log output:
```
[FATAL] Another MeshCenter process already holds the radio - refusing to start a second listener.
[ERROR] Worker (pid:55334) exited with code 1
```
gunicorn kept respawning a second worker to satisfy `workers=2`, and **every single attempt** failed the same way loudly, while the first (legitimate) worker kept running normally the whole time - no silent double-listener, no corrupted state. Reverted to `workers = 1` and restarted clean immediately after.

**(d) Soak + timeout verification** - ran for **15 minutes** under simulated normal use (repeated API polling bursts simulating open tabs). RSS: 122.5MB -> 126.6MB (4.5min) -> 138.8MB (14min) -> 138.8MB (15min, flat) - modest, plateauing growth, not a leak trajectory. No errors/tracebacks in the journal the whole time. Also ran a **150-second** continuous `/video_feed` pull (deliberately longer than the 120s `timeout` setting) - it stayed alive the entire time (28.25MB streamed, ended only by my own client-side cutoff, not a server-side kill) - confirms gunicorn's `timeout` is a worker heartbeat, not a per-request cap, exactly as the gthread model requires.

**Log visibility** - `PYTHONUNBUFFERED=1` confirmed empirically, not assumed: `[VERSION]`, `[INIT]`, `[INSTANCE]`, `[IDENTITY]`, `[CAMERA]`, `[Schedule]` and the startup banner all appear in `journalctl -u meshcenter` immediately under gunicorn, same as under `python server.py`.

**(e) Deployment**:
- **dev** - fully deployed, all of (a)-(d) above performed here.
- **camtest** - deployed, restarted, confirmed `IDENTITY Status: MATCH`, `HTTP:200`, and a concurrency spot-check (fast API response while `/video_feed` streamed for 20s).
- **prod** - code pulled and `gunicorn` installed in its venv, but **the systemd unit could not be updated**: prod's sudoers is intentionally narrowly scoped (only `systemctl restart/reboot/poweroff` + `iw`/`nmcli`, no write access to `/etc/systemd/system/` or `daemon-reload`) - see CLAUDE.md's own note on prod's scoped sudo. prod is currently **unaffected and still running the old `python server.py` command** - no regression, just not yet cut over. Cutting it over needs either a person with full sudo on prod to run the same `sed | sudo tee ... && sudo systemctl daemon-reload && sudo systemctl restart meshcenter` sequence used on dev/camtest, or a deliberate, separate decision to extend prod's sudoers to cover this (not done here, per the task's own scope boundary).

## Rollback

One-line edit in `/etc/systemd/system/meshcenter.service` (documented in the unit file itself):
```
ExecStart=__MESH_HOME__/meshcenter/venv/bin/python __MESH_HOME__/meshcenter/server.py
```
then `sudo systemctl daemon-reload && sudo systemctl restart meshcenter`. No git revert needed - `server.py`'s direct-run path was never touched.

## Out of scope (per the task)

No further `server.py` refactor beyond PR #66, no worker recycling enabled, `workers` stays at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
