### PR TITLE
🛡️ Sentinel: [HIGH] Fix open redirect vulnerability in auth login flow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-17 - Open Redirect Vulnerability in Auth Flow
+**Vulnerability:** The login endpoint checked `next_url.startswith("/") and not next_url.startswith("//")` which allowed malicious parameters containing backslashes (e.g. `/\evil.com`) or schemes/netlocs to bypass validation and trigger open redirects after authentication.
+**Learning:** Checking leading slashes alone is insufficient for URL redirect safety because browsers (and WHATWG URL parsing standards) normalize backslashes `\` to forward slashes `/`, transforming `/\host` or `/\\host` into protocol-relative URLs `//host`.
+**Prevention:** Always validate target redirect URLs using `urllib.parse.urlsplit` to ensure no `netloc` or `scheme` exists, and explicitly reject any URL containing backslashes `\` or starting with `//`.

--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -9,7 +9,7 @@ POST /api/settings merge-and-replace in api_settings.py, and the hash is
 never included in a settings.json snapshot handed back to the browser.
 """
 
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from flask import jsonify, redirect, request, render_template, session
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -45,6 +45,18 @@ def is_protected(auth_state):
     # An enabled flag with no usable hash never blocks access - avoids a
     # misconfigured/corrupted auth.json permanently locking out the UI.
     return bool(auth_state.get("enabled")) and bool(str(auth_state.get("password_hash") or "").strip())
+
+
+def _is_safe_next_url(url):
+    """Ensure the target redirect URL is a relative path to prevent Open Redirects.
+
+    Rejects URLs with network locations (domains), schemes, protocol-relative
+    slashes ('//'), or backslashes ('\\') which browsers can normalize to slashes.
+    """
+    if not url or not url.startswith("/") or url.startswith("//") or "\\" in url:
+        return False
+    parts = urlsplit(url)
+    return not parts.netloc and not parts.scheme
 
 
 def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, resolve_ui_language=None):
@@ -91,7 +103,7 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
             return redirect("/")
 
         next_url = request.values.get("next") or "/"
-        if not next_url.startswith("/") or next_url.startswith("//"):
+        if not _is_safe_next_url(next_url):
             next_url = "/"
 
         error = None

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -8,7 +8,7 @@ import json
 
 from werkzeug.security import generate_password_hash
 
-from api.api_auth import is_protected, load_auth_state
+from api.api_auth import _is_safe_next_url, is_protected, load_auth_state
 
 
 def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
@@ -66,3 +66,22 @@ def test_is_protected_tolerates_missing_keys():
     assert is_protected({}) is False
     assert is_protected({"enabled": True}) is False
     assert is_protected({"password_hash": "somehash"}) is False
+
+
+def test_is_safe_next_url_valid_relative_paths():
+    assert _is_safe_next_url("/") is True
+    assert _is_safe_next_url("/map") is True
+    assert _is_safe_next_url("/settings?tab=general") is True
+    assert _is_safe_next_url("/chat#bottom") is True
+
+
+def test_is_safe_next_url_rejects_open_redirects():
+    assert _is_safe_next_url("https://example.com") is False
+    assert _is_safe_next_url("http://example.com") is False
+    assert _is_safe_next_url("//example.com") is False
+    assert _is_safe_next_url(r"/\\example.com") is False
+    assert _is_safe_next_url(r"/\example.com") is False
+    assert _is_safe_next_url(r"/\\/example.com") is False
+    assert _is_safe_next_url("javascript:alert(1)") is False
+    assert _is_safe_next_url("") is False
+    assert _is_safe_next_url(None) is False


### PR DESCRIPTION
### 🚨 Severity: HIGH
### 💡 Vulnerability
The `/login` endpoint in `api/api_auth.py` previously checked whether `next` started with `/` and did not start with `//`. However, browsers (and the WHATWG URL standard) normalize backslashes `\` to forward slashes `/`. Consequently, payload vectors like `/\evil.com` or `/\\evil.com` bypassed the check and triggered external redirects after successful authentication.

### 🔧 Fix
- Added `_is_safe_next_url(url)` in `api/api_auth.py` to validate redirect URLs.
- The validator rejects URLs containing backslashes `\`, protocol-relative slashes `//`, or any `netloc` / `scheme` resolved via `urllib.parse.urlsplit`.
- Fallbacks safely to `/` for invalid redirect targets.

### ✅ Verification
- Added test cases in `tests/test_api_auth.py` covering valid relative paths (`/`, `/map`, etc.) and malicious open redirect payloads (`/\evil.com`, `//evil.com`, `https://evil.com`, etc.).
- Verified the full pytest suite (112 tests passing).

---
*PR created automatically by Jules for task [18153504251144455014](https://jules.google.com/task/18153504251144455014) started by @FlintUA*