### PR TITLE
fix: register i2c-dev kernel module in /etc/modules on enable-i2c

### DIFF
--- a/api/api_hardware_i2c.py
+++ b/api/api_hardware_i2c.py
@@ -26,7 +26,19 @@ def register_hardware_i2c_routes(app, handle_errors, data_dir: str):
     def api_hardware_i2c_status():
         hardware_config.reconcile_pending(data_dir)
         scan = i2c_service.scan_bus()
-        return jsonify({"ok": True, **scan})
+        response = {"ok": True, **scan}
+        if not scan.get("ok"):
+            # Only pay the extra sudo round-trip (hardware_config.py's
+            # helper_status(), which shells out to the privileged helper)
+            # once the free i2c_service.scan_bus() check has already
+            # failed - i2c_dev_module_loaded (task 27) distinguishes "I2C
+            # was never enabled" from "enabled, i2c-dev registered, just
+            # waiting on a reboot to actually load" without adding that
+            # cost to the common case where the bus already works.
+            helper = hardware_config.helper_status()
+            if helper.get("ok"):
+                response["i2c_dev_module_loaded"] = helper.get("i2c_dev_module")
+        return jsonify(response)
 
     @app.route("/api/hardware/i2c/enable", methods=["POST"])
     @handle_errors

--- a/hardware/hardware_config.py
+++ b/hardware/hardware_config.py
@@ -18,6 +18,7 @@ before rebooting.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 from pathlib import Path
@@ -107,7 +108,32 @@ def configure_rtc(data_dir: str, model: str) -> dict:
 
 
 def helper_status() -> dict:
-    return _run_helper("status")
+    """The helper's own `status` subcommand output, parsed - fields today:
+    i2c_enabled/rtc_overlay (from config.txt) and i2c_dev_module (from
+    /etc/modules, task 27 - the piece a bare dtparam=i2c_arm=on doesn't
+    cover: /dev/i2c-N needs the i2c-dev kernel module loaded, which only
+    happens automatically once it's registered there, the same second
+    step raspi-config's own I2C-enable menu item takes).
+
+    On success, `{"ok": True, "i2c_enabled": bool, "rtc_overlay": str|None,
+    "i2c_dev_module": bool}` (whatever the helper's JSON contained,
+    merged in - forward-compatible with fields added later). On any
+    failure (sudo misconfigured, malformed output, ...) `{"ok": False,
+    "reason": "..."}`, same shape as every other function in this module.
+    """
+    result = _run_helper("status")
+    if not result.get("ok"):
+        return result
+
+    try:
+        parsed = json.loads(result.get("stdout", ""))
+    except (ValueError, TypeError) as exc:
+        return {"ok": False, "reason": f"meshcenter-hw-config status returned invalid JSON: {exc}"}
+
+    if not isinstance(parsed, dict):
+        return {"ok": False, "reason": "meshcenter-hw-config status returned a non-object JSON value"}
+
+    return {"ok": True, **parsed}
 
 
 def get_pending(data_dir: str) -> dict | None:

--- a/hardware/i2c_service.py
+++ b/hardware/i2c_service.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+from pathlib import Path
 
 DEFAULT_BUS = 1
 I2CDETECT_TIMEOUT = 10
@@ -33,6 +34,25 @@ def scan_bus(bus: int = DEFAULT_BUS) -> dict:
     "UU" cells (address claimed by an already-bound kernel driver) count as
     detected - the address responded, that's all this layer answers.
     """
+    device_path = f"/dev/i2c-{bus}"
+    if not Path(device_path).exists():
+        # A cheap, sudo-free check ahead of the real i2cdetect call - found
+        # to matter live (task 27): dtparam=i2c_arm=on alone only brings up
+        # the bus controller at the Device Tree level, not the /dev/i2c-N
+        # character device, which needs the separate i2c-dev kernel module
+        # actually loaded. i2cdetect's own error for this case
+        # ("Could not open file `/dev/i2c-N'...") doesn't explain why or
+        # what to do about it - this does, without the cost of a
+        # privileged status round-trip on every scan.
+        return {
+            "ok": False,
+            "bus": bus,
+            "reason": (
+                f"{device_path} does not exist - I2C may not be enabled yet, or the "
+                "i2c-dev kernel module hasn't loaded (enable I2C, then reboot)"
+            ),
+        }
+
     try:
         result = subprocess.run(
             ["i2cdetect", "-y", str(bus)],

--- a/scripts/meshcenter-hw-config
+++ b/scripts/meshcenter-hw-config
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 #
-# meshcenter-hw-config - narrow, root-only helper for enabling I2C and
-# configuring an RTC overlay in /boot/firmware/config.txt.
+# meshcenter-hw-config - narrow, root-only helper for enabling I2C
+# (config.txt + the i2c-dev kernel module in /etc/modules) and configuring
+# an RTC overlay in /boot/firmware/config.txt.
 #
-# This is the ONLY thing allowed to touch /boot/firmware/config.txt on
-# behalf of MeshCenter's web UI: the Flask process runs as an unprivileged
-# user and calls this script through `sudo -n` (see hardware/hardware_config.py,
-# the single Python entry point for this script - nothing else in the
-# codebase should invoke it directly). Never accepts a config file path as
-# an argument - the path is fixed on purpose, so a compromised/buggy caller
-# can't be tricked into writing an arbitrary file as root.
+# This is the ONLY thing allowed to touch /boot/firmware/config.txt or
+# /etc/modules on behalf of MeshCenter's web UI: the Flask process runs as
+# an unprivileged user and calls this script through `sudo -n` (see
+# hardware/hardware_config.py, the single Python entry point for this
+# script - nothing else in the codebase should invoke it directly). Never
+# accepts a file path as an argument - both paths are fixed on purpose, so
+# a compromised/buggy caller can't be tricked into writing an arbitrary
+# file as root.
 #
 # Usage:
 #   meshcenter-hw-config enable-i2c
@@ -23,51 +25,71 @@
 set -euo pipefail
 
 CONFIG_TXT="/boot/firmware/config.txt"
+MODULES_FILE="/etc/modules"
 
 fail() {
     echo "meshcenter-hw-config: error: $1" >&2
     exit 1
 }
 
-require_config_txt() {
-    [[ -f "$CONFIG_TXT" ]] || fail "$CONFIG_TXT does not exist on this system"
+require_file() {
+    [[ -f "$1" ]] || fail "$1 does not exist on this system"
 }
 
-# Appends $1 to $CONFIG_TXT if no active (non-commented) copy of it already
+require_config_txt() {
+    require_file "$CONFIG_TXT"
+}
+
+# Appends $2 to file $1 if no active (non-commented) copy of it already
 # exists, backing up the original first. A commented-out copy
 # (e.g. "#dtparam=i2c_arm=on") does NOT count as already present - it is
 # left alone and the active line is appended below it, matching how a user
-# manually editing config.txt would expect an explicit request to behave.
-ensure_config_line() {
-    local line="$1"
-    require_config_txt
+# manually editing the file would expect an explicit request to behave.
+# Shared between config.txt (dtparam/dtoverlay lines) and /etc/modules
+# (one bare module name per line, e.g. "i2c-dev") - same idempotent/
+# atomic/backed-up shape either way, just a different target file.
+ensure_line_in_file() {
+    local file="$1"
+    local line="$2"
+    require_file "$file"
 
-    if grep -qxF "$line" "$CONFIG_TXT"; then
-        echo "already present: $line"
+    if grep -qxF "$line" "$file"; then
+        echo "already present in $file: $line"
         return 0
     fi
 
-    local backup="${CONFIG_TXT}.bak-$(date +%Y%m%d%H%M%S)"
-    cp -p "$CONFIG_TXT" "$backup"
+    local backup="${file}.bak-$(date +%Y%m%d%H%M%S)"
+    cp -p "$file" "$backup"
 
     local tmp
-    tmp="$(mktemp "${CONFIG_TXT}.tmp.XXXXXX")"
-    cp -p "$CONFIG_TXT" "$tmp"
+    tmp="$(mktemp "${file}.tmp.XXXXXX")"
+    cp -p "$file" "$tmp"
     printf '%s\n' "$line" >> "$tmp"
-    mv -f "$tmp" "$CONFIG_TXT"
+    mv -f "$tmp" "$file"
 
-    echo "added: $line (backup: $backup)"
+    echo "added to $file: $line (backup: $backup)"
 }
 
 cmd_enable_i2c() {
-    ensure_config_line "dtparam=i2c_arm=on"
+    ensure_line_in_file "$CONFIG_TXT" "dtparam=i2c_arm=on"
+    # dtparam=i2c_arm=on only brings up the bus controller
+    # (i2c_bcm2835/i2c_brcmstb) at the Device Tree level - the /dev/i2c-N
+    # character device that i2cdetect/i2cget/i2ctransfer (and therefore
+    # hardware/i2c_service.py's whole detection layer) actually need comes
+    # from the separate i2c-dev kernel module, which does NOT load
+    # automatically just because the overlay is active. raspi-config's own
+    # I2C-enable menu item does this same second step (registering
+    # i2c-dev in /etc/modules) - confirmed missing here by a real
+    # camtest reboot where /dev/i2c-1 never appeared despite
+    # dtparam=i2c_arm=on being correctly applied (task 27).
+    ensure_line_in_file "$MODULES_FILE" "i2c-dev"
 }
 
 cmd_configure_rtc() {
     local model="${1:-}"
     case "$model" in
         ds3231)
-            ensure_config_line "dtoverlay=i2c-rtc,ds3231"
+            ensure_line_in_file "$CONFIG_TXT" "dtoverlay=i2c-rtc,ds3231"
             ;;
         "")
             fail "configure-rtc requires a model argument (supported: ds3231)"
@@ -91,9 +113,15 @@ cmd_status() {
         rtc_overlay="ds3231"
     fi
 
-    printf '{"i2c_enabled": %s, "rtc_overlay": %s}\n' \
+    local i2c_dev_module="false"
+    if [[ -f "$MODULES_FILE" ]] && grep -qxF "i2c-dev" "$MODULES_FILE"; then
+        i2c_dev_module="true"
+    fi
+
+    printf '{"i2c_enabled": %s, "rtc_overlay": %s, "i2c_dev_module": %s}\n' \
         "$i2c_enabled" \
-        "$([[ -n "$rtc_overlay" ]] && printf '"%s"' "$rtc_overlay" || printf 'null')"
+        "$([[ -n "$rtc_overlay" ]] && printf '"%s"' "$rtc_overlay" || printf 'null')" \
+        "$i2c_dev_module"
 }
 
 main() {

--- a/static/chat.js
+++ b/static/chat.js
@@ -9092,6 +9092,15 @@ function renderRtcCard(hardwareRtcData, profileId) {
                 : window.I18N.t('devices.rtc_not_configured');
 
     const stageMark = (ok) => ok ? '✓' : '✗';
+    // Surfaced as a tooltip rather than new card content (task 27) - the
+    // setup button already tells the user what to do in the common case,
+    // so the underlying technical reason (e.g. "i2c-dev kernel module
+    // hasn't loaded") is more useful as on-hover diagnostic detail for
+    // "I clicked Enable I2C, rebooted, and it's still not working" than
+    // as always-visible card text.
+    const detectedReasonTitle = !detected && stages.detected?.reason
+        ? ` title="${escapeHtml(window.I18N.t('devices.rtc_not_detected_reason', { reason: stages.detected.reason }))}"`
+        : '';
 
     // Exactly one of these three renders: mid-reboot-wait (pending), not
     // yet fully ready (setup button - safe to click even from a partial
@@ -9131,7 +9140,7 @@ function renderRtcCard(hardwareRtcData, profileId) {
                     <div class="device-card-eyebrow">${eyebrow}</div>
                     <h3>${deviceDashboardValue(hardwareRtcData.display_name || hardwareRtcData.model)}</h3>
                 </div>
-                <div class="device-status-pill ${statusClass}">
+                <div class="device-status-pill ${statusClass}"${detectedReasonTitle}>
                     <span class="device-status-dot"></span>${escapeHtml(statusLabel)}
                 </div>
             </div>

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -322,6 +322,7 @@
     "rtc_readable": "Lesbar",
     "rtc_bus_address": "Bus / Adresse",
     "rtc_linux_device": "Linux-Gerät",
+    "rtc_not_detected_reason": "Nicht erkannt: {reason}",
     "rtc_not_configured": "Nicht eingerichtet",
     "rtc_setup_button": "I2C aktivieren & RTC einrichten",
     "rtc_setup_confirm": "I2C aktivieren und den RTC-Overlay einrichten?\n\nDas ändert die Systemdatei /boot/firmware/config.txt und erfordert einen Neustart, damit es wirksam wird.",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -322,6 +322,7 @@
     "rtc_readable": "Readable",
     "rtc_bus_address": "Bus / address",
     "rtc_linux_device": "Linux device",
+    "rtc_not_detected_reason": "Not detected: {reason}",
     "rtc_not_configured": "Not configured",
     "rtc_setup_button": "Enable I2C & configure RTC",
     "rtc_setup_confirm": "Enable I2C and configure the RTC overlay?\n\nThis edits the system file /boot/firmware/config.txt and requires a reboot to take effect.",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -322,6 +322,7 @@
     "rtc_readable": "Читается",
     "rtc_bus_address": "Шина / адрес",
     "rtc_linux_device": "Устройство Linux",
+    "rtc_not_detected_reason": "Не обнаружено: {reason}",
     "rtc_not_configured": "Не настроено",
     "rtc_setup_button": "Включить I2C и настроить RTC",
     "rtc_setup_confirm": "Включить I2C и настроить оверлей RTC?\n\nЭто изменит системный файл /boot/firmware/config.txt и потребует перезагрузки для применения.",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -322,6 +322,7 @@
     "rtc_readable": "Читається",
     "rtc_bus_address": "Шина / адреса",
     "rtc_linux_device": "Пристрій Linux",
+    "rtc_not_detected_reason": "Не виявлено: {reason}",
     "rtc_not_configured": "Не налаштовано",
     "rtc_setup_button": "Увімкнути I2C і налаштувати RTC",
     "rtc_setup_confirm": "Увімкнути I2C і налаштувати оверлей RTC?\n\nЦе змінить системний файл /boot/firmware/config.txt і потребуватиме перезавантаження для застосування.",

--- a/tests/test_api_hardware_i2c.py
+++ b/tests/test_api_hardware_i2c.py
@@ -59,13 +59,55 @@ def test_get_i2c_status_reports_scan_failure_reason(api_env):
     with patch(
         "hardware.i2c_service.scan_bus",
         return_value={"ok": False, "bus": 1, "reason": "i2cdetect not installed"},
-    ):
+    ), patch("hardware.hardware_config.helper_status", return_value={"ok": False, "reason": "boom"}):
         response = api_env["client"].get("/api/hardware/i2c")
 
     assert response.status_code == 200
     body = response.get_json()
     assert body["ok"] is False
     assert body["reason"] == "i2cdetect not installed"
+
+
+def test_get_i2c_status_success_never_calls_helper_status(api_env):
+    # No extra sudo round-trip on the common/happy path (task 27) - only
+    # pay for hardware_config.helper_status() once scan_bus() has already
+    # failed.
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": True, "bus": 1, "addresses": []},
+    ), patch("hardware.hardware_config.helper_status") as mock_helper_status:
+        response = api_env["client"].get("/api/hardware/i2c")
+
+    assert response.status_code == 200
+    mock_helper_status.assert_not_called()
+
+
+def test_get_i2c_status_failure_adds_i2c_dev_module_loaded_field(api_env):
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": False, "bus": 1, "reason": "/dev/i2c-1 does not exist"},
+    ), patch(
+        "hardware.hardware_config.helper_status",
+        return_value={"ok": True, "i2c_enabled": True, "rtc_overlay": None, "i2c_dev_module": False},
+    ):
+        response = api_env["client"].get("/api/hardware/i2c")
+
+    body = response.get_json()
+    assert body["i2c_dev_module_loaded"] is False
+
+
+def test_get_i2c_status_failure_helper_also_failing_omits_field(api_env):
+    with patch(
+        "hardware.i2c_service.scan_bus",
+        return_value={"ok": False, "bus": 1, "reason": "i2cdetect not installed"},
+    ), patch(
+        "hardware.hardware_config.helper_status",
+        return_value={"ok": False, "reason": "sudo is not configured"},
+    ):
+        response = api_env["client"].get("/api/hardware/i2c")
+
+    body = response.get_json()
+    assert "i2c_dev_module_loaded" not in body
 
 
 def test_post_i2c_enable_success_reports_requires_reboot(api_env):

--- a/tests/test_hardware_bme280_service.py
+++ b/tests/test_hardware_bme280_service.py
@@ -17,7 +17,21 @@ without hand-placing each byte.
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from hardware import bme280_service
+
+# get_status() goes through the real i2c_service.scan_bus(), which since
+# task 27 checks /dev/i2c-N exists before ever calling i2cdetect - this
+# dev/CI machine has no such device file, so without this every test below
+# would short-circuit to "not detected" before subprocess.run's mocked
+# dispatch is ever reached. Autouse so it applies uniformly; none of these
+# tests are about that check itself (that's covered directly in
+# test_hardware_i2c_service.py).
+@pytest.fixture(autouse=True)
+def _device_file_exists():
+    with patch("hardware.i2c_service.Path.exists", return_value=True):
+        yield
 
 
 def _u16_le(value: int) -> list:

--- a/tests/test_hardware_config.py
+++ b/tests/test_hardware_config.py
@@ -75,12 +75,41 @@ def test_helper_timeout_reported_not_raised(tmp_path):
 
 
 def test_status_calls_helper_status_subcommand():
-    mock_run = MagicMock(return_value=_completed(stdout='{"i2c_enabled": true, "rtc_overlay": "ds3231"}'))
+    mock_run = MagicMock(
+        return_value=_completed(
+            stdout='{"i2c_enabled": true, "rtc_overlay": "ds3231", "i2c_dev_module": true}'
+        )
+    )
     with patch("subprocess.run", mock_run):
         result = hardware_config.helper_status()
-    assert result["ok"] is True
+    assert result == {
+        "ok": True,
+        "i2c_enabled": True,
+        "rtc_overlay": "ds3231",
+        "i2c_dev_module": True,
+    }
     args, _ = mock_run.call_args
     assert args[0] == ["sudo", "-n", hardware_config.HELPER_PATH, "status"]
+
+
+def test_status_helper_failure_passed_through_unparsed(tmp_path):
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="boom")):
+        result = hardware_config.helper_status()
+    assert result == {"ok": False, "reason": "boom"}
+
+
+def test_status_invalid_json_reported_not_raised():
+    with patch("subprocess.run", return_value=_completed(stdout="not json")):
+        result = hardware_config.helper_status()
+    assert result["ok"] is False
+    assert "invalid JSON" in result["reason"]
+
+
+def test_status_non_object_json_reported():
+    with patch("subprocess.run", return_value=_completed(stdout="[1, 2, 3]")):
+        result = hardware_config.helper_status()
+    assert result["ok"] is False
+    assert "non-object" in result["reason"]
 
 
 # ---------------- pending-setup state machine ----------------

--- a/tests/test_hardware_i2c_service.py
+++ b/tests/test_hardware_i2c_service.py
@@ -7,7 +7,21 @@ subprocess.run is mocked throughout; nothing here touches real hardware.
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hardware import i2c_service
+
+# Every pre-existing test in this file exercises the subprocess.run/i2cdetect
+# path and predates the /dev/i2c-N existence check added in task 27 - none
+# of them mock Path.exists, and the check would otherwise short-circuit
+# before subprocess.run is even called (this file's dev machine, Windows or
+# a CI Linux box, has no /dev/i2c-1). Autouse so every test below keeps
+# testing what it already tests; tests for the new early-return path itself
+# override this explicitly.
+@pytest.fixture(autouse=True)
+def _device_file_exists():
+    with patch("hardware.i2c_service.Path.exists", return_value=True):
+        yield
 
 # Captured verbatim from `sudo i2cdetect -y 1` on the real test node (104) -
 # a DS3231 already bound to the rtc-ds1307 kernel driver, hence "UU" at
@@ -129,3 +143,30 @@ def test_scan_bus_passes_bus_number_as_argument_not_shell_string():
     args, kwargs = mock_run.call_args
     assert args[0] == ["i2cdetect", "-y", "3"]
     assert kwargs.get("shell") is not True
+
+
+# ---------------- /dev/i2c-N existence check (task 27) ----------------
+
+def test_scan_bus_missing_device_file_skips_subprocess_entirely():
+    # The whole point of this check is avoiding the real i2cdetect call
+    # (and its less-actionable error message) when the character device
+    # isn't there at all - assert subprocess.run is never even invoked.
+    mock_run = MagicMock()
+    with patch("hardware.i2c_service.Path.exists", return_value=False), \
+            patch("subprocess.run", mock_run):
+        result = i2c_service.scan_bus(1)
+
+    mock_run.assert_not_called()
+    assert result["ok"] is False
+    assert result["bus"] == 1
+    assert "/dev/i2c-1" in result["reason"]
+    assert "i2c-dev" in result["reason"]
+
+
+def test_scan_bus_missing_device_file_uses_correct_bus_number_in_path():
+    with patch("hardware.i2c_service.Path.exists", return_value=False), \
+            patch("subprocess.run"):
+        result = i2c_service.scan_bus(3)
+
+    assert result["bus"] == 3
+    assert "/dev/i2c-3" in result["reason"]


### PR DESCRIPTION
## Summary
- `enable-i2c` only ever edited `config.txt` (`dtparam=i2c_arm=on`), which brings up the I2C bus controller at the Device Tree level but not the `i2c-dev` kernel module that provides `/dev/i2c-N` — the character device `i2cdetect`/`i2cget`/`i2ctransfer` (and therefore the whole hardware/i2c_service.py detection layer) depend on. Root-caused via a live camtest reboot (task 25's own verification) where `/dev/i2c-1` never appeared despite the overlay being correctly applied.
- `scripts/meshcenter-hw-config`: generalized `ensure_config_line()` into `ensure_line_in_file(file, line)`, reused for both `config.txt` and the new `/etc/modules` target; `enable-i2c` now writes `i2c-dev` there too; `status` reports a new `i2c_dev_module` field.
- `hardware/hardware_config.py`: `helper_status()` now parses the helper's JSON output instead of returning it as a raw string.
- `hardware/i2c_service.py`: `scan_bus()` checks `/dev/i2c-N` exists before shelling out to `i2cdetect`, with a reason string explaining why — cheap and sudo-free, and it propagates through `rtc_service.py`/`bme280_service.py`'s existing reason-passthrough with zero changes needed there.
- `api/api_hardware_i2c.py`: `GET /api/hardware/i2c` surfaces `i2c_dev_module_loaded` as a diagnostic-only field, fetched via the privileged helper only once the free scan has already failed (no added sudo cost on the happy path).
- `static/chat.js` + all 4 i18n catalogs: RTC card's status pill now shows the detection reason as a tooltip (new `devices.rtc_not_detected_reason` key, `{reason}`-interpolation pattern matching the existing `rtc_setup_failed_reason` precedent). BME280's card renders nothing at all when undetected, so there's no element to attach a tooltip to — left untouched.

## Test plan
- [x] `bash -n scripts/meshcenter-hw-config`
- [x] `node --check static/chat.js`
- [x] `python -m compileall` on all changed Python files
- [x] `python scripts/check-i18n.py` — all 4 catalogs in sync
- [x] `pytest -q` — 178 passed / 7 skipped (Windows POSIX-only skips), new/extended coverage in `test_hardware_config.py`, `test_hardware_i2c_service.py`, `test_api_hardware_i2c.py`, `test_hardware_bme280_service.py`
- [x] `pytest -q` on real Linux (dev + camtest) — 185 passed, 0 skipped
- [x] Live on camtest: installed updated helper, ran `enable-i2c` (config.txt no-op idempotent, `/etc/modules` got `i2c-dev` added with backup), reran idempotently (no duplicate line), rebooted — `i2c_dev` module loaded, `/dev/i2c-1` exists, bus scan succeeds with an empty address list (no physical DS3231/BME280 there, that's expected), no errors in journalctl or browser console
- [x] Live on dev/104: confirmed `/etc/modules` already had `i2c-dev` from an earlier manual setup, ran `enable-i2c` twice — genuinely idempotent, exactly one line, no duplicate. Confirmed real DS3231 still detected+configured after the update.

## Known follow-up (out of scope here, not fixed)
On dev/104, the RTC card's `readable` stage fails (`hwclock: Cannot access the Hardware Clock via any known method`) — `/dev/rtc0` is `root`-only (`crw-------`) and `meshcenter.service` runs as the unprivileged `flint` user with no udev rule granting group access. Pre-existing, unrelated to this fix (`rtc_service.py` and permissions aren't touched here); worth a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)