### PR TITLE
🛡️ Sentinel: Fix open redirect vulnerability in login URL redirect

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-17 - Sanitize next_url Parameters to Prevent Open Redirects
+**Vulnerability:** Open redirect vulnerability in `/login` route handler where `next` parameters such as `/\example.com` or `/\\example.com` bypassed `next_url.startswith("/")` and `next_url.startswith("//")` checks in browsers that normalize backslashes to forward slashes.
+**Learning:** Checking only `startswith("/")` and `startswith("//")` is insufficient for `next` URL redirection because browsers handle backslashes (`\`) differently during URL resolution.
+**Prevention:** Always parse `next` URLs using `urllib.parse.urlsplit` to verify that `scheme` and `netloc` are empty, reject URLs containing backslashes (`\`), and ensure the path strictly starts with `/` without leading double slashes or backslashes.

--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -9,7 +9,7 @@ POST /api/settings merge-and-replace in api_settings.py, and the hash is
 never included in a settings.json snapshot handed back to the browser.
 """
 
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from flask import jsonify, redirect, request, render_template, session
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -45,6 +45,33 @@ def is_protected(auth_state):
     # An enabled flag with no usable hash never blocks access - avoids a
     # misconfigured/corrupted auth.json permanently locking out the UI.
     return bool(auth_state.get("enabled")) and bool(str(auth_state.get("password_hash") or "").strip())
+
+
+def sanitize_next_url(next_url):
+    """Ensure next_url is a relative path on the same host to prevent open redirects."""
+    if not isinstance(next_url, str):
+        return "/"
+
+    next_url = next_url.strip()
+
+    # Must start with '/' and not '//' or '/\'
+    if not next_url.startswith("/") or next_url.startswith("//") or next_url.startswith("/\\"):
+        return "/"
+
+    # Backslashes anywhere in the URL can trigger browser-specific domain resolution bypasses
+    if "\\" in next_url:
+        return "/"
+
+    try:
+        parsed = urlsplit(next_url)
+        if parsed.scheme or parsed.netloc:
+            return "/"
+        if not parsed.path.startswith("/") or parsed.path.startswith("//"):
+            return "/"
+    except Exception:
+        return "/"
+
+    return next_url
 
 
 def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, resolve_ui_language=None):
@@ -90,9 +117,7 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
         if not protected:
             return redirect("/")
 
-        next_url = request.values.get("next") or "/"
-        if not next_url.startswith("/") or next_url.startswith("//"):
-            next_url = "/"
+        next_url = sanitize_next_url(request.values.get("next"))
 
         error = None
         if request.method == "POST":

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -8,7 +8,7 @@ import json
 
 from werkzeug.security import generate_password_hash
 
-from api.api_auth import is_protected, load_auth_state
+from api.api_auth import is_protected, load_auth_state, sanitize_next_url
 
 
 def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
@@ -66,3 +66,22 @@ def test_is_protected_tolerates_missing_keys():
     assert is_protected({}) is False
     assert is_protected({"enabled": True}) is False
     assert is_protected({"password_hash": "somehash"}) is False
+
+
+def test_sanitize_next_url_valid():
+    assert sanitize_next_url("/settings") == "/settings"
+    assert sanitize_next_url("/map?node=1234") == "/map?node=1234"
+    assert sanitize_next_url("/") == "/"
+
+
+def test_sanitize_next_url_open_redirect_payloads():
+    assert sanitize_next_url("https://attacker.com") == "/"
+    assert sanitize_next_url("//attacker.com") == "/"
+    assert sanitize_next_url("/\\attacker.com") == "/"
+    assert sanitize_next_url("/\\/attacker.com") == "/"
+    assert sanitize_next_url("http://attacker.com") == "/"
+    assert sanitize_next_url("javascript:alert(1)") == "/"
+    assert sanitize_next_url("///attacker.com") == "/"
+    assert sanitize_next_url("/path\\with\\backslash") == "/"
+    assert sanitize_next_url(None) == "/"
+    assert sanitize_next_url(123) == "/"


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Open Redirect Vulnerability

- **Severity:** HIGH
- **Vulnerability:** Unsanitized `next` URL parameters in `/login` route handler allowed potential open redirect attacks via payloads like `/\example.com` or `/\\example.com`.
- **Impact:** Attackers could construct malicious login links that redirect authenticated users to external phishing sites after logging in.
- **Fix:** Introduced `sanitize_next_url` in `api/api_auth.py` to inspect `next` parameters with `urllib.parse.urlsplit`, ensuring netloc/scheme are empty, backslashes are rejected, and paths strictly begin as valid single-slash relative paths.
- **Verification:** Added comprehensive unit tests in `tests/test_api_auth.py` and verified all 112 pytest tests pass.

---
*PR created automatically by Jules for task [1291408443264080932](https://jules.google.com/task/1291408443264080932) started by @FlintUA*