### PR TITLE
docs: catch up CLAUDE.md and README on PR #62-#69 (tests, auth, gunicorn)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MeshCenter is a Flask web control center for a Meshtastic LoRa radio attached to
 
 ## Running it
 
-There is no build step, package.json, linter config, or test suite in this repo — don't invent `npm run`, `pytest`, or lint commands that don't exist here.
+There is no build step, package.json, or linter config in this repo — don't invent `npm run` or lint commands that don't exist here. There **is** a pytest test suite (`tests/`, `pytest.ini`) and a GitHub Actions CI workflow (`.github/workflows/ci.yml`) — see "Testing" below.
 
 ```bash
 python3 -m venv --system-site-packages venv   # --system-site-packages required for Picamera2 on the Pi
@@ -20,12 +20,23 @@ mkdir -p data
 
 python server.py                               # dev run, http://<host>:5000
 # or, in production:
-sudo systemctl restart meshcenter.service       # see deploy/meshcenter.service
+sudo systemctl restart meshcenter.service       # runs gunicorn - see "Deployment" below
 ```
 
 `config.py` and `weather_secrets.py` are gitignored local files; `server.py` exits at import time if `config.py` is missing or missing required variables (see the `required_vars` check near the top of `server.py`). When changing code that reads config, check `config.example.py` for the authoritative variable list.
 
-Manual verification is normally done against a real or simulated radio (`meshtastic --port <dev> --info`) and by exercising the REST endpoints/UI in a browser — there's no automated test harness to run instead.
+### Testing
+
+```bash
+pip install -r requirements-dev.txt   # adds pytest on top of requirements.txt - never installed on a production Pi
+pytest                                 # run from the repo root; picks up pytest.ini automatically
+```
+
+`tests/conftest.py` makes `server.py` importable without a Pi or a radio attached (a synthetic `config.py`, a fake Meshtastic CLI/serial port, a stub for the Pi-only `libcamera` import) - it does **not** start `start_runtime()`'s background threads/radio listener, so the suite is safe to run anywhere, including CI. As of PR #69 this covers CLI-output parsing, `normalize_settings()`, node ID validation, `sanitize_text()`, the auth/message-queue/radio-identity/profile-manager logic, and the gunicorn runtime lock - not full end-to-end coverage, but a real regression net. Run `pytest` locally before opening a PR.
+
+`.github/workflows/ci.yml` runs on every PR and push to `main`: `python -m compileall` (all Python), `bash -n` on every installer/deploy shell script, `node --check` on the non-vendored `static/*.js` files, then `pytest`. It does not run linters (none configured) or touch real hardware.
+
+Beyond that, manual verification against a real or simulated radio (`meshtastic --port <dev> --info`) and exercising the REST endpoints/UI in a browser is still how anything touching the actual radio listener, camera, or e-Paper hardware gets validated - the test suite deliberately doesn't attempt to fake real hardware I/O for those.
 
 ## Architecture
 
@@ -85,4 +96,10 @@ Routes are split between `server.py` (nodes, chats, waypoints, telemetry, system
 
 ## Deployment
 
-`deploy/meshcenter.service` is a template (`__MESH_USER__` / `__MESH_HOME__` placeholders filled via `sed` at install time, see README step 8) for running under systemd. Its `ExecStart` runs `python server.py` directly — that means production actually serves requests through Flask's built-in Werkzeug dev server (`app.run(..., debug=False, threaded=True)` at the bottom of `server.py`), not through a real WSGI server. `wsgi.py` (`from server import app`) exists and is correctly importable, but nothing in this deployment path invokes it via Gunicorn/uWSGI/Waitress — it is currently dead code, not the production entrypoint its own docstring claims. `debug=False` keeps the interactive debugger (the actual RCE-risk part of the dev server) off, and this is a LAN-only single-user deployment, so the practical exposure is limited — but don't describe `wsgi.py` as "the" production entrypoint elsewhere in this repo until something in `deploy/` actually runs it that way. `deploy/meshcenter.sudoers` and `deploy/meshcenter-wifi.sudoers` grant the narrowly-scoped sudo rules needed for the in-app system actions (restart/reboot/shutdown) and Wi-Fi management (NetworkManager) respectively — extend these rather than widening sudo access when adding new privileged actions.
+`deploy/meshcenter.service` is a template (`__MESH_USER__` / `__MESH_HOME__` placeholders filled via `sed` at install time, see INSTALL.md) for running under systemd. As of PR #69, its `ExecStart` runs `gunicorn -c gunicorn.conf.py wsgi:app`, not `python server.py` directly - production is a real WSGI server now, not Flask's Werkzeug dev server. `wsgi.py` does `from server import app, start_runtime` and calls `start_runtime()` explicitly at import time, since a WSGI server never executes `server.py`'s own `if __name__ == "__main__":` block.
+
+`gunicorn.conf.py` (repo root, loaded automatically by `-c` + `WorkingDirectory`) hardcodes `workers = 1` - not a performance choice, a correctness requirement. The radio listener owns the serial port exclusively and all runtime state (`nodes`/`chats`/`messages`/`settings`) lives in one process's memory behind `state_lock`; a second worker process would run its own `start_runtime()` and race the first for the same serial port. `start_runtime()` also takes an OS-level `flock()` on `data/runtime.lock` (`_acquire_runtime_lock()` in `server.py`) as a second, independent guard in case `workers` is ever overridden - a second process fails loudly (`[FATAL] ...`) instead of silently corrupting state. `worker_class = "gthread"` (not the `sync` default) is what lets `/video_feed`'s long-lived MJPEG stream coexist with ordinary API traffic instead of blocking the whole process for whoever's watching the camera.
+
+Rollback to the old direct-run command is a one-line `ExecStart` edit, documented in `deploy/meshcenter.service` itself; `python server.py` still works exactly as before for local/manual runs, `start_runtime()`/`app.run()` unchanged.
+
+`deploy/meshcenter.sudoers` and `deploy/meshcenter-wifi.sudoers` grant the narrowly-scoped sudo rules needed for the in-app system actions (restart/reboot/shutdown) and Wi-Fi management (NetworkManager) respectively — extend these rather than widening sudo access when adding new privileged actions.

--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ MeshCenter is built with a lightweight and practical technology stack:
 
 - Python
 - Flask
+- Gunicorn (production WSGI server)
 - HTML5
 - CSS3
 - JavaScript
@@ -1297,6 +1298,8 @@ MeshCenter consists of several independent modules that work together.
 
 The browser never communicates directly with the Meshtastic node. All communication is handled by the Flask application, which coordinates the different subsystems.
 
+In production, requests reach the Flask application through [Gunicorn](https://gunicorn.org/) (see `gunicorn.conf.py` / `wsgi.py`), not shown separately above to keep the diagram focused on MeshCenter's own subsystems.
+
 ---
 
 ## Data Storage
@@ -1384,6 +1387,12 @@ GET    /api/updates/preflight
 POST   /api/updates/apply
 
 GET    /api/weather/current
+
+GET    /api/security
+POST   /api/security
+GET    /login
+POST   /login
+POST   /api/logout
 ```
 
 The API is primarily intended for the built-in web interface, but it also allows future integrations with third-party applications.
@@ -1423,7 +1432,14 @@ Current security model:
 
 If remote access is required, it is recommended to use a VPN or another secure tunnel instead of exposing the web interface directly to the Internet.
 
-Future versions may include optional authentication.
+### Optional password protection
+
+MeshCenter can be protected with a single shared password - **Settings → Security**. It's a single on/off switch, not a multi-user system: one password guards the entire application (every API route, including `restart`/`reboot`/`shutdown` and Wi‑Fi management), not individual users or features.
+
+- **Off by default.** Existing installs and fresh installs both start unprotected - nothing changes until you set a password and turn it on.
+- When enabled, an unauthenticated browser is redirected to a login page (`/login`); unauthenticated API requests get `401`. Static assets and the login page itself stay reachable so the login form can render.
+- The password is hashed (`werkzeug.security`, never stored in plain text) in `data/auth.json`, not in `config.py` or `settings.json` - it isn't wiped by an unrelated settings save and never comes back in a settings API response.
+- This is one shared secret for the whole app, not per-user accounts - it doesn't replace a VPN for remote access, it's meant to reduce exposure on a shared or guest local network.
 
 ---
 
@@ -1712,6 +1728,8 @@ Contributions are welcome.
 If you find a bug, have an idea for an improvement or would like to contribute code, please open an Issue or submit a Pull Request.
 
 Suggestions for improving the documentation are also greatly appreciated.
+
+Before opening a Pull Request, install `requirements-dev.txt` and run `pytest` from the repo root - it's quick (well under a minute) and catches regressions in the areas it covers (CLI-output parsing, settings normalization, node ID validation, auth, and more - see `tests/`). GitHub Actions CI runs the same suite plus `python -m compileall`, `bash -n` on the installer scripts, and `node --check` on `static/*.js` on every PR and push to `main`, so it'll be checked either way - running it locally first just means you find out sooner.
 
 ### Reporting Issues
 


### PR DESCRIPTION
## Summary

Pure documentation - no `.py`/`.js`/`.sh` file touched. Catches `CLAUDE.md` and `README.md` up on real, shipped work from PR #62-#69 that had gone undocumented (or was documented incorrectly).

### 1. CLAUDE.md (most important fix)

> "There is no build step, package.json, linter config, or test suite in this repo"

False as of PR #64 - there's a pytest suite (77 tests), `pytest.ini`, `requirements-dev.txt`, and a GitHub Actions CI workflow. This line is read by every future AI session working in this repo (including whoever plans the next task) - left as-is, it actively risks a future session skipping the existing tests before making changes, believing none exist.

Replaced with a new **"Testing"** subsection: how to install/run pytest locally, what `tests/conftest.py`'s hardware-free import shim covers (and deliberately doesn't), what `ci.yml` actually checks, and an explicit "run pytest before opening a PR."

Also fixed the adjacent "there's no automated test harness to run instead" line (same false premise), and rewrote the entire **"Deployment"** section, which still described the pre-PR#69 state in detail - Werkzeug dev server, `wsgi.py` called "dead code," "don't describe `wsgi.py` as the production entrypoint until something in `deploy/` actually runs it that way." That condition is now true, so the section describes `gunicorn.conf.py`, the `workers = 1` requirement, and the OS-level runtime lock as they actually exist post-#69.

### 2. README.md "## Security"

Replaced "Future versions may include optional authentication" (shipped in PR #63) with a real description - how to enable it (Settings → Security), what it protects (every API route, including restart/reboot/shutdown and Wi‑Fi), that it's off by default, and that it's one shared password for the whole app, not a multi-user system. The existing VPN-for-remote-access recommendation is left in place since it's still accurate and this doesn't replace it.

### 3. README.md "## Tech Stack"

Added Gunicorn (production WSGI server).

### 4. README.md "## Application Architecture"

Added one sentence noting Gunicorn sits between the browser and the Flask application in production, without redrawing the existing ASCII diagram - it's already a simplification of MeshCenter's own subsystems, not a literal network topology, so gunicorn didn't need its own box in it.

### 5. README.md "## Contributing"

Added a short paragraph: install `requirements-dev.txt` and run `pytest` locally before opening a PR, and that CI runs the same suite (plus `compileall`/`bash -n`/`node --check`) either way.

### 6. README.md "## REST API" (optional item - done)

Added `GET/POST /api/security`, `GET/POST /login`, `POST /api/logout` to the example endpoint list, matching the existing GET/POST-pair formatting already used for other routes there.

### 7. README.md "## Version History" - deliberately NOT touched, needs your decision

A version number is a release/process decision, not a documentation fact I should assert unilaterally. I did **not** add a row to the table. If you'd like one, here's a draft for you to adjust or use as-is:

```
| v1.8.0 | Security hardening, test suite + CI, gunicorn production server |
```

That's meant to summarize PR #62-#69 (stored-XSS fixes, optional password protection, pytest + GitHub Actions CI, installer parity, wsgi.py lifecycle fix, gunicorn cutover) in one line matching the table's existing style - but the version number, wording, and even whether this warrants its own row (vs. folding into whatever the next release's line ends up being) are entirely your call. Happy to add it in a follow-up once you decide.

## Verification

- `python -m pytest`: 75 passed, 2 skipped (unrelated - `fcntl` unavailable on this dev sandbox's OS) - unaffected by a docs-only change, just confirming nothing broke.
- Scanned both files end to end (not just the sections named in the task) for the same class of staleness - grepped for "no test", "no automated", "Werkzeug", "dev server", "future versions may include...authentication" and similar - no other stale claims found beyond what's listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
