### PR TITLE
copy: generalize E-Paper Display settings card description

### DIFF
--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -644,7 +644,7 @@
     "unable_to_save_settings_short": "Einstellungen konnten nicht gespeichert werden",
     "open_location_settings": "Standorteinstellungen öffnen",
     "epaper_title": "E-Paper-Display",
-    "epaper_description": "Waveshare 2,13\"-Statusdisplay.",
+    "epaper_description": "Einstellungen für Display und Informationsanzeige.",
     "epaper_enabled": "Aktiviert",
     "epaper_refresh_mode": "Aktualisierungsmodus",
     "epaper_mode_responsive": "Reaktionsschnell",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -644,7 +644,7 @@
     "unable_to_save_settings_short": "Unable to save settings",
     "open_location_settings": "Open location settings",
     "epaper_title": "E-Paper Display",
-    "epaper_description": "Waveshare 2.13\" status display.",
+    "epaper_description": "Display and information-display settings.",
     "epaper_enabled": "Enabled",
     "epaper_refresh_mode": "Refresh mode",
     "epaper_mode_responsive": "Responsive",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -644,7 +644,7 @@
     "unable_to_save_settings_short": "Не удалось сохранить настройки",
     "open_location_settings": "Открыть настройки местоположения",
     "epaper_title": "Дисплей E-Paper",
-    "epaper_description": "Статусный дисплей Waveshare 2.13\".",
+    "epaper_description": "Настройки дисплея и отображения информации.",
     "epaper_enabled": "Включено",
     "epaper_refresh_mode": "Режим обновления",
     "epaper_mode_responsive": "Отзывчивый",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -644,7 +644,7 @@
     "unable_to_save_settings_short": "Не вдалося зберегти налаштування",
     "open_location_settings": "Відкрити налаштування розташування",
     "epaper_title": "Дисплей E-Paper",
-    "epaper_description": "Статусний дисплей Waveshare 2.13\".",
+    "epaper_description": "Налаштування дисплея та відображення інформації.",
     "epaper_enabled": "Увімкнено",
     "epaper_refresh_mode": "Режим оновлення",
     "epaper_mode_responsive": "Швидкий",


### PR DESCRIPTION
## Summary
The Devices > Settings > "E-Paper Display" card's description line was hardcoded to "Waveshare 2.13\" status display" - stale since Stage 2 added the WeAct 1.54" model as a selectable alternative. Replaced with a generic "Display and information-display settings" description in all 4 locales, per user request.

## Test plan
- [x] `python scripts/check-i18n.py` - all catalogs in sync
- Pure i18n string change, no code touched - no other checks needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)