### PR TITLE
style: move Time card's source indicator onto the clock's line

### DIFF
--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -948,6 +948,12 @@
     padding: 14px 0 12px;
 }
 
+.time-hero-clock-row {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
 .time-hero-clock {
     color: #263b52;
     font-size: 38px;
@@ -968,9 +974,21 @@
     font-weight: 600;
 }
 
+/* Same look as .weather-provider-link (task 36) - same small/muted/dotted
+   style so the two "where this reading came from" indicators read as one
+   consistent pattern. That element gets its color via `color: inherit`
+   from an ancestor with its own dark-mode override; .time-clock-source
+   sits in an unrelated part of the DOM with no equivalent ancestor, so
+   this hardcodes the exact computed values (devtools, both themes)
+   instead of trying to reproduce that inheritance chain here. */
 .time-clock-source {
-    color: #79879a;
-    font-size: 10px;
+    color: #10233f;
+    font-size: 9px;
+    font-weight: 650;
+    opacity: 0.85;
+}
+.time-clock-source::before {
+    content: "· ";
 }
 
 .time-section-label {

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -3951,6 +3951,7 @@ html[data-theme="dark"] #timeCard {
 [data-theme="dark"] .time-hero-clock { color: #e5eff8; }
 [data-theme="dark"] .time-hero-date { color: #dbe8f5; }
 [data-theme="dark"] .time-hero-week { color: #9eb3c8; }
+[data-theme="dark"] .time-clock-source { color: #8bc0ff; }
 [data-theme="dark"] .time-section-label { color: #9eb3c8; }
 
 [data-theme="dark"] .time-schedule-row { border-bottom-color: #2a3f54; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,8 +8,8 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260821-style-split">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260821-style-split">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260821-style-split">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260821-style-split">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260822-time-source-row">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260822-time-source-row">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
@@ -141,10 +141,12 @@
                 </div>
                 <div class="time-card-body" id="timeCardBody">
                     <div class="time-hero">
-                        <div class="time-hero-clock" id="timeClockDisplay">--:--</div>
+                        <div class="time-hero-clock-row">
+                            <div class="time-hero-clock" id="timeClockDisplay">--:--</div>
+                            <span class="time-clock-source" id="timeClockSource"></span>
+                        </div>
                         <div class="time-hero-date" id="timeClockDate"></div>
                         <div class="time-hero-week" id="timeClockWeek"></div>
-                        <span class="time-clock-source" id="timeClockSource"></span>
                     </div>
                     <div class="time-schedules-section" id="timeSchedulesSection">
                         <div class="time-section-label" data-i18n="time.schedules">Schedules</div>


### PR DESCRIPTION
## Summary
- `#timeClockSource` (NTP/RTC/System clock (not verified), task 24) used to render as its own fourth row under the week label inside `.time-hero` — one row more than the compact Time card needs.
- Moved into a new `.time-hero-clock-row` (flex, `align-items: baseline`) alongside `#timeClockDisplay`, so the source text's baseline lines up with the clock digits' own baseline.
- Restyled `.time-clock-source` to match the weather card's `.weather-provider-link` pattern: small (9px), muted, `"· "` prefix via `::before`, no link/no cursor (plain text per the request — not wrapped in `<a>`).
- Colors are hardcoded to the exact devtools-measured values for `.weather-provider-link` in each theme (`#10233f` light / `#8bc0ff` dark), rather than reproduced via `color: inherit` — that element gets its color from an ancestor with its own dark-mode override; `.time-clock-source` sits in an unrelated part of the DOM with no equivalent ancestor to hook into. Simpler to hardcode both explicit values than fake the inheritance chain.
- No JS changes — `updateTimeCardClock()`/`updateTimeCardSource()` still address the same `#timeClockDisplay`/`#timeClockSource` ids, unmoved. No i18n changes — source text values unchanged.
- Cache-busting bumped on `style-part3.css`/`style-part4.css` (the only files that changed).

## Test plan
- [x] `node --check static/chat.js` — unchanged file, still clean
- [x] `pytest -q` — 178 passed / 7 skipped (unchanged, no Python touched)
- [x] Live on dev: clock/source now baseline-aligned in one row (bottom edges within 2px, expected for baseline alignment between very differently sized text), color/font-size/`::before` match `.weather-provider-link` exactly in both themes (verified via devtools computed styles, light `rgb(16, 35, 63)` and dark `rgb(139, 192, 255)` both match precisely), no overflow at mobile viewport (375px) with all three source strings (`NTP`, `RTC`, `System clock (not verified)`) substituted in
- [x] Live on camtest: same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)