### PR TITLE
feat: integrate RTC status into Time Service

### DIFF
--- a/meshsrv/time_service.py
+++ b/meshsrv/time_service.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python3
 """System time status for MeshCenter.
 
-Single source of truth for system time state (NTP sync, RTC presence,
+Single source of truth for system time state (NTP sync, RTC status,
 timezone) shared by the Time card, the e-paper System Screen and any future
 schedule engine. Probes ``timedatectl``/``/etc/timezone`` on a background
 thread and caches the result so request handlers never shell out directly.
+
+RTC status (hardware/rtc_service.py's three independent stages - detected/
+configured/readable) is folded in here too, but on its own, much longer
+cache TTL (_RTC_CACHE_TTL) separate from the NTP/timezone one (_CACHE_TTL):
+unlike NTP sync state, RTC hardware status essentially never changes on its
+own between a config.txt edit + reboot (tracked separately by
+hardware/hardware_config.py's pending-setup mechanism, not here), so
+re-running i2cdetect/hwclock (real subprocess calls, up to 10s timeout
+each) on every 20s tick would be pure waste.
+
+is_trusted() deliberately still only looks at NTP synchronization, not RTC
+- RTC here is a boot/offline-recovery time source, not a "trusted time"
+signal for meshsrv/node_time_sync.py or meshsrv/schedule_engine.py.
 """
 
 from __future__ import annotations
@@ -15,20 +28,60 @@ import time
 from pathlib import Path
 from typing import Any
 
+from hardware import rtc_service
+
 _lock: threading.Lock = threading.Lock()
 _cache: dict[str, Any] = {}
 _cache_ts: float = 0.0
 _CACHE_TTL = 20  # seconds
 
+_rtc_cache: dict[str, Any] = {}
+_rtc_cache_ts: float = 0.0
+_RTC_CACHE_TTL = 300  # seconds - see module docstring
+
+
+def _get_rtc_status() -> dict[str, Any]:
+    """Cached wrapper around hardware.rtc_service.get_status() - refreshes
+    at most once every _RTC_CACHE_TTL seconds. Never raises: rtc_service
+    itself is documented not to, but this background thread must not die
+    from it either way, so any unexpected exception is caught here too and
+    treated as "RTC fully unavailable this cycle", not a crash."""
+    global _rtc_cache, _rtc_cache_ts
+    now = time.monotonic()
+    if _rtc_cache and (now - _rtc_cache_ts) < _RTC_CACHE_TTL:
+        return _rtc_cache
+
+    try:
+        status = rtc_service.get_status(model="ds3231")
+    except Exception as error:
+        print(f"[TIME] RTC probe failed: {error}", flush=True)
+        status = {"ok": False}
+
+    _rtc_cache = status
+    _rtc_cache_ts = now
+    return _rtc_cache
+
 
 def _probe() -> dict[str, Any]:
     """Query the system for time status. Always returns a dict, never raises."""
+    rtc_status = _get_rtc_status()
+    stages = rtc_status.get("stages", {}) if rtc_status.get("ok") else {}
+    rtc_detected = bool(stages.get("detected", {}).get("ok"))
+    rtc_configured = bool(stages.get("configured", {}).get("ok"))
+    rtc_readable = bool(stages.get("readable", {}).get("ok"))
+
     result: dict[str, Any] = {
         "synchronized": False,
         "source": "system",
         "quality": "system",
         "timezone": "UTC",
-        "rtc_present": Path("/sys/class/rtc/rtc0").exists(),
+        # rtc_present kept for backward compatibility - same meaning as
+        # rtc_configured ("the kernel has an RTC device configured"), not
+        # the old raw Path("/sys/class/rtc/rtc0").exists() check.
+        "rtc_present": rtc_configured,
+        "rtc_detected": rtc_detected,
+        "rtc_configured": rtc_configured,
+        "rtc_readable": rtc_readable,
     }
     try:
         out = subprocess.check_output(
@@ -63,9 +116,15 @@ def _probe() -> dict[str, Any]:
             pass
 
     if result["synchronized"]:
+        # NTP always wins, regardless of RTC state.
         result["quality"] = "synchronized"
         result["source"] = "ntp"
-    elif result["rtc_present"]:
+    elif result["rtc_configured"] and result["rtc_readable"]:
+        # Configured-but-not-readable (e.g. permissions, or a different
+        # device occupying /dev/rtc0 - see rtc_service.py's own docstring)
+        # is deliberately NOT treated as quality "rtc" here anymore: the
+        # old check only looked at /dev/rtc0 existing, which could report
+        # "rtc" quality for an RTC that actually can't be read.
         result["quality"] = "rtc"
         result["source"] = "rtc"
 
@@ -107,6 +166,10 @@ def get_status() -> dict[str, Any]:
                 "source": "system",
                 "synchronized": False,
                 "quality": "unknown",
+                "rtc_present": False,
+                "rtc_detected": False,
+                "rtc_configured": False,
+                "rtc_readable": False,
             }
         return {
             "utc": int(time.time()),
@@ -114,6 +177,10 @@ def get_status() -> dict[str, Any]:
             "source": _cache.get("source", "system"),
             "synchronized": _cache.get("synchronized", False),
             "quality": _cache.get("quality", "system"),
+            "rtc_present": _cache.get("rtc_present", False),
+            "rtc_detected": _cache.get("rtc_detected", False),
+            "rtc_configured": _cache.get("rtc_configured", False),
+            "rtc_readable": _cache.get("rtc_readable", False),
         }
 
 

--- a/static/chat.js
+++ b/static/chat.js
@@ -193,7 +193,13 @@ function updateTimeCardSource(data) {
     el.textContent = TimeFormatter._serverEpoch ? `(${window.I18N.t('time.not_synchronized')})` : '';
     return;
   }
-  el.textContent = data.synchronized ? '' : `(${window.I18N.t('time.not_synchronized')})`;
+  if (data.quality === 'synchronized') {
+    el.textContent = window.I18N.t('time.source_ntp');
+  } else if (data.quality === 'rtc') {
+    el.textContent = window.I18N.t('time.source_rtc');
+  } else {
+    el.textContent = `${window.I18N.t('time.source_system')} (${window.I18N.t('time.not_verified')})`;
+  }
 }
 
 function updateTimeCardClock() {

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -174,6 +174,19 @@ def test_rtc_service_exception_does_not_crash_probe(monkeypatch):
 
     monkeypatch.setattr(time_service.rtc_service, "get_status", _raise)
 
+    # _probe() falls back to reading the real /etc/timezone off disk
+    # whenever the parsed timedatectl timezone is "UTC" (see its own
+    # docstring-less fallback block) - left unmocked, this test's result
+    # silently depends on the host machine's actual /etc/timezone content
+    # (e.g. "Etc/UTC" rather than "UTC" on some systems), which is exactly
+    # what broke it during review. Force that read to fail the same way it
+    # does on a system with no /etc/timezone file at all, so the mocked
+    # "UTC" from _timedatectl_output() above is what actually survives.
+    def _raise_file_not_found(self):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(time_service.Path, "read_text", _raise_file_not_found)
+
     result = time_service._probe()  # must not raise
 
     assert result["rtc_detected"] is False

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -1,0 +1,265 @@
+"""Tests for meshsrv/time_service.py - the first test file for this module.
+
+subprocess (timedatectl) and hardware.rtc_service.get_status() are mocked
+throughout; nothing here touches real hardware. No server.py import
+needed - this module only depends on hardware/rtc_service.py, which has
+no hardware dependency of its own at import time either.
+
+Module-level cache state (_cache/_cache_ts/_rtc_cache/_rtc_cache_ts) is
+reset around every test via an autouse fixture, same pattern
+tests/test_cpu_history.py already uses for its own module-level state.
+"""
+
+import subprocess
+import time
+
+import pytest
+
+import meshsrv.time_service as time_service
+
+
+@pytest.fixture(autouse=True)
+def _reset_time_service_state():
+    def _reset():
+        time_service._cache = {}
+        time_service._cache_ts = 0.0
+        time_service._rtc_cache = {}
+        time_service._rtc_cache_ts = 0.0
+
+    _reset()
+    yield
+    _reset()
+
+
+def _timedatectl_output(synchronized: bool, timesource: str | None = None, timezone: str = "UTC") -> str:
+    # Timesource left unset by default when not synchronized, matching a
+    # realistic `timedatectl show` on a system that isn't actually NTP-
+    # synced right now (it does NOT report "Timesource=NTP" in that case) -
+    # letting _probe()'s own "source" default of "system" stand unless a
+    # later branch (synchronized / RTC-ready) overrides it.
+    if timesource is None:
+        timesource = "NTP" if synchronized else ""
+    lines = [f"NTPSynchronized={'yes' if synchronized else 'no'}"]
+    if timesource:
+        lines.append(f"Timesource={timesource}")
+    lines.append(f"Timezone={timezone}")
+    return "\n".join(lines) + "\n"
+
+
+def _rtc_status(detected=False, configured=False, readable=False, ok=True) -> dict:
+    if not ok:
+        return {"ok": False, "reason": "unsupported model"}
+    return {
+        "ok": True,
+        "model": "ds3231",
+        "stages": {
+            "detected": {"ok": detected},
+            "configured": {"ok": configured},
+            "readable": {"ok": readable},
+        },
+    }
+
+
+# ---------------- quality/source logic ----------------
+
+def test_ntp_synchronized_wins_regardless_of_rtc_state(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=True))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
+    )
+
+    result = time_service._probe()
+
+    assert result["synchronized"] is True
+    assert result["quality"] == "synchronized"
+    assert result["source"] == "ntp"
+
+
+def test_ntp_unsynchronized_rtc_fully_ready_reports_rtc_quality(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
+    )
+
+    result = time_service._probe()
+
+    assert result["synchronized"] is False
+    assert result["quality"] == "rtc"
+    assert result["source"] == "rtc"
+
+
+def test_ntp_unsynchronized_rtc_configured_but_not_readable_falls_back_to_system(monkeypatch):
+    # The tightened check from this task: configured-but-not-readable must
+    # NOT be reported as quality "rtc" (the old code only checked
+    # /dev/rtc0 existing, which this scenario would have wrongly passed).
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=False),
+    )
+
+    result = time_service._probe()
+
+    assert result["quality"] == "system"
+    assert result["source"] == "system"
+
+
+def test_ntp_unsynchronized_rtc_not_detected_falls_back_to_system(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=False, configured=False, readable=False),
+    )
+
+    result = time_service._probe()
+
+    assert result["quality"] == "system"
+    assert result["source"] == "system"
+
+
+# ---------------- new fields ----------------
+
+def test_new_rtc_fields_present_and_match_stages(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=False),
+    )
+
+    result = time_service._probe()
+
+    assert result["rtc_detected"] is True
+    assert result["rtc_configured"] is True
+    assert result["rtc_readable"] is False
+    # Backward-compat field mirrors rtc_configured, not the old raw
+    # /sys/class/rtc/rtc0 existence check.
+    assert result["rtc_present"] is True
+
+
+def test_get_status_exposes_new_fields_after_refresh(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
+    )
+
+    time_service._refresh_cache()
+    status = time_service.get_status()
+
+    assert status["rtc_detected"] is True
+    assert status["rtc_configured"] is True
+    assert status["rtc_readable"] is True
+    assert status["rtc_present"] is True
+    assert status["quality"] == "rtc"
+
+
+def test_get_status_defaults_when_cache_empty():
+    status = time_service.get_status()
+    assert status["rtc_detected"] is False
+    assert status["rtc_configured"] is False
+    assert status["rtc_readable"] is False
+    assert status["rtc_present"] is False
+    assert status["quality"] == "unknown"
+
+
+# ---------------- error resilience ----------------
+
+def test_rtc_service_exception_does_not_crash_probe(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+
+    def _raise(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(time_service.rtc_service, "get_status", _raise)
+
+    result = time_service._probe()  # must not raise
+
+    assert result["rtc_detected"] is False
+    assert result["rtc_configured"] is False
+    assert result["rtc_readable"] is False
+    assert result["quality"] == "system"
+    # NTP/timezone side of the probe is unaffected by the RTC exception.
+    assert result["synchronized"] is False
+    assert result["timezone"] == "UTC"
+
+
+def test_timedatectl_failure_does_not_crash_probe(monkeypatch):
+    def _raise(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="timedatectl", timeout=3)
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
+    )
+
+    result = time_service._probe()  # must not raise
+
+    assert result["synchronized"] is False
+    # RTC side is unaffected by the timedatectl failure - still reports
+    # quality "rtc" since NTP unsynced + RTC fully ready.
+    assert result["quality"] == "rtc"
+
+
+# ---------------- RTC caching (_RTC_CACHE_TTL) ----------------
+
+def test_rtc_status_not_requeried_within_ttl(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    calls = []
+
+    def _tracked_get_status(**kwargs):
+        calls.append(kwargs)
+        return _rtc_status(detected=True, configured=True, readable=True)
+
+    monkeypatch.setattr(time_service.rtc_service, "get_status", _tracked_get_status)
+
+    time_service._probe()
+    time_service._probe()
+
+    assert len(calls) == 1
+
+
+def test_rtc_status_requeried_after_ttl_expires(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    calls = []
+
+    def _tracked_get_status(**kwargs):
+        calls.append(kwargs)
+        return _rtc_status(detected=True, configured=True, readable=True)
+
+    monkeypatch.setattr(time_service.rtc_service, "get_status", _tracked_get_status)
+
+    time_service._probe()
+    assert len(calls) == 1
+
+    # Simulate TTL having elapsed by directly backdating the module's own
+    # cache timestamp - same "touch module state directly" approach the
+    # rest of this test suite uses for module-level caches (see
+    # tests/test_cpu_history.py), rather than mocking time.monotonic().
+    time_service._rtc_cache_ts = time.monotonic() - time_service._RTC_CACHE_TTL - 1
+
+    time_service._probe()
+    assert len(calls) == 2
+
+
+# ---------------- is_trusted() unaffected ----------------
+
+def test_is_trusted_only_looks_at_ntp_synchronized(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
+    )
+
+    time_service._refresh_cache()
+
+    # RTC is fully ready here, but is_trusted() must still be False - it
+    # only ever looks at NTP synchronization, per this task's explicit
+    # instruction not to change that.
+    assert time_service.is_trusted() is False
+
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=True))
+    time_service._refresh_cache()
+    assert time_service.is_trusted() is True


### PR DESCRIPTION
## Summary

Follow-up to task 23 ([PR #84](https://github.com/FlintUA/MeshCenter/pull/84)), which deliberately left `meshsrv/time_service.py` untouched. This PR gives it a real, three-stage RTC status via `hardware/rtc_service.py` instead of a single `Path("/sys/class/rtc/rtc0").exists()` check.

## `meshsrv/time_service.py`

- Replaced the raw `Path` check with `hardware.rtc_service.get_status(model="ds3231")`, on its own cache separate from the existing 20s NTP/timezone poll: `_RTC_CACHE_TTL = 300` seconds, its own `_rtc_cache`/`_rtc_cache_ts` pair mirroring the existing `_cache`/`_cache_ts` pattern (same architecture, not a new caching approach). `_get_rtc_status()` is called every `_probe()` (every 20s) but only actually re-queries `i2cdetect`/`hwclock` once per 5 minutes.
- Wrapped in its own `try/except Exception` inside `_get_rtc_status()` (not relying on `rtc_service` itself never raising, per the task's explicit instruction) - an unexpected exception logs via `print(f"[TIME] ...")` (same style as the existing `except` in `_probe()`) and reports RTC as fully unavailable for that cycle without affecting the NTP/timezone side of the probe at all.
- New fields, nothing removed/renamed: `rtc_detected`, `rtc_configured`, `rtc_readable` (from the three stages), plus `rtc_present` kept for backward compatibility - now mirrors `rtc_configured`'s meaning (same underlying fact: "the kernel has an RTC device configured") rather than the old raw file check.
- `quality`/`source` logic **tightened, not rewritten**: `synchronized: true` still always wins regardless of RTC state (unconditional, no change there). The RTC fallback branch now requires **both** `rtc_configured` and `rtc_readable` - previously it only checked "the file exists," which would misreport `quality: "rtc"` for an RTC that's configured but genuinely can't be read (permissions, occupied by a different device - see `rtc_service.py`'s own docstring for these exact scenarios). Otherwise falls back to `"system"`, unchanged.
- `is_trusted()` **untouched** - still only reads `synchronized`, per the task's explicit instruction (RTC is a boot/offline-recovery source, not a "trusted time" signal for `node_time_sync.py`/`schedule_engine.py`).
- Module docstring updated to describe the RTC integration and the caching rationale.

### Consumers - confirmed unbroken

`grep -n "rtc_present\|get_status()" meshsrv/time_service.py modules/display/service.py meshsrv/node_time_sync.py meshsrv/schedule_engine.py api/api_system.py` - the four external consumers only ever read `'utc'`/`'timezone'` off the returned dict or call `is_trusted()`, none reference a field that was removed or renamed. `api/api_system.py`'s `GET /api/time` route (`return jsonify(get_status())`) is unchanged - it just gets a larger dict now.

## UI (`static/chat.js`)

`updateTimeCardSource()` now actually uses the `time.source_ntp`/`source_rtc`/`source_system`/`not_verified` i18n keys that were already present in all four catalogs but unused anywhere in the code (confirmed via grep before this task):

- `quality === "synchronized"` → `I18N.t('time.source_ntp')` (previously showed nothing at all when synchronized - only the "not synchronized" case was ever visible to the user).
- `quality === "rtc"` → `I18N.t('time.source_rtc')`.
- otherwise → `` `${I18N.t('time.source_system')} (${I18N.t('time.not_verified')})` `` - same parenthetical formatting pattern the file already uses elsewhere (`` `(${I18N.t('time.not_synchronized')})` ``).
- The `data === null` (fetch failure) branch is untouched, as instructed - unrelated to `quality`.

No new i18n keys needed - confirmed via `scripts/check-i18n.py` (still in sync, zero catalog files touched by this commit).

## Tests - `tests/test_time_service.py` (first test file for this module, 12 tests)

- Quality/source logic for all four combinations called out by the task: NTP synced (wins regardless of RTC, even fully-ready RTC), NTP unsynced + RTC fully ready (`"rtc"`), NTP unsynced + RTC configured-but-not-readable (the tightened case - `"system"`, not `"rtc"`), NTP unsynced + RTC not detected at all (`"system"`, unchanged prior behavior).
- New-field presence: `rtc_detected`/`rtc_configured`/`rtc_readable` match the mocked stages; `rtc_present` mirrors `rtc_configured`; `get_status()` exposes all of them both after a real refresh and in the empty-cache default case.
- Error resilience: `rtc_service.get_status()` raising an unexpected exception doesn't crash `_probe()` - RTC fields fall to `False`, NTP/timezone side unaffected. Same check for a `timedatectl` failure (pre-existing behavior, re-verified it still holds with the RTC integration added).
- Caching: two `_probe()` calls in a row within `_RTC_CACHE_TTL` call the mocked `rtc_service.get_status` exactly once; after directly backdating `time_service._rtc_cache_ts` past the TTL (same "touch module state directly" approach `tests/test_cpu_history.py` already uses for its own module cache, rather than mocking `time.monotonic()` - matches this project's existing pattern per the task's instruction), a third call re-queries.
- `is_trusted()` confirmed still NTP-only: `False` with a fully-ready RTC and unsynced NTP, `True` once NTP syncs, regardless of RTC.

## Verification

- `python -m compileall meshsrv/time_service.py` - clean (ran on the whole repo too, no regressions elsewhere).
- `node --check static/chat.js` - clean.
- `pytest -q`: **159 passed + 7 skipped** (was 147 + 7).
- Required grep check (consumers): see above - all four confirmed unbroken.
- **Live-verified on node 104** (real DS3231, already configured, per task 23):
  - `GET /api/time` → `{"quality":"synchronized","rtc_configured":true,"rtc_detected":true,"rtc_present":true,"rtc_readable":false,"source":"ntp","synchronized":true,"timezone":"Europe/Berlin",...}` - real network NTP wins as expected; RTC fields correctly reflect the same `readable: false` finding from task 23's own live verification (`/dev/rtc0` is root-only, the service runs unprivileged) - the tightened `quality` logic correctly does **not** report `"rtc"` here even though `configured` is true, because `readable` is false.
  - Time card in the browser: `#timeClockSource` now shows **"NTP"**, visible and rendered (confirmed via `getBoundingClientRect()`), no longer blank.
  - Directly exercised the other two branches by calling `updateTimeCardSource()` with synthetic `quality: 'system'`/`quality: 'rtc'` data (without disturbing dev's real NTP state) - correctly rendered `"Системные часы (не проверено)"` (ru UI) and `"RTC"` respectively, then restored to the real `"NTP"` state via a fresh `syncTimeWithServer()` call, confirmed.
  - No new console errors (only the same pre-existing node-icon 404 pattern already seen and explained in every prior task's verification pass this session).
  - **The live RTC-quality branch (NTP genuinely unsynced) was not exercised on real hardware** - stopping `systemd-timesyncd` on dev to force it was judged not worth the risk to a working node for this verification; per the task's own explicit allowance, this branch is verified only by `test_time_service.py`'s mocked tests (all passing) plus the direct `updateTimeCardSource()` browser call above, not by an actual NTP outage.
  - `journalctl` showed one unrelated transient radio-serial glitch (`LISTENER_DOWN` self-recovering, one `Wire format was corrupt` protobuf decode error) during this pass - same category of pre-existing hardware-layer noise already seen and explained in multiple prior tasks' verification passes this session (PHOTO/MAP/UPDATES-SECURITY), unrelated to this pure-Python change; confirmed the service is fully healthy immediately after via direct `curl` on both `/api/base_status` and `/api/time`.

## Out of scope (per this task, confirmed not touched)

`is_trusted()` unchanged. `hardware/hardware_config.py`'s pending-setup mechanism and `/api/hardware/rtc` untouched (already done in task 23). No UI configurator (Enable I2C/Configure RTC buttons) built. `modules/display/service.py` untouched - it only ever reads `timezone`, no RTC details needed there. RTC-caching logic kept inside `meshsrv/time_service.py`, not extracted to a separate module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Fix after review: hermetic test

Review caught a real, non-flaky-but-non-hermetic bug in `tests/test_time_service.py::test_rtc_service_exception_does_not_crash_probe`: it mocked `subprocess.check_output` (timedatectl) but not the real `/etc/timezone` file read `_probe()` falls back to whenever the parsed timezone is `"UTC"`. On any machine where `/etc/timezone` doesn't literally contain `"UTC"` (e.g. `"Etc/UTC"`, or - confirmed on node 104 - `"Europe/Berlin"`), that real read silently overrides the mocked value and the test's `result["timezone"] == "UTC"` assertion fails deterministically.

Fixed by mocking `Path.read_text` to raise `FileNotFoundError` for that one test, matching how a system with no `/etc/timezone` at all already behaves via `_probe()`'s own `except Exception: pass` fallback - the mocked `"UTC"` is what actually survives now, regardless of the host's real file content.

**Verified the fix on two machines with different real `/etc/timezone` contents**: this Windows sandbox (no `/etc/timezone` at all) and node 104, whose real `/etc/timezone` is `"Europe/Berlin"` - confirmed that value would have broken the original test the same way it broke on review. `pytest -q tests/test_time_service.py` → 12/12 passed on node 104's real Linux environment; full suite → **166/166 passed** there (the 7 tests skipped on Windows for POSIX-only reasons run for real on Linux). No other files touched, no other test needed the same fix (grep confirmed this was the only `assert result["timezone"] == "UTC"` in the file).
