### PR TITLE
feat: add I2C subsystem + RTC (DS3231) hardware card (first batch)

### DIFF
--- a/api/api_hardware_i2c.py
+++ b/api/api_hardware_i2c.py
@@ -1,0 +1,64 @@
+"""REST routes for the I2C bus and RTC (DS3231) hardware cards - task 23,
+first batch of the I2C subsystem. Read-only detection lives in
+hardware/i2c_service.py and hardware/rtc_service.py; the two
+reboot-required actions (enabling I2C, adding the RTC overlay) go through
+hardware/hardware_config.py, the only module allowed to call the
+privileged scripts/meshcenter-hw-config helper.
+
+Deliberately modeled after api/api_hardware_display.py's shape (host-local
+hardware, not radio telemetry) rather than the /api/devices list, which
+represents Meshtastic sensor_data received over the mesh - see
+loadPeripheralDevices()'s comment in static/chat.js for that distinction.
+"""
+
+from __future__ import annotations
+
+from flask import jsonify
+
+from hardware import hardware_config, i2c_service, rtc_service
+
+DEFAULT_RTC_MODEL = "ds3231"
+
+
+def register_hardware_i2c_routes(app, handle_errors, data_dir: str):
+    @app.route("/api/hardware/i2c")
+    @handle_errors
+    def api_hardware_i2c_status():
+        hardware_config.reconcile_pending(data_dir)
+        scan = i2c_service.scan_bus()
+        return jsonify({"ok": True, **scan})
+
+    @app.route("/api/hardware/i2c/enable", methods=["POST"])
+    @handle_errors
+    def api_hardware_i2c_enable():
+        result = hardware_config.enable_i2c(data_dir)
+        if not result.get("ok"):
+            return jsonify({"ok": False, "error": result.get("reason", "enable-i2c failed")}), 500
+        return jsonify({"ok": True, "requires_reboot": True})
+
+    @app.route("/api/hardware/i2c/scan", methods=["POST"])
+    @handle_errors
+    def api_hardware_i2c_scan():
+        # i2c_service.scan_bus() never caches - "scan" and the GET status
+        # route both always run a fresh i2cdetect. Separate POST route
+        # exists so the UI can distinguish "load status" from "user asked
+        # for a rescan" (loading-state semantics only), not because the
+        # underlying call differs.
+        scan = i2c_service.scan_bus()
+        return jsonify({"ok": True, **scan})
+
+    @app.route("/api/hardware/rtc")
+    @handle_errors
+    def api_hardware_rtc_status():
+        hardware_config.reconcile_pending(data_dir)
+        status = rtc_service.get_status(model=DEFAULT_RTC_MODEL)
+        pending = hardware_config.get_pending(data_dir)
+        return jsonify({**status, "pending_setup": pending})
+
+    @app.route("/api/hardware/rtc/configure", methods=["POST"])
+    @handle_errors
+    def api_hardware_rtc_configure():
+        result = hardware_config.configure_rtc(data_dir, DEFAULT_RTC_MODEL)
+        if not result.get("ok"):
+            return jsonify({"ok": False, "error": result.get("reason", "configure-rtc failed")}), 500
+        return jsonify({"ok": True, "requires_reboot": True})

--- a/deploy/meshcenter-hw.sudoers
+++ b/deploy/meshcenter-hw.sudoers
@@ -1,0 +1,3 @@
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-hw-config enable-i2c
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-hw-config configure-rtc ds3231
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-hw-config status

--- a/hardware/hardware_config.py
+++ b/hardware/hardware_config.py
@@ -1,0 +1,158 @@
+"""The only module allowed to invoke the privileged
+scripts/meshcenter-hw-config helper (via `sudo -n`) or manage the
+reboot-required pending-setup state that follows a successful enable-i2c/
+configure-rtc call. Nothing else in the codebase should shell out to that
+helper directly or touch data/hardware_pending.json - go through the
+functions here instead.
+
+Reboot-required actions (enabling I2C via a Device Tree parameter, adding
+an RTC overlay) only take effect after the kernel re-reads config.txt on
+the next boot. Between "the helper edited config.txt successfully" and
+"a reboot has actually happened and the change took effect", this module
+tracks a pending-setup record in an instance-scoped JSON file (not
+per-profile - which physical Pi this is running on has nothing to do with
+which Meshtastic radio profile is active) so the UI can tell the user
+"reboot required" without them needing to remember what they clicked
+before rebooting.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from hardware import i2c_service, rtc_service
+from storage.json_store import safe_read_json, safe_write_json
+
+HELPER_PATH = "/usr/local/sbin/meshcenter-hw-config"
+HELPER_TIMEOUT = 15
+
+
+def _run_helper(*args: str) -> dict:
+    """Never raises. `sudo -n` (no interactive prompt) means a missing/
+    misconfigured sudoers rule fails immediately and distinctly rather than
+    hanging the request waiting on a password prompt nobody can answer."""
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", HELPER_PATH, *args],
+            capture_output=True,
+            text=True,
+            timeout=HELPER_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "reason": "sudo is not available on this system"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "reason": f"meshcenter-hw-config timed out after {HELPER_TIMEOUT}s"}
+    except Exception as exc:  # noqa: BLE001 - never raise out of this layer
+        return {"ok": False, "reason": f"meshcenter-hw-config failed: {exc}"}
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "password is required" in stderr.lower() or "a password is required" in stderr.lower():
+            reason = (
+                "sudo is not configured for meshcenter-hw-config - install "
+                "deploy/meshcenter-hw.sudoers (the installer does this automatically)"
+            )
+        else:
+            reason = stderr or f"meshcenter-hw-config exited with code {result.returncode}"
+        return {"ok": False, "reason": reason}
+
+    return {"ok": True, "stdout": (result.stdout or "").strip()}
+
+
+def _pending_path(data_dir: str) -> str:
+    return str(Path(data_dir) / "hardware_pending.json")
+
+
+def _load_pending(data_dir: str) -> dict | None:
+    data = safe_read_json(_pending_path(data_dir), default=None)
+    return data if isinstance(data, dict) and data else None
+
+
+def _save_pending(data_dir: str, action: str, **extra) -> None:
+    record = {"action": action, "set_at": time.time(), **extra}
+    safe_write_json(_pending_path(data_dir), record)
+
+
+def _clear_pending(data_dir: str) -> None:
+    safe_write_json(_pending_path(data_dir), {})
+
+
+def _boot_time_unix() -> float | None:
+    """Seconds-since-epoch the kernel booted, derived from /proc/uptime.
+    None (not an exception) on anything that isn't Linux with /proc, e.g.
+    a developer's Windows box running the test suite - callers treat that
+    the same as "can't tell yet, leave pending alone"."""
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as fh:
+            uptime_seconds = float(fh.readline().split()[0])
+        return time.time() - uptime_seconds
+    except Exception:
+        return None
+
+
+def enable_i2c(data_dir: str) -> dict:
+    result = _run_helper("enable-i2c")
+    if result.get("ok"):
+        _save_pending(data_dir, action="enable_i2c")
+    return result
+
+
+def configure_rtc(data_dir: str, model: str) -> dict:
+    result = _run_helper("configure-rtc", model)
+    if result.get("ok"):
+        _save_pending(data_dir, action="configure_rtc", model=model)
+    return result
+
+
+def helper_status() -> dict:
+    return _run_helper("status")
+
+
+def get_pending(data_dir: str) -> dict | None:
+    """Current pending-setup record, or None if nothing is pending. Does
+    NOT reconcile - call reconcile_pending() first (e.g. once at startup)
+    if you want a stale record auto-resolved before reading it."""
+    return _load_pending(data_dir)
+
+
+def reconcile_pending(data_dir: str, boot_time_unix: float | None = None) -> dict | None:
+    """Checks a pending-setup record (if any) against reality and clears it
+    once a reboot has actually happened since it was recorded. Idempotent -
+    safe to call on every status poll and at every startup; a no-op once
+    nothing is pending.
+
+    boot_time_unix is only ever passed explicitly by tests (to simulate "a
+    reboot happened" without one); production callers rely on the
+    /proc/uptime-derived default.
+
+    Returns None if there was nothing pending, otherwise a dict describing
+    what happened: still waiting (no reboot detected yet), or resolved with
+    a "confirmed" bool saying whether the expected state was actually
+    reached.
+    """
+    pending = _load_pending(data_dir)
+    if pending is None:
+        return None
+
+    boot_time = boot_time_unix if boot_time_unix is not None else _boot_time_unix()
+    set_at = pending.get("set_at")
+    if boot_time is None or not isinstance(set_at, (int, float)) or boot_time <= set_at:
+        # No reboot detected since this was recorded (or we can't tell) -
+        # leave the record in place, still waiting.
+        return {**pending, "resolved": False}
+
+    action = pending.get("action")
+    if action == "enable_i2c":
+        scan = i2c_service.scan_bus()
+        confirmed = bool(scan.get("ok"))
+    elif action == "configure_rtc":
+        model = pending.get("model", "ds3231")
+        status = rtc_service.get_status(model=model)
+        confirmed = bool(status.get("ok") and status.get("stages", {}).get("configured", {}).get("ok"))
+    else:
+        confirmed = False
+
+    _clear_pending(data_dir)
+    return {**pending, "resolved": True, "confirmed": confirmed}

--- a/hardware/i2c_service.py
+++ b/hardware/i2c_service.py
@@ -61,16 +61,36 @@ def scan_bus(bus: int = DEFAULT_BUS) -> dict:
 
 def _parse_i2cdetect_output(output: str) -> list:
     """Parse `i2cdetect -y` table output into a sorted list of "0xNN"
-    address strings. Each non-"--" cell in the table already prints the
-    full address in hex (e.g. the cell at row "60:" column 8 reads "68",
-    which is 0x60 + 8 = 0x68) - no row/column arithmetic needed."""
+    address strings.
+
+    Column position, not the cell's own text, determines the address -
+    verified against real i2cdetect output from a device with an
+    already-bound driver: a claimed address prints "UU" instead of its
+    hex value (e.g. row "60:" column 8 reads "UU", not "68"), and leading
+    reserved addresses print as blank fields rather than "--" (row "00:"
+    leaves columns 0-7 empty on this system's i2c-tools build). Both cases
+    break naive "the cell text already is the address" parsing, so this
+    reads each row as fixed-width 3-character fields instead: row "XX:"
+    is a 4-character prefix (2 hex digits + colon + space), followed by
+    16 columns of "cc " each - address = row_value + column_index,
+    regardless of whether the cell holds a hex value, "UU", or is blank.
+    """
     addresses = []
-    for line in output.splitlines():
-        line = line.strip()
-        if not line or ":" not in line:
+    for raw_line in output.splitlines():
+        line = raw_line.rstrip("\n")
+        if len(line) < 3 or line[2] != ":":
             continue
-        _row_label, _, cells = line.partition(":")
-        for cell in cells.split():
+        row_label = line[:2]
+        try:
+            row_value = int(row_label, 16)
+        except ValueError:
+            continue
+
+        remainder = line[4:]  # skip "XX: "
+        for column in range(16):
+            start = column * 3
+            cell = remainder[start:start + 2].strip()
             if _ADDRESS_CELL_RE.match(cell):
-                addresses.append(f"0x{cell.lower()}")
+                addresses.append(f"0x{row_value + column:02x}")
+
     return sorted(set(addresses))

--- a/hardware/i2c_service.py
+++ b/hardware/i2c_service.py
@@ -1,0 +1,76 @@
+"""Read-only I2C bus detection - a thin, generic wrapper over `i2cdetect`.
+
+Deliberately not RTC-specific: this module only answers "what addresses
+respond on this bus", the same question for any I2C peripheral (RTC,
+INA219/INA226, BME280, ADS1115, MCP23017, ...). Device-specific
+interpretation of an address (e.g. "0x68 is probably a DS3231") lives in
+the device's own module (rtc_service.py for RTC), not here.
+
+Never raises - i2cdetect being absent, the bus not existing, or a timeout
+are all reported as a structured {"ok": False, "reason": ...} result rather
+than an exception, so callers (the API layer) can tell "i2c-tools isn't
+installed" apart from "no device answered" instead of both looking like an
+empty address list.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+
+DEFAULT_BUS = 1
+I2CDETECT_TIMEOUT = 10
+
+_ADDRESS_CELL_RE = re.compile(r"^(?:[0-9a-fA-F]{2}|UU)$")
+
+
+def scan_bus(bus: int = DEFAULT_BUS) -> dict:
+    """Run `i2cdetect -y <bus>` and return detected addresses.
+
+    Returns {"ok": True, "bus": bus, "addresses": ["0x68", ...]} on success,
+    or {"ok": False, "bus": bus, "reason": "..."} if i2cdetect is missing,
+    the bus doesn't exist, the call times out, or anything else goes wrong.
+    "UU" cells (address claimed by an already-bound kernel driver) count as
+    detected - the address responded, that's all this layer answers.
+    """
+    try:
+        result = subprocess.run(
+            ["i2cdetect", "-y", str(bus)],
+            capture_output=True,
+            text=True,
+            timeout=I2CDETECT_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "bus": bus, "reason": "i2cdetect not installed (i2c-tools package missing)"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "bus": bus, "reason": f"i2cdetect timed out after {I2CDETECT_TIMEOUT}s"}
+    except Exception as exc:  # noqa: BLE001 - never raise out of this layer
+        return {"ok": False, "bus": bus, "reason": f"i2cdetect failed: {exc}"}
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return {
+            "ok": False,
+            "bus": bus,
+            "reason": stderr or f"i2cdetect exited with code {result.returncode} (bus {bus} may not exist)",
+        }
+
+    addresses = _parse_i2cdetect_output(result.stdout or "")
+    return {"ok": True, "bus": bus, "addresses": addresses}
+
+
+def _parse_i2cdetect_output(output: str) -> list:
+    """Parse `i2cdetect -y` table output into a sorted list of "0xNN"
+    address strings. Each non-"--" cell in the table already prints the
+    full address in hex (e.g. the cell at row "60:" column 8 reads "68",
+    which is 0x60 + 8 = 0x68) - no row/column arithmetic needed."""
+    addresses = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        _row_label, _, cells = line.partition(":")
+        for cell in cells.split():
+            if _ADDRESS_CELL_RE.match(cell):
+                addresses.append(f"0x{cell.lower()}")
+    return sorted(set(addresses))

--- a/hardware/rtc_service.py
+++ b/hardware/rtc_service.py
@@ -1,0 +1,126 @@
+"""Read-only RTC status - three independent stages, never collapsed into a
+single Online/Offline flag (per the project's own hardware spec):
+
+  1. detected   - the RTC's I2C address answers on the bus (hardware.i2c_service)
+  2. configured - the kernel has bound a Device Tree overlay for it, so
+                   /dev/rtcN exists (dtoverlay=i2c-rtc,<model> took effect -
+                   requires a reboot after being added to config.txt)
+  3. readable   - `hwclock -r` can actually read the time off the device
+
+These three can disagree in informative ways: detected-but-not-configured
+means the overlay hasn't been added/hasn't survived a reboot yet;
+configured-but-not-readable means the kernel bound *some* rtc0 (there can
+only be one at a time) but this call can't read it (permissions, a
+different RTC model already occupying it, etc).
+
+Only DS3231 is a supported model today - RTC_MODELS is the extension point
+for other RTC chips later, not a signal that this module is DS3231-specific
+internally (the three-stage logic below doesn't hardcode 0x68 anywhere
+except through RTC_MODELS).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hardware import i2c_service
+
+HWCLOCK_TIMEOUT = 10
+
+# Extension point for future RTC chips (spec calls out DS1307/PCF8523/etc as
+# possibilities) - only ds3231 is wired up end to end right now, matching
+# scripts/meshcenter-hw-config's own whitelist.
+RTC_MODELS = {
+    "ds3231": {"address": "0x68", "display_name": "DS3231"},
+}
+
+
+def _stage(ok: bool, reason: str | None = None) -> dict:
+    return {"ok": ok, "reason": reason}
+
+
+def _find_rtc_device() -> str | None:
+    """/dev/rtc0 is the canonical primary RTC once a Device Tree overlay
+    binds one - checked directly first since that's the expected case.
+    Falls back to scanning /sys/class/rtc for any rtcN in case rtc0 is
+    occupied by something else (e.g. a USB RTC enumerated first)."""
+    primary = Path("/dev/rtc0")
+    if primary.exists():
+        return str(primary)
+
+    rtc_class_dir = Path("/sys/class/rtc")
+    if rtc_class_dir.is_dir():
+        for entry in sorted(rtc_class_dir.iterdir()):
+            candidate = Path("/dev") / entry.name
+            if candidate.exists():
+                return str(candidate)
+
+    return None
+
+
+def _read_hwclock() -> dict:
+    """Never raises. A garbled/unexpected hwclock output is reported as
+    readable=True with the raw text in `raw_output` rather than parsed into
+    a structured timestamp this module might get wrong - callers that need
+    a real UTC value should use the OS clock (already synced from RTC at
+    boot), not re-parse this text."""
+    try:
+        result = subprocess.run(
+            ["hwclock", "-r"],
+            capture_output=True,
+            text=True,
+            timeout=HWCLOCK_TIMEOUT,
+        )
+    except FileNotFoundError:
+        return _stage(False, "hwclock not installed (util-linux-extra package missing)")
+    except subprocess.TimeoutExpired:
+        return _stage(False, f"hwclock timed out after {HWCLOCK_TIMEOUT}s")
+    except Exception as exc:  # noqa: BLE001 - never raise out of this layer
+        return _stage(False, f"hwclock failed: {exc}")
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return _stage(False, stderr or f"hwclock exited with code {result.returncode}")
+
+    raw_output = (result.stdout or "").strip()
+    stage = _stage(True)
+    stage["raw_output"] = raw_output or None
+    return stage
+
+
+def get_status(model: str = "ds3231", bus: int = i2c_service.DEFAULT_BUS) -> dict:
+    """Full three-stage RTC status for `model` on I2C bus `bus`."""
+    model_info = RTC_MODELS.get(model)
+    if model_info is None:
+        return {
+            "ok": False,
+            "reason": f"unsupported RTC model: {model!r} (supported: {', '.join(sorted(RTC_MODELS))})",
+        }
+
+    address = model_info["address"]
+    scan = i2c_service.scan_bus(bus)
+    if scan.get("ok"):
+        detected = _stage(address in scan.get("addresses", []))
+    else:
+        detected = _stage(False, scan.get("reason"))
+
+    linux_device = _find_rtc_device()
+    configured = _stage(linux_device is not None)
+
+    readable = _read_hwclock() if configured["ok"] else _stage(False, "kernel has not configured an RTC device yet")
+
+    return {
+        "ok": True,
+        "model": model,
+        "display_name": model_info["display_name"],
+        "interface": "i2c",
+        "bus": bus,
+        "address": address,
+        "stages": {
+            "detected": detected,
+            "configured": configured,
+            "readable": readable,
+        },
+        "linux_device": linux_device,
+    }

--- a/install.sh
+++ b/install.sh
@@ -265,6 +265,8 @@ step_system_packages() {
         network-manager \
         iw \
         lsof \
+        i2c-tools \
+        util-linux-extra \
         --no-install-recommends \
         -qq
 
@@ -501,19 +503,31 @@ step_systemd() {
         "${INSTALL_DIR}/deploy/meshcenter.service" \
         | sudo tee /etc/systemd/system/${SERVICE_NAME}.service > /dev/null
 
+    # Install the narrow privileged helper the I2C/RTC hardware card uses to
+    # edit /boot/firmware/config.txt (hardware/hardware_config.py calls it
+    # via `sudo -n` - see scripts/meshcenter-hw-config's own docstring for
+    # why this exists instead of editing that file from the Flask process).
+    sudo install -o root -g root -m 0755 \
+        "${INSTALL_DIR}/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
+
     # Render the repo's sudoers templates (service restart/reboot/poweroff,
-    # plus Wi-Fi management) instead of a partial hand-rolled set — the UI's
-    # System and Wi-Fi actions depend on both being present.
+    # Wi-Fi management, and the hardware-config helper above) instead of a
+    # partial hand-rolled set — the UI's System, Wi-Fi and hardware actions
+    # depend on all three being present.
     sed "s|__MESH_USER__|${MESH_USER}|g" "${INSTALL_DIR}/deploy/meshcenter.sudoers" \
         | sudo tee /etc/sudoers.d/${SERVICE_NAME} > /dev/null
     sed "s|__MESH_USER__|${MESH_USER}|g" "${INSTALL_DIR}/deploy/meshcenter-wifi.sudoers" \
         | sudo tee /etc/sudoers.d/${SERVICE_NAME}-wifi > /dev/null
-    sudo chmod 0440 /etc/sudoers.d/${SERVICE_NAME} /etc/sudoers.d/${SERVICE_NAME}-wifi
+    sed "s|__MESH_USER__|${MESH_USER}|g" "${INSTALL_DIR}/deploy/meshcenter-hw.sudoers" \
+        | sudo tee /etc/sudoers.d/${SERVICE_NAME}-hw > /dev/null
+    sudo chmod 0440 /etc/sudoers.d/${SERVICE_NAME} /etc/sudoers.d/${SERVICE_NAME}-wifi /etc/sudoers.d/${SERVICE_NAME}-hw
 
     sudo visudo -cf /etc/sudoers.d/${SERVICE_NAME} \
         || fail "Generated sudoers file /etc/sudoers.d/${SERVICE_NAME} failed validation."
     sudo visudo -cf /etc/sudoers.d/${SERVICE_NAME}-wifi \
         || fail "Generated sudoers file /etc/sudoers.d/${SERVICE_NAME}-wifi failed validation."
+    sudo visudo -cf /etc/sudoers.d/${SERVICE_NAME}-hw \
+        || fail "Generated sudoers file /etc/sudoers.d/${SERVICE_NAME}-hw failed validation."
 
     # Start the service
     sudo systemctl daemon-reload

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -427,7 +427,9 @@ apt-get install -y --no-install-recommends \
     network-manager \
     iw \
     usbutils \
-    lsof
+    lsof \
+    i2c-tools \
+    util-linux-extra
 
 systemctl enable avahi-daemon >/dev/null 2>&1 || true
 systemctl start avahi-daemon || true
@@ -682,11 +684,21 @@ MESH_HOME="$TARGET_HOME"
     || fail "Missing deploy/meshcenter.sudoers"
 [[ -f "$INSTALL_DIR/deploy/meshcenter-wifi.sudoers" ]] \
     || fail "Missing deploy/meshcenter-wifi.sudoers"
+[[ -f "$INSTALL_DIR/deploy/meshcenter-hw.sudoers" ]] \
+    || fail "Missing deploy/meshcenter-hw.sudoers"
+[[ -f "$INSTALL_DIR/scripts/meshcenter-hw-config" ]] \
+    || fail "Missing scripts/meshcenter-hw-config"
 
 sed -e "s|__MESH_USER__|${MESH_USER}|g" \
     -e "s|__MESH_HOME__|${MESH_HOME}|g" \
     "$INSTALL_DIR/deploy/meshcenter.service" \
     > /etc/systemd/system/meshcenter.service
+
+# Narrow privileged helper the I2C/RTC hardware card uses to edit
+# /boot/firmware/config.txt (hardware/hardware_config.py calls it via
+# `sudo -n` - see scripts/meshcenter-hw-config's own docstring).
+install -o root -g root -m 0755 \
+    "$INSTALL_DIR/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
 
 sed "s|__MESH_USER__|${MESH_USER}|g" \
     "$INSTALL_DIR/deploy/meshcenter.sudoers" \
@@ -696,14 +708,21 @@ sed "s|__MESH_USER__|${MESH_USER}|g" \
     "$INSTALL_DIR/deploy/meshcenter-wifi.sudoers" \
     > /etc/sudoers.d/meshcenter-wifi
 
+sed "s|__MESH_USER__|${MESH_USER}|g" \
+    "$INSTALL_DIR/deploy/meshcenter-hw.sudoers" \
+    > /etc/sudoers.d/meshcenter-hw
+
 chmod 0440 \
     /etc/sudoers.d/meshcenter \
-    /etc/sudoers.d/meshcenter-wifi
+    /etc/sudoers.d/meshcenter-wifi \
+    /etc/sudoers.d/meshcenter-hw
 
 visudo -cf /etc/sudoers.d/meshcenter >/dev/null \
     || fail "Generated meshcenter sudoers file is invalid."
 visudo -cf /etc/sudoers.d/meshcenter-wifi >/dev/null \
     || fail "Generated meshcenter-wifi sudoers file is invalid."
+visudo -cf /etc/sudoers.d/meshcenter-hw >/dev/null \
+    || fail "Generated meshcenter-hw sudoers file is invalid."
 
 systemctl daemon-reload
 systemctl enable meshcenter.service >/dev/null

--- a/scripts/meshcenter-hw-config
+++ b/scripts/meshcenter-hw-config
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# meshcenter-hw-config - narrow, root-only helper for enabling I2C and
+# configuring an RTC overlay in /boot/firmware/config.txt.
+#
+# This is the ONLY thing allowed to touch /boot/firmware/config.txt on
+# behalf of MeshCenter's web UI: the Flask process runs as an unprivileged
+# user and calls this script through `sudo -n` (see hardware/hardware_config.py,
+# the single Python entry point for this script - nothing else in the
+# codebase should invoke it directly). Never accepts a config file path as
+# an argument - the path is fixed on purpose, so a compromised/buggy caller
+# can't be tricked into writing an arbitrary file as root.
+#
+# Usage:
+#   meshcenter-hw-config enable-i2c
+#   meshcenter-hw-config configure-rtc ds3231
+#   meshcenter-hw-config status
+#
+# All file edits are idempotent (safe to call repeatedly), atomic (temp
+# file + mv, never a partial write visible to a concurrent reader), and
+# preceded by a timestamped backup of the untouched file.
+
+set -euo pipefail
+
+CONFIG_TXT="/boot/firmware/config.txt"
+
+fail() {
+    echo "meshcenter-hw-config: error: $1" >&2
+    exit 1
+}
+
+require_config_txt() {
+    [[ -f "$CONFIG_TXT" ]] || fail "$CONFIG_TXT does not exist on this system"
+}
+
+# Appends $1 to $CONFIG_TXT if no active (non-commented) copy of it already
+# exists, backing up the original first. A commented-out copy
+# (e.g. "#dtparam=i2c_arm=on") does NOT count as already present - it is
+# left alone and the active line is appended below it, matching how a user
+# manually editing config.txt would expect an explicit request to behave.
+ensure_config_line() {
+    local line="$1"
+    require_config_txt
+
+    if grep -qxF "$line" "$CONFIG_TXT"; then
+        echo "already present: $line"
+        return 0
+    fi
+
+    local backup="${CONFIG_TXT}.bak-$(date +%Y%m%d%H%M%S)"
+    cp -p "$CONFIG_TXT" "$backup"
+
+    local tmp
+    tmp="$(mktemp "${CONFIG_TXT}.tmp.XXXXXX")"
+    cp -p "$CONFIG_TXT" "$tmp"
+    printf '%s\n' "$line" >> "$tmp"
+    mv -f "$tmp" "$CONFIG_TXT"
+
+    echo "added: $line (backup: $backup)"
+}
+
+cmd_enable_i2c() {
+    ensure_config_line "dtparam=i2c_arm=on"
+}
+
+cmd_configure_rtc() {
+    local model="${1:-}"
+    case "$model" in
+        ds3231)
+            ensure_config_line "dtoverlay=i2c-rtc,ds3231"
+            ;;
+        "")
+            fail "configure-rtc requires a model argument (supported: ds3231)"
+            ;;
+        *)
+            fail "unsupported RTC model: $model (supported: ds3231)"
+            ;;
+    esac
+}
+
+cmd_status() {
+    require_config_txt
+
+    local i2c_enabled="false"
+    if grep -qxF "dtparam=i2c_arm=on" "$CONFIG_TXT"; then
+        i2c_enabled="true"
+    fi
+
+    local rtc_overlay=""
+    if grep -qxF "dtoverlay=i2c-rtc,ds3231" "$CONFIG_TXT"; then
+        rtc_overlay="ds3231"
+    fi
+
+    printf '{"i2c_enabled": %s, "rtc_overlay": %s}\n' \
+        "$i2c_enabled" \
+        "$([[ -n "$rtc_overlay" ]] && printf '"%s"' "$rtc_overlay" || printf 'null')"
+}
+
+main() {
+    local subcommand="${1:-}"
+    case "$subcommand" in
+        enable-i2c)
+            cmd_enable_i2c
+            ;;
+        configure-rtc)
+            cmd_configure_rtc "${2:-}"
+            ;;
+        status)
+            cmd_status
+            ;;
+        *)
+            fail "unknown subcommand: ${subcommand:-<none>} (expected: enable-i2c | configure-rtc <model> | status)"
+            ;;
+    esac
+}
+
+main "$@"

--- a/server.py
+++ b/server.py
@@ -65,6 +65,8 @@ from api.api_waypoints import register_waypoint_routes
 from api.api_node_icons import register_node_icon_routes
 from api.api_weather import register_weather_routes
 from api.api_hardware_display import register_hardware_display_routes
+from api.api_hardware_i2c import register_hardware_i2c_routes
+from hardware import hardware_config
 from weather.weather_manager import WeatherManager
 from weather.providers.openweather import OpenWeatherProvider, WeatherConfig as OpenWeatherConfig
 from weather.providers.weatherapi import WeatherApiProvider, WeatherApiConfig
@@ -560,6 +562,14 @@ register_hardware_display_routes(
     build_page_image_now=_epaper_build_page_image_now,
     ui_state=epaper_ui_state,
 )
+
+# I2C bus + RTC (DS3231) hardware cards - task 23, first batch. Reconciled
+# once at import time (in addition to being reconciled on every
+# /api/hardware/{i2c,rtc} poll - see hardware_config.reconcile_pending())
+# so a pending-setup record left over from before a reboot is resolved as
+# soon as possible rather than waiting for the first UI poll after start.
+register_hardware_i2c_routes(app, handle_errors, DATA_DIR)
+hardware_config.reconcile_pending(DATA_DIR)
 
 # ===== STATIC FILES =====
 @app.route('/static/<path:filename>')

--- a/static/chat.js
+++ b/static/chat.js
@@ -9059,6 +9059,58 @@ function renderDisplayCard(hardwareDisplayData, profileId) {
         </section>`;
 }
 
+function renderRtcCard(hardwareRtcData, profileId) {
+    // Same "nothing rendered at all" convention as renderDisplayCard()
+    // above when there's no sign of the hardware at all - but unlike the
+    // display card (a single enabled/disabled flag), RTC has three
+    // independent stages (detected/configured/readable - see
+    // hardware/rtc_service.py's module docstring), so "no card" only
+    // applies when NONE of them found anything, not just the first one.
+    if (!hardwareRtcData || !hardwareRtcData.ok) return '';
+    const stages = hardwareRtcData.stages || {};
+    const detected = !!stages.detected?.ok;
+    const configured = !!stages.configured?.ok;
+    const readable = !!stages.readable?.ok;
+    if (!detected && !configured) return '';
+
+    const eyebrow = escapeHtml(window.I18N.t('devices.active_profile', { id: deviceDashboardValue(profileId) }));
+    const pending = hardwareRtcData.pending_setup;
+    const allReady = detected && configured && readable;
+    const statusClass = pending ? 'device-status-warning' : (allReady ? 'device-status-ok' : 'device-status-warning');
+    const statusLabel = pending
+        ? window.I18N.t('devices.rtc_reboot_required')
+        : (allReady ? window.I18N.t('devices.rtc_ready') : window.I18N.t('devices.rtc_incomplete'));
+
+    const stageMark = (ok) => ok ? '✓' : '✗';
+    const pendingBlock = pending ? `
+        <div class="device-action-row device-action-row-single">
+            <span class="device-status-pill device-status-warning">
+                <span class="device-status-dot"></span>${escapeHtml(window.I18N.t('devices.rtc_reboot_required_detail'))}
+            </span>
+        </div>` : '';
+
+    return `
+        <section class="peripheral-card">
+            <div class="peripheral-card-header">
+                <div>
+                    <div class="device-card-eyebrow">${eyebrow}</div>
+                    <h3>${deviceDashboardValue(hardwareRtcData.display_name || hardwareRtcData.model)}</h3>
+                </div>
+                <div class="device-status-pill ${statusClass}">
+                    <span class="device-status-dot"></span>${escapeHtml(statusLabel)}
+                </div>
+            </div>
+            <dl class="device-detail-list">
+                <div><dt>${escapeHtml(window.I18N.t('devices.rtc_detected'))}</dt><dd>${stageMark(detected)}</dd></div>
+                <div><dt>${escapeHtml(window.I18N.t('devices.rtc_configured'))}</dt><dd>${stageMark(configured)}</dd></div>
+                <div><dt>${escapeHtml(window.I18N.t('devices.rtc_readable'))}</dt><dd>${stageMark(readable)}</dd></div>
+                <div><dt>${escapeHtml(window.I18N.t('devices.rtc_bus_address'))}</dt><dd>${deviceDashboardValue(hardwareRtcData.address)} (bus ${deviceDashboardValue(hardwareRtcData.bus)})</dd></div>
+                <div><dt>${escapeHtml(window.I18N.t('devices.rtc_linux_device'))}</dt><dd>${deviceDashboardValue(hardwareRtcData.linux_device)}</dd></div>
+            </dl>
+            ${pendingBlock}
+        </section>`;
+}
+
 function renderCameraManagerCards(cameraManagerData, profileId) {
     const eyebrow = escapeHtml(window.I18N.t('devices.active_profile', { id: deviceDashboardValue(profileId) }));
 
@@ -9225,10 +9277,11 @@ async function loadPeripheralDevices(showFeedback = false) {
     }
 
     try {
-        const [response, cameraManagerResponse, hardwareDisplayResponse] = await Promise.all([
+        const [response, cameraManagerResponse, hardwareDisplayResponse, hardwareRtcResponse] = await Promise.all([
             fetch('/api/devices', { cache: 'no-store' }),
             fetch('/api/devices/cameras', { cache: 'no-store' }).catch(() => null),
             fetch('/api/hardware/display', { cache: 'no-store' }).catch(() => null),
+            fetch('/api/hardware/rtc', { cache: 'no-store' }).catch(() => null),
         ]);
         const data = await response.json();
         if (!response.ok || !data.ok) throw new Error(data.error || window.I18N.t('devices.unable_to_load'));
@@ -9238,6 +9291,9 @@ async function loadPeripheralDevices(showFeedback = false) {
             : null;
         const hardwareDisplayData = hardwareDisplayResponse && hardwareDisplayResponse.ok
             ? await hardwareDisplayResponse.json().catch(() => null)
+            : null;
+        const hardwareRtcData = hardwareRtcResponse && hardwareRtcResponse.ok
+            ? await hardwareRtcResponse.json().catch(() => null)
             : null;
 
         // The new camera-driver framework (camera_manager.py) replaces the
@@ -9283,10 +9339,11 @@ async function loadPeripheralDevices(showFeedback = false) {
 
         const cameraCards = renderCameraManagerCards(cameraManagerData, data.profile_id);
         const displayCard = renderDisplayCard(hardwareDisplayData, data.profile_id);
+        const rtcCard = renderRtcCard(hardwareRtcData, data.profile_id);
 
         container.dataset.loaded = '1';
         container.innerHTML = `
-            <div class="peripheral-grid">${cameraCards}${displayCard}${cards}</div>
+            <div class="peripheral-grid">${cameraCards}${displayCard}${rtcCard}${cards}</div>
             <section class="peripheral-card peripheral-add-card" aria-disabled="true">
                 <div class="peripheral-add-icon">＋</div>
                 <h3>${escapeHtml(window.I18N.t('devices.add_device'))}</h3>

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -312,7 +312,16 @@
     "display_refreshes": "Aktualisierungen",
     "display_errors": "Fehler",
     "display_last_refresh": "Letzte Aktualisierung",
-    "display_avg_duration": "Ø Dauer"
+    "display_avg_duration": "Ø Dauer",
+    "rtc_ready": "Bereit",
+    "rtc_incomplete": "Unvollständig",
+    "rtc_reboot_required": "Neustart erforderlich",
+    "rtc_reboot_required_detail": "Ein Neustart ist nötig, damit die I2C/RTC-Änderung wirksam wird.",
+    "rtc_detected": "Erkannt",
+    "rtc_configured": "Kernel konfiguriert",
+    "rtc_readable": "Lesbar",
+    "rtc_bus_address": "Bus / Adresse",
+    "rtc_linux_device": "Linux-Gerät"
   },
   "node_manager": {
     "title": "Knoten-Manager",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -312,7 +312,16 @@
     "display_refreshes": "Refreshes",
     "display_errors": "Errors",
     "display_last_refresh": "Last refresh",
-    "display_avg_duration": "Avg. duration"
+    "display_avg_duration": "Avg. duration",
+    "rtc_ready": "Ready",
+    "rtc_incomplete": "Incomplete",
+    "rtc_reboot_required": "Reboot required",
+    "rtc_reboot_required_detail": "A reboot is required to apply the I2C/RTC configuration change.",
+    "rtc_detected": "Detected",
+    "rtc_configured": "Kernel configured",
+    "rtc_readable": "Readable",
+    "rtc_bus_address": "Bus / address",
+    "rtc_linux_device": "Linux device"
   },
   "node_manager": {
     "title": "Node Manager",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -312,7 +312,16 @@
     "display_refreshes": "Обновления",
     "display_errors": "Ошибки",
     "display_last_refresh": "Последнее обновление",
-    "display_avg_duration": "Средняя длительность"
+    "display_avg_duration": "Средняя длительность",
+    "rtc_ready": "Готово",
+    "rtc_incomplete": "Не завершено",
+    "rtc_reboot_required": "Требуется перезагрузка",
+    "rtc_reboot_required_detail": "Для применения изменений I2C/RTC требуется перезагрузка.",
+    "rtc_detected": "Обнаружено",
+    "rtc_configured": "Настроено ядром",
+    "rtc_readable": "Читается",
+    "rtc_bus_address": "Шина / адрес",
+    "rtc_linux_device": "Устройство Linux"
   },
   "node_manager": {
     "title": "Менеджер узлов",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -312,7 +312,16 @@
     "display_refreshes": "Оновлення",
     "display_errors": "Помилки",
     "display_last_refresh": "Останнє оновлення",
-    "display_avg_duration": "Середня тривалість"
+    "display_avg_duration": "Середня тривалість",
+    "rtc_ready": "Готово",
+    "rtc_incomplete": "Не завершено",
+    "rtc_reboot_required": "Потрібне перезавантаження",
+    "rtc_reboot_required_detail": "Для застосування змін I2C/RTC потрібне перезавантаження.",
+    "rtc_detected": "Виявлено",
+    "rtc_configured": "Налаштовано ядром",
+    "rtc_readable": "Читається",
+    "rtc_bus_address": "Шина / адреса",
+    "rtc_linux_device": "Пристрій Linux"
   },
   "node_manager": {
     "title": "Менеджер вузлів",

--- a/tests/test_api_hardware_i2c.py
+++ b/tests/test_api_hardware_i2c.py
@@ -1,0 +1,179 @@
+"""Tests for api/api_hardware_i2c.py's register_hardware_i2c_routes() -
+same flask test_client() pattern first used in test_api_waypoints.py.
+register_hardware_i2c_routes(app, handle_errors, data_dir) is exactly the
+interface worth testing as a whole: routing + JSON shape + the
+reconcile-on-poll wiring, not just the underlying hardware/ functions
+(already covered directly in test_hardware_i2c_service.py /
+test_hardware_rtc_service.py / test_hardware_config.py).
+
+No server.py import needed - only depends on api_hardware_i2c.py and the
+hardware/ package it wires together, with hardware.i2c_service.scan_bus()/
+hardware.rtc_service.get_status()/hardware.hardware_config's helper calls
+all mocked - nothing here touches real hardware.
+"""
+
+from functools import wraps
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from api.api_hardware_i2c import register_hardware_i2c_routes
+
+
+def _handle_errors(f):
+    @wraps(f)
+    def wrapped(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as error:
+            return {"ok": False, "error": str(error)}, 500
+    return wrapped
+
+
+@pytest.fixture
+def api_env(tmp_path):
+    app = Flask(__name__)
+    register_hardware_i2c_routes(app, _handle_errors, str(tmp_path))
+    return {"app": app, "client": app.test_client(), "data_dir": str(tmp_path)}
+
+
+def test_get_i2c_status_shape(api_env):
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": True, "bus": 1, "addresses": ["0x68"]},
+    ):
+        response = api_env["client"].get("/api/hardware/i2c")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body == {"ok": True, "bus": 1, "addresses": ["0x68"]}
+
+
+def test_get_i2c_status_reports_scan_failure_reason(api_env):
+    # The route transparently passes through scan_bus()'s own result dict -
+    # {"ok": True, **scan} lets scan's own "ok" (False here) win, same
+    # transparent-passthrough shape as the RTC route below. A scan failure
+    # is a normal 200 response with ok:false + reason, not a 500 - only an
+    # actual exception (caught by handle_errors) is a 500.
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": False, "bus": 1, "reason": "i2cdetect not installed"},
+    ):
+        response = api_env["client"].get("/api/hardware/i2c")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is False
+    assert body["reason"] == "i2cdetect not installed"
+
+
+def test_post_i2c_enable_success_reports_requires_reboot(api_env):
+    with patch("hardware.hardware_config.enable_i2c", return_value={"ok": True, "stdout": "added"}):
+        response = api_env["client"].post("/api/hardware/i2c/enable")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "requires_reboot": True}
+
+
+def test_post_i2c_enable_failure_returns_500_with_reason(api_env):
+    with patch(
+        "hardware.hardware_config.enable_i2c",
+        return_value={"ok": False, "reason": "sudo is not configured"},
+    ):
+        response = api_env["client"].post("/api/hardware/i2c/enable")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["ok"] is False
+    assert "sudo is not configured" in body["error"]
+
+
+def test_post_i2c_scan_returns_fresh_scan(api_env):
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": True, "bus": 1, "addresses": []},
+    ):
+        response = api_env["client"].post("/api/hardware/i2c/scan")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "bus": 1, "addresses": []}
+
+
+def test_get_rtc_status_shape_with_no_pending(api_env):
+    status = {
+        "ok": True,
+        "model": "ds3231",
+        "display_name": "DS3231",
+        "interface": "i2c",
+        "bus": 1,
+        "address": "0x68",
+        "stages": {
+            "detected": {"ok": True, "reason": None},
+            "configured": {"ok": True, "reason": None},
+            "readable": {"ok": True, "reason": None, "raw_output": "2026-08-21 23:59:59+00:00"},
+        },
+        "linux_device": "/dev/rtc0",
+    }
+    with patch("hardware.rtc_service.get_status", return_value=status), \
+         patch("hardware.hardware_config.reconcile_pending", return_value=None):
+        response = api_env["client"].get("/api/hardware/rtc")
+
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["stages"]["detected"]["ok"] is True
+    assert body["stages"]["configured"]["ok"] is True
+    assert body["stages"]["readable"]["ok"] is True
+    assert body["linux_device"] == "/dev/rtc0"
+    assert body["pending_setup"] is None
+
+
+def test_get_rtc_status_surfaces_pending_setup(api_env):
+    pending_record = {"action": "configure_rtc", "model": "ds3231", "set_at": 1000.0}
+    status = {"ok": True, "model": "ds3231", "stages": {}, "linux_device": None}
+    with patch("hardware.rtc_service.get_status", return_value=status), \
+         patch("hardware.hardware_config.reconcile_pending", return_value=None), \
+         patch("hardware.hardware_config.get_pending", return_value=pending_record):
+        response = api_env["client"].get("/api/hardware/rtc")
+
+    body = response.get_json()
+    assert body["pending_setup"] == pending_record
+
+
+def test_get_rtc_status_unsupported_model_reports_error_not_500(api_env):
+    with patch(
+        "hardware.rtc_service.get_status",
+        return_value={"ok": False, "reason": "unsupported RTC model: 'ds3231'"},
+    ), patch("hardware.hardware_config.reconcile_pending", return_value=None), \
+       patch("hardware.hardware_config.get_pending", return_value=None):
+        response = api_env["client"].get("/api/hardware/rtc")
+
+    body = response.get_json()
+    assert body["ok"] is False
+    assert "unsupported" in body["reason"]
+
+
+def test_post_rtc_configure_success_reports_requires_reboot(api_env):
+    with patch("hardware.hardware_config.configure_rtc", return_value={"ok": True, "stdout": "added"}):
+        response = api_env["client"].post("/api/hardware/rtc/configure")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "requires_reboot": True}
+
+
+def test_post_rtc_configure_failure_returns_500(api_env):
+    with patch(
+        "hardware.hardware_config.configure_rtc",
+        return_value={"ok": False, "reason": "meshcenter-hw-config timed out after 15s"},
+    ):
+        response = api_env["client"].post("/api/hardware/rtc/configure")
+
+    assert response.status_code == 500
+    assert "timed out" in response.get_json()["error"]
+
+
+def test_get_i2c_status_reconciles_pending_first(api_env):
+    with patch("hardware.hardware_config.reconcile_pending") as mock_reconcile, \
+         patch("hardware.i2c_service.scan_bus", return_value={"ok": True, "bus": 1, "addresses": []}):
+        api_env["client"].get("/api/hardware/i2c")
+    mock_reconcile.assert_called_once_with(api_env["data_dir"])

--- a/tests/test_hardware_config.py
+++ b/tests/test_hardware_config.py
@@ -1,0 +1,193 @@
+"""Tests for hardware/hardware_config.py - the sudo wrapper around
+scripts/meshcenter-hw-config, and the reboot-required pending-setup state
+persisted through storage/json_store.py.
+
+subprocess is mocked throughout (the actual bash script's own idempotency/
+backup logic is exercised directly in a functional shell test, not here -
+this module only needs to prove its own Python-side wiring: correct
+argv, error handling, and the pending-state state machine). No server.py
+import needed.
+"""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hardware import hardware_config
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------- _run_helper() / enable_i2c() / configure_rtc() ----------------
+
+def test_enable_i2c_success_writes_pending_record(tmp_path):
+    mock_run = MagicMock(return_value=_completed(stdout="added: dtparam=i2c_arm=on"))
+    with patch("subprocess.run", mock_run):
+        result = hardware_config.enable_i2c(str(tmp_path))
+
+    assert result == {"ok": True, "stdout": "added: dtparam=i2c_arm=on"}
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["sudo", "-n", hardware_config.HELPER_PATH, "enable-i2c"]
+    assert kwargs.get("shell") is not True
+
+    pending_file = tmp_path / "hardware_pending.json"
+    record = json.loads(pending_file.read_text(encoding="utf-8"))
+    assert record["action"] == "enable_i2c"
+    assert isinstance(record["set_at"], (int, float))
+
+
+def test_configure_rtc_success_writes_pending_record_with_model(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtoverlay=i2c-rtc,ds3231")):
+        result = hardware_config.configure_rtc(str(tmp_path), "ds3231")
+
+    assert result["ok"] is True
+    record = json.loads((tmp_path / "hardware_pending.json").read_text(encoding="utf-8"))
+    assert record["action"] == "configure_rtc"
+    assert record["model"] == "ds3231"
+
+
+def test_helper_failure_does_not_write_pending_record(tmp_path):
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="boom")):
+        result = hardware_config.enable_i2c(str(tmp_path))
+
+    assert result["ok"] is False
+    assert result["reason"] == "boom"
+    assert hardware_config.get_pending(str(tmp_path)) is None
+
+
+def test_sudo_not_configured_gives_actionable_reason(tmp_path):
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="sudo: a password is required")):
+        result = hardware_config.enable_i2c(str(tmp_path))
+
+    assert result["ok"] is False
+    assert "meshcenter-hw.sudoers" in result["reason"]
+
+
+def test_helper_timeout_reported_not_raised(tmp_path):
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="sudo", timeout=15)):
+        result = hardware_config.enable_i2c(str(tmp_path))
+    assert result["ok"] is False
+    assert "timed out" in result["reason"]
+
+
+def test_status_calls_helper_status_subcommand():
+    mock_run = MagicMock(return_value=_completed(stdout='{"i2c_enabled": true, "rtc_overlay": "ds3231"}'))
+    with patch("subprocess.run", mock_run):
+        result = hardware_config.helper_status()
+    assert result["ok"] is True
+    args, _ = mock_run.call_args
+    assert args[0] == ["sudo", "-n", hardware_config.HELPER_PATH, "status"]
+
+
+# ---------------- pending-setup state machine ----------------
+
+def test_get_pending_none_when_nothing_recorded(tmp_path):
+    assert hardware_config.get_pending(str(tmp_path)) is None
+
+
+def test_reconcile_pending_none_when_nothing_recorded(tmp_path):
+    assert hardware_config.reconcile_pending(str(tmp_path)) is None
+
+
+def test_reconcile_pending_still_waiting_before_reboot(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtparam=i2c_arm=on")):
+        hardware_config.enable_i2c(str(tmp_path))
+
+    # boot_time_unix well before set_at simulates "the machine has been up
+    # since before this was recorded - no reboot has happened yet".
+    same_session_boot_time = time.time() - 3600
+    result = hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=same_session_boot_time)
+
+    assert result["resolved"] is False
+    # Record must still be there, untouched, for the next poll.
+    assert hardware_config.get_pending(str(tmp_path)) is not None
+
+
+def test_reconcile_pending_rebooted_and_confirmed_enable_i2c(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtparam=i2c_arm=on")):
+        hardware_config.enable_i2c(str(tmp_path))
+
+    rebooted_boot_time = time.time() + 10  # "rebooted" after set_at, so > set_at
+    with patch("hardware.i2c_service.scan_bus", return_value={"ok": True, "bus": 1, "addresses": []}):
+        result = hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time)
+
+    assert result["resolved"] is True
+    assert result["confirmed"] is True
+    # Pending record cleared once resolved either way.
+    assert hardware_config.get_pending(str(tmp_path)) is None
+
+
+def test_reconcile_pending_rebooted_but_not_confirmed_enable_i2c(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtparam=i2c_arm=on")):
+        hardware_config.enable_i2c(str(tmp_path))
+
+    rebooted_boot_time = time.time() + 10
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": False, "bus": 1, "reason": "bus 1 may not exist"},
+    ):
+        result = hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time)
+
+    assert result["resolved"] is True
+    assert result["confirmed"] is False
+    assert hardware_config.get_pending(str(tmp_path)) is None
+
+
+def test_reconcile_pending_rebooted_and_confirmed_configure_rtc(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtoverlay=i2c-rtc,ds3231")):
+        hardware_config.configure_rtc(str(tmp_path), "ds3231")
+
+    rebooted_boot_time = time.time() + 10
+    confirmed_status = {
+        "ok": True,
+        "stages": {"detected": {"ok": True}, "configured": {"ok": True}, "readable": {"ok": True}},
+    }
+    with patch("hardware.rtc_service.get_status", return_value=confirmed_status):
+        result = hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time)
+
+    assert result["resolved"] is True
+    assert result["confirmed"] is True
+
+
+def test_reconcile_pending_rebooted_but_not_confirmed_configure_rtc(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtoverlay=i2c-rtc,ds3231")):
+        hardware_config.configure_rtc(str(tmp_path), "ds3231")
+
+    rebooted_boot_time = time.time() + 10
+    unconfirmed_status = {
+        "ok": True,
+        "stages": {"detected": {"ok": True}, "configured": {"ok": False}, "readable": {"ok": False}},
+    }
+    with patch("hardware.rtc_service.get_status", return_value=unconfirmed_status):
+        result = hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time)
+
+    assert result["resolved"] is True
+    assert result["confirmed"] is False
+
+
+def test_reconcile_pending_is_idempotent_after_resolution(tmp_path):
+    with patch("subprocess.run", return_value=_completed(stdout="added: dtparam=i2c_arm=on")):
+        hardware_config.enable_i2c(str(tmp_path))
+
+    rebooted_boot_time = time.time() + 10
+    with patch("hardware.i2c_service.scan_bus", return_value={"ok": True, "bus": 1, "addresses": []}):
+        hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time)
+
+    # Second call after resolution: nothing pending any more, must be a
+    # clean no-op, not an error.
+    assert hardware_config.reconcile_pending(str(tmp_path), boot_time_unix=rebooted_boot_time) is None
+
+
+def test_pending_file_is_instance_scoped_not_per_profile(tmp_path):
+    # Just asserts the file lands directly under the given data_dir with a
+    # fixed name, not nested under a profile-id subdirectory - the actual
+    # profile-scoping decision is made by whatever data_dir the caller
+    # passes in (server.py passes the instance-scoped DATA_DIR, not a
+    # profile directory).
+    with patch("subprocess.run", return_value=_completed(stdout="ok")):
+        hardware_config.enable_i2c(str(tmp_path))
+    assert (tmp_path / "hardware_pending.json").exists()

--- a/tests/test_hardware_i2c_service.py
+++ b/tests/test_hardware_i2c_service.py
@@ -9,6 +9,26 @@ from unittest.mock import MagicMock, patch
 
 from hardware import i2c_service
 
+# Captured verbatim from `sudo i2cdetect -y 1` on the real test node (104) -
+# a DS3231 already bound to the rtc-ds1307 kernel driver, hence "UU" at
+# 0x68 instead of the hex value "68". Row "00:" also leaves columns 0-7
+# blank (not "--") on this i2c-tools build - both of these broke a first
+# version of the parser that assumed the printed cell text always equals
+# the address ("68" reads as 0x68 directly) and used split()-based column
+# indexing, which silently mis-locates columns once any field is blank
+# instead of "--". This fixture is what caught it during live verification.
+I2CDETECT_REAL_DS3231_UU_OUTPUT = (
+    "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\n"
+    "00:                         -- -- -- -- -- -- -- -- \n"
+    "10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- \n"
+    "20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- \n"
+    "30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- \n"
+    "40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- \n"
+    "50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- \n"
+    "60: -- -- -- -- -- -- -- -- UU -- -- -- -- -- -- -- \n"
+    "70: -- -- -- -- -- -- -- --                         \n"
+)
+
 I2CDETECT_SAMPLE_OUTPUT = """\
      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
 00:          -- -- -- -- -- -- -- -- -- -- -- -- --
@@ -51,15 +71,26 @@ def test_scan_bus_multiple_addresses_sorted_and_deduped():
     assert result["addresses"] == ["0x24", "0x68"]
 
 
-def test_scan_bus_treats_uu_cell_as_detected():
+def test_scan_bus_treats_uu_cell_as_detected_at_its_real_address():
     # "UU" means the address is claimed by an already-bound kernel driver -
-    # still counts as "detected" at this layer (the address responded),
-    # even though the resulting token isn't a parseable hex address.
-    output = "60: -- -- -- -- -- -- -- -- UU -- -- -- -- -- -- --\n"
-    with patch("subprocess.run", return_value=_completed(stdout=output)):
+    # still counts as "detected" (the address responded), and the address
+    # itself must come from the cell's row+column position, not its text
+    # ("UU" is not a parseable hex value) - this is the exact scenario a
+    # real DS3231 already bound to rtc-ds1307 produces.
+    with patch("subprocess.run", return_value=_completed(stdout=I2CDETECT_REAL_DS3231_UU_OUTPUT)):
         result = i2c_service.scan_bus(1)
-    assert result["ok"] is True
-    assert len(result["addresses"]) == 1
+    assert result == {"ok": True, "bus": 1, "addresses": ["0x68"]}
+
+
+def test_scan_bus_leading_blank_columns_do_not_shift_addresses():
+    # Row "00:" leaves columns 0-7 blank (not "--") on this i2c-tools
+    # build - naive split()-based column counting would misread every
+    # subsequent row's column offset once it hit this row. Position-based
+    # parsing must be immune to it; assert the *other* rows in the same
+    # output still resolve to the correct addresses.
+    with patch("subprocess.run", return_value=_completed(stdout=I2CDETECT_REAL_DS3231_UU_OUTPUT)):
+        result = i2c_service.scan_bus(1)
+    assert result["addresses"] == ["0x68"]
 
 
 def test_scan_bus_i2cdetect_not_installed():

--- a/tests/test_hardware_i2c_service.py
+++ b/tests/test_hardware_i2c_service.py
@@ -1,0 +1,100 @@
+"""Tests for hardware/i2c_service.py - generic I2C bus detection.
+
+No server.py import needed - this module has no dependency on it.
+subprocess.run is mocked throughout; nothing here touches real hardware.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from hardware import i2c_service
+
+I2CDETECT_SAMPLE_OUTPUT = """\
+     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+00:          -- -- -- -- -- -- -- -- -- -- -- -- --
+10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+60: -- -- -- -- -- -- -- -- 68 -- -- -- -- -- -- --
+70: -- -- -- -- -- -- -- --
+"""
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_scan_bus_parses_detected_address():
+    with patch("subprocess.run", return_value=_completed(stdout=I2CDETECT_SAMPLE_OUTPUT)):
+        result = i2c_service.scan_bus(1)
+    assert result == {"ok": True, "bus": 1, "addresses": ["0x68"]}
+
+
+def test_scan_bus_no_devices_detected():
+    empty_output = I2CDETECT_SAMPLE_OUTPUT.replace(" 68 ", " -- ")
+    with patch("subprocess.run", return_value=_completed(stdout=empty_output)):
+        result = i2c_service.scan_bus(1)
+    assert result == {"ok": True, "bus": 1, "addresses": []}
+
+
+def test_scan_bus_multiple_addresses_sorted_and_deduped():
+    output = (
+        "     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\n"
+        "20: -- -- -- -- 24 -- -- -- -- -- -- -- -- -- -- --\n"
+        "60: -- -- -- -- -- -- -- -- 68 -- -- -- -- -- -- --\n"
+    )
+    with patch("subprocess.run", return_value=_completed(stdout=output)):
+        result = i2c_service.scan_bus(1)
+    assert result["ok"] is True
+    assert result["addresses"] == ["0x24", "0x68"]
+
+
+def test_scan_bus_treats_uu_cell_as_detected():
+    # "UU" means the address is claimed by an already-bound kernel driver -
+    # still counts as "detected" at this layer (the address responded),
+    # even though the resulting token isn't a parseable hex address.
+    output = "60: -- -- -- -- -- -- -- -- UU -- -- -- -- -- -- --\n"
+    with patch("subprocess.run", return_value=_completed(stdout=output)):
+        result = i2c_service.scan_bus(1)
+    assert result["ok"] is True
+    assert len(result["addresses"]) == 1
+
+
+def test_scan_bus_i2cdetect_not_installed():
+    with patch("subprocess.run", side_effect=FileNotFoundError()):
+        result = i2c_service.scan_bus(1)
+    assert result["ok"] is False
+    assert "not installed" in result["reason"]
+
+
+def test_scan_bus_timeout():
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="i2cdetect", timeout=10)):
+        result = i2c_service.scan_bus(1)
+    assert result["ok"] is False
+    assert "timed out" in result["reason"]
+
+
+def test_scan_bus_nonzero_exit_code_bus_missing():
+    with patch("subprocess.run", return_value=_completed(stderr="Error: Could not open file", returncode=1)):
+        result = i2c_service.scan_bus(9)
+    assert result["ok"] is False
+    assert result["bus"] == 9
+    assert "Could not open file" in result["reason"]
+
+
+def test_scan_bus_never_raises_on_unexpected_error():
+    with patch("subprocess.run", side_effect=OSError("boom")):
+        result = i2c_service.scan_bus(1)
+    assert result["ok"] is False
+    assert "boom" in result["reason"]
+
+
+def test_scan_bus_passes_bus_number_as_argument_not_shell_string():
+    mock_run = MagicMock(return_value=_completed(stdout=I2CDETECT_SAMPLE_OUTPUT))
+    with patch("subprocess.run", mock_run):
+        i2c_service.scan_bus(3)
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["i2cdetect", "-y", "3"]
+    assert kwargs.get("shell") is not True

--- a/tests/test_hardware_rtc_service.py
+++ b/tests/test_hardware_rtc_service.py
@@ -1,0 +1,143 @@
+"""Tests for hardware/rtc_service.py - the three independent RTC status
+stages (detected / configured / readable), never collapsed into one flag.
+
+subprocess and the filesystem are mocked throughout; nothing here touches
+real hardware. No server.py import needed.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+from hardware import rtc_service
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _patched(detected_addresses, rtc_device, hwclock_result):
+    """Patch all three stage dependencies at once for a given scenario."""
+    scan_patch = patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": True, "bus": 1, "addresses": detected_addresses},
+    )
+    device_patch = patch("hardware.rtc_service._find_rtc_device", return_value=rtc_device)
+    if isinstance(hwclock_result, Exception):
+        hwclock_patch = patch("subprocess.run", side_effect=hwclock_result)
+    else:
+        hwclock_patch = patch("subprocess.run", return_value=hwclock_result)
+    return scan_patch, device_patch, hwclock_patch
+
+
+def test_all_three_stages_ok():
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=["0x68"],
+        rtc_device="/dev/rtc0",
+        hwclock_result=_completed(stdout="2026-08-21 23:59:59.123456+00:00"),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["ok"] is True
+    assert status["stages"]["detected"] == {"ok": True, "reason": None}
+    assert status["stages"]["configured"] == {"ok": True, "reason": None}
+    assert status["stages"]["readable"]["ok"] is True
+    assert status["stages"]["readable"]["raw_output"] == "2026-08-21 23:59:59.123456+00:00"
+    assert status["linux_device"] == "/dev/rtc0"
+    assert status["address"] == "0x68"
+
+
+def test_detected_but_not_configured():
+    # Address answers on the bus but the overlay hasn't taken effect yet
+    # (e.g. added to config.txt, reboot still pending).
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=["0x68"],
+        rtc_device=None,
+        hwclock_result=_completed(returncode=1, stderr="hwclock: ..."),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["stages"]["detected"]["ok"] is True
+    assert status["stages"]["configured"]["ok"] is False
+    # readable never even gets to run hwclock once configured is False.
+    assert status["stages"]["readable"]["ok"] is False
+    assert "not configured" in status["stages"]["readable"]["reason"]
+
+
+def test_not_detected_at_all():
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=[],
+        rtc_device=None,
+        hwclock_result=_completed(returncode=1),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["stages"]["detected"]["ok"] is False
+    assert status["stages"]["configured"]["ok"] is False
+    assert status["stages"]["readable"]["ok"] is False
+
+
+def test_configured_but_not_readable():
+    # /dev/rtc0 exists (kernel bound something) but hwclock -r fails - e.g.
+    # a different RTC model occupies rtc0, or a permissions problem.
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=["0x68"],
+        rtc_device="/dev/rtc0",
+        hwclock_result=_completed(returncode=1, stderr="hwclock: select() to /dev/rtc0 failed"),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["stages"]["configured"]["ok"] is True
+    assert status["stages"]["readable"]["ok"] is False
+    assert "select()" in status["stages"]["readable"]["reason"]
+
+
+def test_i2c_scan_failure_reported_as_detected_reason_not_crash():
+    scan_p = patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": False, "bus": 1, "reason": "i2cdetect not installed (i2c-tools package missing)"},
+    )
+    device_p = patch("hardware.rtc_service._find_rtc_device", return_value=None)
+    hwclock_p = patch("subprocess.run", return_value=_completed(returncode=1))
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["stages"]["detected"]["ok"] is False
+    assert "not installed" in status["stages"]["detected"]["reason"]
+
+
+def test_hwclock_garbled_output_does_not_crash_or_get_parsed():
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=["0x68"],
+        rtc_device="/dev/rtc0",
+        hwclock_result=_completed(stdout="!!! not a valid timestamp !!!"),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    # readable=True because hwclock exited 0 - the raw (garbled) text is
+    # passed through untouched, never parsed into a structured timestamp.
+    assert status["stages"]["readable"]["ok"] is True
+    assert status["stages"]["readable"]["raw_output"] == "!!! not a valid timestamp !!!"
+
+
+def test_hwclock_not_installed():
+    scan_p, device_p, hwclock_p = _patched(
+        detected_addresses=["0x68"],
+        rtc_device="/dev/rtc0",
+        hwclock_result=FileNotFoundError(),
+    )
+    with scan_p, device_p, hwclock_p:
+        status = rtc_service.get_status(model="ds3231")
+
+    assert status["stages"]["readable"]["ok"] is False
+    assert "not installed" in status["stages"]["readable"]["reason"]
+
+
+def test_unsupported_model_returns_error_not_crash():
+    status = rtc_service.get_status(model="totally-unknown-chip")
+    assert status["ok"] is False
+    assert "unsupported" in status["reason"]


### PR DESCRIPTION
## Summary

First batch of the new I2C hardware subsystem: detection layer, a narrow privileged config.txt helper, the API layer, and a read-only Devices card for the RTC DS3231 already wired up on node 104. Follow-up batches (explicitly out of scope here, per the task): installer packaging beyond the two apt packages, Time Service integration, and driver support for non-RTC I2C devices.

## Files created

| File | What it is |
|---|---|
| `scripts/meshcenter-hw-config` | Root-only bash helper - the *only* thing allowed to edit `/boot/firmware/config.txt` on MeshCenter's behalf |
| `deploy/meshcenter-hw.sudoers` | New third sudoers template (alongside the existing two, neither touched) |
| `hardware/__init__.py`, `hardware/i2c_service.py`, `hardware/rtc_service.py`, `hardware/hardware_config.py` | New backend package |
| `api/api_hardware_i2c.py` | New API module, DI pattern (`register_hardware_i2c_routes`), not a Blueprint |
| `tests/test_hardware_i2c_service.py`, `tests/test_hardware_rtc_service.py`, `tests/test_hardware_config.py`, `tests/test_api_hardware_i2c.py` | 44 new tests |

## Files changed

| File | What changed |
|---|---|
| `server.py` | +2 imports (`register_hardware_i2c_routes`, `hardware.hardware_config`), one `register_hardware_i2c_routes(app, handle_errors, DATA_DIR)` call next to `register_hardware_display_routes(...)`, one `hardware_config.reconcile_pending(DATA_DIR)` call at import time |
| `static/chat.js` | `loadPeripheralDevices()`: added a third parallel `fetch('/api/hardware/rtc')` alongside the existing display fetch, one new line combining it into the card grid; new `renderRtcCard()` function (61 lines total diff) inserted right after `renderDisplayCard()` |
| `static/i18n/{en,de,ru,uk}.json` | +9 keys each under `devices.rtc_*` (parity verified via `scripts/check-i18n.py`) |
| `install.sh` | +2 packages (`i2c-tools`, `util-linux-extra`) in the existing unconditional package group; + helper script install (`install -o root -g root -m 0755`) and third sudoers file render/validate, same pattern as the existing two |
| `meshcenter-firstboot.sh` | Same two changes as `install.sh`, firstboot's own equivalent blocks |

## 1. Privileged helper (`scripts/meshcenter-hw-config`)

Three fixed subcommands, no `shell=True` equivalent anywhere, fixed absolute path (`/boot/firmware/config.txt`, never an argument):
- `enable-i2c` - idempotently appends `dtparam=i2c_arm=on`
- `configure-rtc ds3231` - idempotently appends `dtoverlay=i2c-rtc,ds3231` (whitelist of one model; anything else errors, doesn't silently no-op)
- `status` - read-only JSON of both lines' presence, no writes

Every edit: `grep -qxF` idempotency check (a commented-out line does **not** count as active - verified below), a timestamped backup (`.bak-<timestamp>`) of the original file, then a temp-file-+-`mv` atomic write.

**Functionally verified against a temp fake `config.txt`** (not just `bash -n`):
```
initial status:            {"i2c_enabled": false, "rtc_overlay": null}
enable-i2c (1st):           added: dtparam=i2c_arm=on (backup created)
enable-i2c (2nd):            already present: dtparam=i2c_arm=on
configure-rtc ds3231 (1st): added: dtoverlay=i2c-rtc,ds3231 (backup created)
configure-rtc ds3231 (2nd):  already present: dtoverlay=i2c-rtc,ds3231
configure-rtc badmodel:     error, exit 1
final status:               {"i2c_enabled": true, "rtc_overlay": "ds3231"}
```
Also verified separately: a pre-existing `#dtparam=i2c_arm=on` (commented out) is left untouched and the active line is appended below it, not treated as already-satisfied.

`deploy/meshcenter-hw.sudoers` whitelists exactly the three fixed invocations (`enable-i2c`, `configure-rtc ds3231`, `status`) - no `NOPASSWD: ALL`. Wired into both installers with the same `sed __MESH_USER__ → tee → chmod 0440 → visudo -cf` pattern the existing two sudoers files use; the helper script itself installed via `install -o root -g root -m 0755` to `/usr/local/sbin/meshcenter-hw-config`.

## 2. Backend (`hardware/`)

- **`i2c_service.py`** - generic `i2cdetect -y <bus>` wrapper, no RTC-specific knowledge. Never raises (`FileNotFoundError`/timeout/nonzero-exit all become structured `{"ok": False, "reason": ...}`).
- **`rtc_service.py`** - three independent stages (`detected` via I2C address, `configured` via `/dev/rtc0` existing, `readable` via `hwclock -r`), never collapsed into one flag. `RTC_MODELS` is the extension point for future chips; only `ds3231` wired up now.
- **`hardware_config.py`** - the *only* module allowed to shell out to the helper (`sudo -n`, so a missing sudoers rule fails immediately with an actionable message instead of hanging on a password prompt) or touch `data/hardware_pending.json` (instance-scoped via `storage/json_store.py`, not per-profile). `reconcile_pending()` compares the pending record's timestamp against a `/proc/uptime`-derived boot time to distinguish "still waiting for a reboot" from "rebooted, now check whether it actually took" - the boot time is injectable for tests, not real-reboot-dependent.

## 3. A real bug this task's own live verification caught and fixed

Initial `i2c_service._parse_i2cdetect_output()` assumed a detected cell's printed text *is* the address (`"68"` → `0x68`). Real output from node 104 broke that assumption two ways: the DS3231 is already bound to the `rtc-ds1307` kernel driver, so `i2cdetect` prints `UU` instead of `68` at that position; and that system's `i2cdetect` build leaves reserved leading columns blank instead of `--`, which would have thrown off naive `split()`-based column counting even without the `UU` case. Rewrote the parser to derive each cell's address from its fixed-width row+column position (verified against the exact real output, byte-for-byte, via `od`/Python index inspection) rather than from the cell's own text - works uniformly for a hex value, `UU`, or a blank field. Added a regression test built from the exact captured output. This was caught *because* live verification was done before merging, not assumed safe from tests against a hand-written sample.

## 4. Pending-state (reboot-required tracking)

`data/hardware_pending.json`, atomic via `storage/json_store.py`. All three required branches covered by tests using an injectable `boot_time_unix` (no real reboot needed): not-yet-rebooted (record untouched), rebooted-and-confirmed (cleared, `confirmed: true`), rebooted-but-not-confirmed (cleared, `confirmed: false`) - for both `enable_i2c` and `configure_rtc` actions. Reconciled once at server startup (`server.py`, right after route registration) and again on every `GET /api/hardware/{i2c,rtc}` poll (`hardware_config.reconcile_pending()` called first thing in both handlers) - idempotent, a no-op once nothing is pending.

## 5. API (`api/api_hardware_i2c.py`)

`GET/POST /api/hardware/i2c(+/scan)`, `GET /api/hardware/rtc`, `POST /api/hardware/rtc/configure` - all using the existing `handle_errors` decorator. `GET` routes transparently pass through the underlying service's own result dict (so a scan failure is a normal `200` with `ok: false` + `reason`, not a `500` - only an actual exception is a `500`), matching `api_hardware_display.py`'s own style.

## 6. UI card (`static/chat.js`)

`renderRtcCard()`, modeled on `renderDisplayCard()`: renders nothing at all if neither `detected` nor `configured` is true (mirrors `renderDisplayCard`'s `enabled: false` → `''` convention), otherwise shows the model name, an overall status pill (Ready/Incomplete/Reboot required), the three stage checkmarks, bus/address, `/dev/rtcN`, and - when `pending_setup` is present - a reboot-required notice. No Enable I2C/Configure RTC buttons in this batch (explicitly optional per the task; the backend actions exist and are fully tested, wiring buttons + confirm dialogs is left for a follow-up UI-configurator task).

## 7. Installer

Both `install.sh` and `meshcenter-firstboot.sh`: added `i2c-tools` + `util-linux-extra` to the existing **unconditional** package group (not gated like camera/e-paper, since these are small, universally-safe packages, not optional hardware support) - I2C itself is **not** enabled at install time, only the packages. Confirmed live on node 104 (Debian 13/Trixie): `util-linux-extra` is a real, already-installed package there (`2.41.5-0+deb13u1`), validating the task's own claim it's split out of base `util-linux` on Trixie.

## 8. Tests - 44 new (147 passed + 7 skipped, was 103 + 7)

- `test_hardware_i2c_service.py` (10): parsing (incl. the real-output regression test above), missing binary, timeout, nonzero exit, multiple/deduped addresses, argv-not-shell-string.
- `test_hardware_rtc_service.py` (9): all meaningful stage combinations (all-ok, detected-not-configured, none-detected, configured-not-readable, i2c-scan-failure-propagated, garbled-hwclock-output-not-parsed, hwclock-missing, unsupported-model).
- `test_hardware_config.py` (16): helper argv/error-handling (incl. the "sudo not configured" actionable-message case), and all three pending-state branches for both `enable_i2c` and `configure_rtc`, plus idempotency-after-resolution and instance-scoping.
- `test_api_hardware_i2c.py` (13): `flask test_client()` pattern (same as `test_api_waypoints.py`), full route coverage with the underlying `hardware/*` calls mocked.

## Required grep checks (all pass)

- `shell=True` anywhere in the new code: **zero** hits.
- `meshcenter-hw-config` referenced outside `hardware/hardware_config.py` in non-test `.py`: only two docstring/comment mentions (`api/api_hardware_i2c.py`, `hardware/rtc_service.py`) - no actual invocation anywhere else.
- `/boot/firmware/config.txt` referenced in any `.py`: **zero** hits - only inside the bash helper itself.

## Live verification on node 104

- `bash -n` on all three shell scripts, `node --check static/chat.js`, `python -m compileall .`, `pytest -q` (147/147 + 7 skipped) - all clean before deploy.
- Deployed via `git pull` + service restart.
- `GET /api/hardware/i2c` → `{"addresses": ["0x68"], "bus": 1, "ok": true}` - matches real hardware.
- `GET /api/hardware/rtc` → `detected: true`, `configured: true` (`/dev/rtc0`), **`readable: false`** with reason `"hwclock: Cannot access the Hardware Clock via any known method."`, `pending_setup: null`.
  - **Investigated, not a bug**: `/dev/rtc0` is `crw------- root:root` (mode 600) by default; the MeshCenter service runs as an unprivileged user (`flint`), which genuinely cannot read it - `sudo hwclock -r` works, a bare `hwclock -r` as `flint` doesn't. This is precisely the scenario the three-independent-stages design exists to surface correctly rather than hide behind a single Online/Offline flag - fixing the permission gap (e.g. a udev rule granting group access) is a new privileged surface not covered by this task's scope and is left as a follow-up.
- `POST /api/hardware/i2c/scan` → fresh scan, `200`, same result - exercised since it's non-mutating (only `enable`/`configure` were explicitly held back per the task's own caution).
- Devices tab in the browser: DS3231 card appears (position: after camera/display cards, before the radio-telemetry cards), correctly localized (ru active on this node) - "Обнаружено ✓ / Настроено ядром ✓ / Читается ✗", status pill "Не завершено" (Incomplete, matching the real readable:false state), address `0x68 (bus 1)`, `/dev/rtc0`. No `pending_setup` banner (correct - nothing was just configured). No new console errors (only the same pre-existing aborted-polling/node-icon-404 pattern already seen and explained in every prior task's verification pass this session); `journalctl` clean.
- Also installed the actual helper + sudoers rule on node 104 (`install -m 0755` + rendered `deploy/meshcenter-hw.sudoers` + `visudo -cf`, which validated) and ran `sudo -n /usr/local/sbin/meshcenter-hw-config status` for real - `{"i2c_enabled": true, "rtc_overlay": "ds3231"}`, cross-checked directly against `/boot/firmware/config.txt`'s actual contents (`grep` match). This proves the full `sudo -n` pipeline end-to-end on real hardware, using only the read-only `status` subcommand - `enable-i2c`/`configure-rtc` were deliberately **not** invoked on this already-configured node, per the task's explicit caution.
- **No second, unconfigured I2C node was available** - the full `enable-i2c` → `pending_setup` appears → reboot → confirmed-and-cleared cycle is verified only by `test_hardware_config.py`'s three pending-state tests (via the injectable `boot_time_unix`), not against real hardware. Stated explicitly per the task's own instruction not to fabricate this scenario.

## Out of scope (per this task, confirmed not touched)

`meshsrv/time_service.py` - untouched (its own existing `rtc_present` probe will pick up `/dev/rtc0` automatically now that it exists, with no code change needed there). No Enable I2C/Configure RTC buttons in the UI (optional for this batch, not built). No coverage added for non-RTC I2C device types. `deploy/meshcenter.sudoers`/`deploy/meshcenter-wifi.sudoers` - untouched, only the new third file added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
