### PR TITLE
fix: grant i2c group read access to /dev/rtcN (RTC readable stage)

### DIFF
--- a/deploy/99-meshcenter-rtc.rules
+++ b/deploy/99-meshcenter-rtc.rules
@@ -1,0 +1,19 @@
+# MeshCenter - grants the `i2c` group read access to the RTC hardware clock
+# device. Debian/Raspberry Pi OS ship no udev rule for /dev/rtcN at all, so
+# it defaults to root:root mode 0600 - confirmed live (task 35) via
+# `ls -l /dev/rtc0` on two nodes with a physical DS3231 attached, both
+# showing the identical permission gap. Without this,
+# hardware/rtc_service.py's readable-stage check (`hwclock -r`, deliberately
+# called without sudo - see that module's own docstring) can never succeed
+# for the unprivileged MeshCenter service user, even once the RTC is
+# correctly detected and configured.
+#
+# Reuses the `i2c` group rather than inventing a new one: it's already what
+# grants /dev/i2c-N access via the stock 60-i2c-aliases.rules/
+# 60-i2c-tools.rules (GROUP="i2c", MODE="0660"), and both install.sh and
+# meshcenter-firstboot.sh already put the MeshCenter user in it for that
+# reason - RTC access piggybacks on membership that already has to exist
+# for I2C detection to work at all.
+#
+# Read-only (no "w") is enough - hwclock -r only reads.
+SUBSYSTEM=="rtc", GROUP="i2c", MODE="0640"

--- a/install.sh
+++ b/install.sh
@@ -510,6 +510,23 @@ step_systemd() {
     sudo install -o root -g root -m 0755 \
         "${INSTALL_DIR}/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
 
+    # I2C bus access (unprivileged, via stock 60-i2c-aliases.rules) and now
+    # RTC hardware-clock access (deploy/99-meshcenter-rtc.rules below) both
+    # ride on membership in the `i2c` group - meshcenter-firstboot.sh's
+    # first-boot path already grants this, but this manual/existing-install
+    # path (unlike its `dialout` usermod above) never did (task 35).
+    sudo usermod -a -G i2c "$USER" 2>/dev/null || true
+
+    # Grants the `i2c` group read access to /dev/rtcN - without it,
+    # hardware/rtc_service.py's readable-stage check can never succeed even
+    # once the RTC is detected and configured (task 35). Declarative, not a
+    # sudo rule - unlike the helper above, this needs no privileged runtime
+    # call.
+    sudo install -o root -g root -m 0644 \
+        "${INSTALL_DIR}/deploy/99-meshcenter-rtc.rules" /etc/udev/rules.d/99-meshcenter-rtc.rules
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger --subsystem-match=rtc
+
     # Render the repo's sudoers templates (service restart/reboot/poweroff,
     # Wi-Fi management, and the hardware-config helper above) instead of a
     # partial hand-rolled set — the UI's System, Wi-Fi and hardware actions

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -688,6 +688,8 @@ MESH_HOME="$TARGET_HOME"
     || fail "Missing deploy/meshcenter-hw.sudoers"
 [[ -f "$INSTALL_DIR/scripts/meshcenter-hw-config" ]] \
     || fail "Missing scripts/meshcenter-hw-config"
+[[ -f "$INSTALL_DIR/deploy/99-meshcenter-rtc.rules" ]] \
+    || fail "Missing deploy/99-meshcenter-rtc.rules"
 
 sed -e "s|__MESH_USER__|${MESH_USER}|g" \
     -e "s|__MESH_HOME__|${MESH_HOME}|g" \
@@ -699,6 +701,16 @@ sed -e "s|__MESH_USER__|${MESH_USER}|g" \
 # `sudo -n` - see scripts/meshcenter-hw-config's own docstring).
 install -o root -g root -m 0755 \
     "$INSTALL_DIR/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
+
+# Grants the `i2c` group (already assigned to $TARGET_USER above) read
+# access to /dev/rtcN - without it, hardware/rtc_service.py's readable-stage
+# check can never succeed even once the RTC is detected and configured
+# (task 35). Declarative, not a sudo rule - unlike the helper above, this
+# needs no privileged runtime call.
+install -o root -g root -m 0644 \
+    "$INSTALL_DIR/deploy/99-meshcenter-rtc.rules" /etc/udev/rules.d/99-meshcenter-rtc.rules
+udevadm control --reload-rules
+udevadm trigger --subsystem-match=rtc
 
 sed "s|__MESH_USER__|${MESH_USER}|g" \
     "$INSTALL_DIR/deploy/meshcenter.sudoers" \


### PR DESCRIPTION
## Summary
- `hardware/rtc_service.py`'s `readable` stage (`hwclock -r`, deliberately called without `sudo` — it's meant to stay a read-only, unprivileged check) could never succeed: Debian/Raspberry Pi OS ship no udev rule for `/dev/rtcN` at all, so it defaults to `root:root` mode `0600`.
- Confirmed live on two independent nodes with a physical DS3231 (dev and camtest) — both showed `detected:true`, `configured:true`, `readable:false`, with the exact same `hwclock: cannot open /dev/rtc0: Permission denied` underneath (`--verbose` output), ruling out a one-off install fluke.
- New `deploy/99-meshcenter-rtc.rules`: `SUBSYSTEM=="rtc", GROUP="i2c", MODE="0640"` — reuses the existing `i2c` group (already what grants `/dev/i2c-N` access via stock `60-i2c-aliases.rules`) rather than inventing a new one. Both install scripts already put the MeshCenter user in that group for I2C detection to work at all, so this just piggybacks on membership that already has to exist.
- `meshcenter-firstboot.sh`: installs the new rule alongside the existing `meshcenter-hw-config` helper install, reloads/triggers udev.
- `install.sh`: same rule install, **plus** `usermod -a -G i2c "$USER"` — this manual/existing-install path was missing `i2c` group membership entirely (only `dialout` was handled there; `firstboot.sh`'s group loop already covered `i2c`).
- No changes to `hardware/rtc_service.py` or `scripts/meshcenter-hw-config` — this is a declarative permissions fix, not a new privileged runtime call.

## Test plan
- [x] `bash -n install.sh meshcenter-firstboot.sh`
- [x] `pytest -q` — 178 passed / 7 skipped (unchanged — no Python touched)
- [x] Live on dev: installed the rule, `udevadm control --reload-rules && udevadm trigger --subsystem-match=rtc` — `/dev/rtc0` flipped to `root:i2c 0640`, `GET /api/hardware/rtc` immediately reports `readable: true` with a real timestamp (no service restart needed — this node's service user was already in `i2c` from earlier setup)
- [x] Live on camtest: same result, `readable: true` with a real timestamp
- [x] Idempotency: re-ran the rule install + `usermod` + `udevadm trigger` on dev — no error, no duplicate group entry, rule file cleanly overwritten

## Note
On a genuinely fresh install where `usermod -a -G i2c` grants group membership for the first time (rather than it already existing, as on both live-tested nodes here), that part needs a new login session or service restart to take effect — normal Linux group-membership semantics, not something this fix can skip. Not exercised live in this PR since both test nodes already had the membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)