### PR TITLE
fix: verify-install.sh now checks meshcenter-hw-config sudoers coverage

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -301,10 +301,18 @@ of this automatically.
        | sudo tee /etc/sudoers.d/meshcenter >/dev/null
    sed "s|__MESH_USER__|$MESH_USER|g" deploy/meshcenter-wifi.sudoers \
        | sudo tee /etc/sudoers.d/meshcenter-wifi >/dev/null
-   sudo chmod 440 /etc/sudoers.d/meshcenter /etc/sudoers.d/meshcenter-wifi
+   sed "s|__MESH_USER__|$MESH_USER|g" deploy/meshcenter-hw.sudoers \
+       | sudo tee /etc/sudoers.d/meshcenter-hw >/dev/null
+   sudo install -o root -g root -m 0755 scripts/meshcenter-hw-config /usr/local/sbin/meshcenter-hw-config
+   sudo chmod 440 /etc/sudoers.d/meshcenter /etc/sudoers.d/meshcenter-wifi /etc/sudoers.d/meshcenter-hw
    sudo visudo -cf /etc/sudoers.d/meshcenter        # expect: parsed OK
    sudo visudo -cf /etc/sudoers.d/meshcenter-wifi    # expect: parsed OK
+   sudo visudo -cf /etc/sudoers.d/meshcenter-hw      # expect: parsed OK
    ```
+   `meshcenter-hw.sudoers` + the installed helper are what the Devices tab's
+   I2C/RTC hardware card (task 23+) needs — the app runs fine without them,
+   that card's "Enable I2C & configure RTC" button just fails.
+
    `scripts/verify-install.sh` checks this by asking `sudo -n -l` what the
    current user can actually run passwordlessly, not by looking for these
    exact files — a Pi where the user already has broader NOPASSWD sudo some
@@ -334,6 +342,16 @@ of this automatically.
   happened on this project's own prod node: dev had it configured, prod
   didn't, and it only surfaced when a deploy needed a restart. Do this step
   during install, don't defer it.
+- **A `git pull` update never installs new sudoers/helper files** — updating
+  MeshCenter is deliberately just `git merge --ff-only` + a service restart
+  (see `meshsrv/update_service.py`), it never touches `/etc/sudoers.d/` or
+  `/usr/local/sbin/`. A node installed before `deploy/meshcenter-hw.sudoers`
+  existed (task 23) and only ever updated via `git pull` since will silently
+  be missing it — the Devices tab's I2C/RTC card just fails when clicked,
+  with no warning at update time. `./scripts/verify-install.sh` catches this
+  (`meshcenter-hw-config` sudoers/helper check) — re-run it after any update
+  that adds a new sudoers template, and apply step 9's commands for whatever
+  it flags.
 - **`config.py` doesn't exist after `git clone`** — it's gitignored by
   design (step 5). If you skip `cp config.example.py config.py`, `python
   server.py` exits immediately with a missing-config error, not a vague one.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -149,6 +149,24 @@ if [ -n "$SUDO_LIST" ] && echo "$SUDO_LIST" | grep -qE "NOPASSWD:\s*ALL|nmcli|/u
 else
     warn "nmcli/iw not covered by passwordless sudo — Wi-Fi actions in the UI will fail (see deploy/meshcenter-wifi.sudoers)"
 fi
+# Not `bad` - this only affects the Devices tab's optional I2C/RTC card, not
+# core MeshCenter functionality. An install predating task 23 (PR #84) that
+# has only ever been updated via `git pull` + service restart will land here
+# silently: update_service.py deliberately never touches system files, so
+# deploy/meshcenter-hw.sudoers only gets installed by install.sh/
+# meshcenter-firstboot.sh themselves, never by an update - confirmed live on
+# a real node (067A40FA, task 39) whose "Enable I2C & configure RTC" button
+# failed with exactly this gap.
+if [ -n "$SUDO_LIST" ] && echo "$SUDO_LIST" | grep -qE "NOPASSWD:\s*ALL|meshcenter-hw-config"; then
+    ok "NOPASSWD sudo confirmed for meshcenter-hw-config (I2C/RTC hardware setup)"
+else
+    warn "meshcenter-hw-config not covered by passwordless sudo — the Devices tab's 'Enable I2C & configure RTC' button will fail (see deploy/meshcenter-hw.sudoers; on an install that predates this feature, updating via git pull alone will NOT add it — install the sudoers file manually or re-run install.sh/meshcenter-firstboot.sh's relevant step)"
+fi
+if [ -x "/usr/local/sbin/meshcenter-hw-config" ]; then
+    ok "meshcenter-hw-config helper installed at /usr/local/sbin/meshcenter-hw-config"
+else
+    warn "/usr/local/sbin/meshcenter-hw-config missing or not executable — the I2C/RTC hardware card will fail even with correct sudoers (see scripts/meshcenter-hw-config, installed by install.sh/meshcenter-firstboot.sh)"
+fi
 echo
 
 # --- 5. radio identity ---------------------------------------------------------


### PR DESCRIPTION
## Summary
Live finding on prod (`067A40FA`): the Devices tab's "Enable I2C & configure RTC" button failed with `hardware_config.py`'s own diagnostic (sudo not configured for `meshcenter-hw-config`). Root cause: `deploy/meshcenter-hw.sudoers` and the helper binary only get installed by `install.sh`/`meshcenter-firstboot.sh` at install time - the documented update path (`git pull` + restart, `meshsrv/update_service.py`) deliberately never touches `/etc/sudoers.d/` or `/usr/local/sbin/`. Any node installed before task 23 (PR #84) and only updated via `git pull` since is silently missing it - `scripts/verify-install.sh`'s existing sudoers section had no check for this at all.

- `scripts/verify-install.sh` section 4: reuses the existing `SUDO_LIST` capture (no second `sudo -n -l` call) to add:
  - NOPASSWD coverage check for `meshcenter-hw-config`
  - the helper binary's actual presence (`-x /usr/local/sbin/meshcenter-hw-config`) - sudoers can be right while the helper itself is missing/stale
  - Both are `warn`, not `bad` - the I2C/RTC card is optional, doesn't fail the whole check for nodes that don't use it.
- `INSTALL.md`: step 9 was itself missing `deploy/meshcenter-hw.sudoers` from its manual install commands (only the other two sudoers files were listed) - added, plus a new "Easy to forget" bullet on the update-path gap.

## Test plan
- [x] `bash -n scripts/verify-install.sh`
- [x] `python3 -m compileall .` / `python3 -m pytest -q` - no regressions (219 passed / 19 skipped, unchanged - pure bash/doc change)
- [x] Ran the **old** script on prod first: all-OK, confirmed it misses the gap entirely (before-evidence)
- [x] Ran the **fixed** script on prod, dev, and camtest: dev/camtest (fully configured) - clean OK, no false warning; prod's sudoers had actually already been fixed by an earlier task's live session by the time of this check, so to still prove the new logic really catches the gap, I directly ran the check's exact logic against a mocked `sudo -n -l` output with the `meshcenter-hw-config` lines removed - confirmed it correctly emits `WARN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)