### PR TITLE
🛡️ Sentinel: Fix command option injection in Wi-Fi SSID endpoints

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -327,11 +327,12 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
     @app.route("/api/system/wifi/connect", methods=["POST"])
     def api_system_wifi_connect():
-        data = request.get_json(force=True)
-        ssid = (data.get("ssid") or "").strip()
-        password = data.get("password") or ""
-        if not ssid:
-            return jsonify({"ok": False, "error": "SSID is required"}), 400
+        data = request.get_json(silent=True) or {}
+        raw_ssid = str(data.get("ssid") or "")
+        ssid = raw_ssid.strip()
+        password = str(data.get("password") or "")
+        if not ssid or ssid.startswith("-") or any(ord(c) < 32 or ord(c) == 127 for c in raw_ssid):
+            return jsonify({"ok": False, "error": "Invalid SSID"}), 400
         def run_nmcli(args, timeout=30):
             return subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli"] + args, text=True, stderr=subprocess.STDOUT, timeout=timeout)
         try:
@@ -344,7 +345,7 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
             err = e.output.strip() if e.output else str(e)
             if "key-mgmt" in err or "property is missing" in err or "secrets were required" in err:
                 try:
-                    run_nmcli(["connection", "delete", ssid], timeout=10)
+                    run_nmcli(["connection", "delete", "--", ssid], timeout=10)
                 except Exception:
                     pass
                 try:
@@ -361,12 +362,13 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
     @app.route("/api/system/wifi/forget", methods=["POST"])
     def api_system_wifi_forget():
-        data = request.get_json(force=True)
-        ssid = (data.get("ssid") or "").strip()
-        if not ssid:
-            return jsonify({"ok": False, "error": "SSID is required"}), 400
+        data = request.get_json(silent=True) or {}
+        raw_ssid = str(data.get("ssid") or "")
+        ssid = raw_ssid.strip()
+        if not ssid or ssid.startswith("-") or any(ord(c) < 32 or ord(c) == 127 for c in raw_ssid):
+            return jsonify({"ok": False, "error": "Invalid SSID"}), 400
         try:
-            out = subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli", "connection", "delete", ssid], text=True, stderr=subprocess.STDOUT, timeout=15)
+            out = subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli", "connection", "delete", "--", ssid], text=True, stderr=subprocess.STDOUT, timeout=15)
             return jsonify({"ok": True, "message": out.strip()})
         except subprocess.CalledProcessError as e:
             return jsonify({"ok": False, "error": e.output.strip() if e.output else str(e)}), 500

--- a/tests/test_api_system_wifi.py
+++ b/tests/test_api_system_wifi.py
@@ -1,0 +1,51 @@
+"""Tests for Wi-Fi security validation in api/api_system.py.
+
+Verifies that input validation prevents command option injection and control
+character injection when SSID inputs are processed for system Wi-Fi commands.
+"""
+
+
+def test_wifi_connect_rejects_invalid_ssids(server_module):
+    client = server_module.app.test_client()
+
+    # Missing/empty SSID
+    res = client.post("/api/system/wifi/connect", json={"ssid": ""})
+    assert res.status_code == 400
+    assert res.json.get("ok") is False
+
+    # Option injection attempts starting with '-'
+    for invalid_ssid in ("--help", "-f", "--active", "--version", "-a"):
+        res = client.post("/api/system/wifi/connect", json={"ssid": invalid_ssid, "password": "pass"})
+        assert res.status_code == 400
+        assert res.json.get("ok") is False
+        assert res.json.get("error") == "Invalid SSID"
+
+    # Control character injection attempts
+    for invalid_ssid in ("MyWiFi\x00", "MyWiFi\nInjected", "MyWiFi\rInjected"):
+        res = client.post("/api/system/wifi/connect", json={"ssid": invalid_ssid})
+        assert res.status_code == 400
+        assert res.json.get("ok") is False
+        assert res.json.get("error") == "Invalid SSID"
+
+
+def test_wifi_forget_rejects_invalid_ssids(server_module):
+    client = server_module.app.test_client()
+
+    # Missing/empty SSID
+    res = client.post("/api/system/wifi/forget", json={"ssid": ""})
+    assert res.status_code == 400
+    assert res.json.get("ok") is False
+
+    # Option injection attempts starting with '-'
+    for invalid_ssid in ("--help", "-f", "--delete", "-r"):
+        res = client.post("/api/system/wifi/forget", json={"ssid": invalid_ssid})
+        assert res.status_code == 400
+        assert res.json.get("ok") is False
+        assert res.json.get("error") == "Invalid SSID"
+
+    # Control character injection attempts
+    for invalid_ssid in ("HomeNet\x00", "HomeNet\n", "HomeNet\r"):
+        res = client.post("/api/system/wifi/forget", json={"ssid": invalid_ssid})
+        assert res.status_code == 400
+        assert res.json.get("ok") is False
+        assert res.json.get("error") == "Invalid SSID"


### PR DESCRIPTION
Sanitizes and validates SSID inputs in Wi-Fi API endpoints to prevent command option injection into nmcli and rejects embedded control characters. Adds unit tests covering invalid and malicious SSID inputs.

---
*PR created automatically by Jules for task [1226848385667241975](https://jules.google.com/task/1226848385667241975) started by @FlintUA*