### PR TITLE
fix: rotation-driven page changes bypass debounce, not just alerts

### DIFF
--- a/modules/display/service.py
+++ b/modules/display/service.py
@@ -467,6 +467,7 @@ def _poll_once(
     # clears, advance_rotation() sees a large now-last_advance_ts gap and
     # advances exactly one step from wherever it left off - continuing the
     # same cycle position, never resetting to the start.
+    rotation_advanced = False
     if ui_state is not None:
         rotation_config = get_rotation_config() or {}
         if rotation_config.get("enabled"):
@@ -487,6 +488,21 @@ def _poll_once(
                     # route) stays visible until rotation's own next real
                     # tick, instead of being stomped within seconds.
                     ui_state["active_page"] = rotation_pages[new_index]
+                    rotation_advanced = True
+
+    # A rotation-driven page change bypasses debounce (CRITICAL), same as
+    # an alert - found live (task 40 follow-up): with a rotation_interval
+    # shorter than (or close to) debounce_seconds, a NORMAL-priority
+    # mark_dirty() sits in DisplayManager._debounce()'s wait and gets
+    # silently *replaced* by the next tick's newer frame before the
+    # debounce window ever elapses (see that method's own "merging in any
+    # newer frame that arrives during the wait" docstring) - the page
+    # that arrived first is never shown at all, not delayed. Over several
+    # cycles this visibly drops pages from the rotation ("only Radio and
+    # System show" with 4 pages checked, user's own live report) rather
+    # than just slowing it down. debounce_seconds still fully applies to
+    # everything else (routine Status Screen churn, non-rotation content).
+    priority = EventPriority.CRITICAL if rotation_advanced else EventPriority.NORMAL
 
     active_page = get_active_page()
     if active_page and active_page != "status":
@@ -497,12 +513,12 @@ def _poll_once(
             get_battery_percent, get_radio_identity, get_uptime_seconds,
         )
         if image is not None:
-            _mark_dirty_with_clock(manager, image, clock_text)
+            _mark_dirty_with_clock(manager, image, clock_text, priority=priority)
             return
 
     data.last_update = content_state.stamp(content_key)
     image = render(manager.capabilities, data, locale=locale)
-    _mark_dirty_with_clock(manager, image, clock_text)
+    _mark_dirty_with_clock(manager, image, clock_text, priority=priority)
 
 
 def build_status_image_now(

--- a/tests/test_epaper_rotation.py
+++ b/tests/test_epaper_rotation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from modules.display.drivers.base import DisplayCapabilities
+from modules.display.models import EventPriority
 from modules.display.service import _ContentState, _poll_once, advance_rotation
 
 WEACT_CAPS = DisplayCapabilities(width=200, height=200, colors=("black", "white"))
@@ -142,6 +143,13 @@ def test_normal_poll_with_rotation_enabled_advances_active_page():
     # used internally, so this tick should have advanced.
     assert ui_state["rotation_index"] == 1
     assert ui_state["active_page"] == "radio"
+    # A genuine rotation advance must bypass debounce (CRITICAL) - see
+    # test_rotation_advance_bypasses_debounce_via_critical_priority()
+    # below for why (DisplayManager._debounce() silently drops a page
+    # whose mark_dirty() call gets superseded by the next tick's newer
+    # frame before its debounce window elapses).
+    _, kwargs = manager.mark_dirty.call_args
+    assert kwargs["priority"] == EventPriority.CRITICAL
 
 
 def test_rotation_disabled_leaves_active_page_alone():
@@ -163,3 +171,44 @@ def test_rotation_disabled_leaves_active_page_alone():
 
     assert "rotation_index" not in ui_state
     assert ui_state["active_page"] == "power"
+    # Not a rotation advance (rotation is disabled) - stays NORMAL, so
+    # routine (non-rotation) content still respects debounce_seconds as
+    # before.
+    _, kwargs = manager.mark_dirty.call_args
+    assert kwargs["priority"] == EventPriority.NORMAL
+
+
+def test_rotation_advance_bypasses_debounce_via_critical_priority():
+    """The actual bug this was written for (live report: "only Radio and
+    System show up" with all 4 pages checked and rotation_interval_seconds
+    (5s) shorter than debounce_seconds (6s)). DisplayManager._debounce()
+    silently *replaces* a still-waiting NORMAL-priority frame with a newer
+    one that arrives before its debounce window elapses - the first page
+    is never shown at all. CRITICAL priority skips that wait entirely
+    (see manager.py's _run(): "if priority != EventPriority.CRITICAL").
+    Every rotation-driven page change must use it, or fast rotation
+    intervals silently drop pages from the cycle."""
+    manager = MagicMock()
+    manager.capabilities = WEACT_CAPS
+    ui_state = {"active_page": "status", "rotation_index": 0, "rotation_last_advance_ts": None}
+    rotation_config = {
+        "enabled": True, "pages": ["status", "radio", "power", "system"], "interval_seconds": 5.0,
+    }
+    # Simulate 5 consecutive rotation ticks (one full cycle plus one) -
+    # every single one must mark_dirty() with CRITICAL, not just the
+    # first, since a shorter-than-debounce interval affects every tick
+    # equally, not just the initial one.
+    for _ in range(5):
+        ui_state["rotation_last_advance_ts"] = None  # force "advanced" every call, isolating the assertion
+        _poll_once(
+            manager, MagicMock(), {},
+            get_radio_status=lambda: {"mode": "connected", "serial_port": "/dev/ttyACM0"},
+            get_cpu_percent=lambda: 10.0,
+            get_ram_percent=lambda: 20.0,
+            get_listener_alive=lambda: True,
+            local_node_name="Test Node",
+            content_state=_ContentState(),
+            **_rotation_poll_kwargs(ui_state, rotation_config),
+        )
+        _, kwargs = manager.mark_dirty.call_args
+        assert kwargs["priority"] == EventPriority.CRITICAL, "every rotation-driven page must bypass debounce"


### PR DESCRIPTION
## Summary
**Not a checkbox/ordering bug** - the user reported "only Radio and System show up on the display" with all 4 rotation pages checked, but `rotation_pages` filtering and the canonical status→radio→power→system ordering were correct all along. The real issue is a timing interaction between `rotation_interval_seconds` and `debounce_seconds` that task 40's original design didn't account for.

**Root cause**: a rotation-driven `mark_dirty()` call used `NORMAL` priority, which routes through `DisplayManager._debounce()`. That method's own documented behavior is to *replace* a still-waiting frame with a newer one that arrives before the debounce deadline elapses. With `rotation_interval_seconds` (5s, in the reported config) shorter than `debounce_seconds` (6s), a new rotation tick reliably arrived before the previous one's debounce window closed - so the *first* page of every overlapping pair was silently discarded, never shown on the panel at all (not delayed, dropped). That's exactly what "only Radio and System show" looks like from a 4-page cycle.

**Fix**: `_poll_once()` now tracks whether the current tick is a genuine rotation advance (`advance_rotation()` returned `advanced=True`) and, if so, passes `EventPriority.CRITICAL` to `_mark_dirty_with_clock()` - the same debounce-bypass mechanism already used for the Alert Screen. Routine (non-rotation) content still respects `debounce_seconds` exactly as before; only rotation's own deliberate, user-paced page changes are now guaranteed to actually reach the panel.

## Test plan
- [x] `python3 -m compileall .`
- [x] `python3 -m pytest -q` - 243 passed / 19 skipped locally; 262 passed / 0 skipped on dev (real Linux)
- [x] New assertions: `mark_dirty`'s `priority` kwarg is `CRITICAL` on every rotation advance (checked across 5 consecutive ticks, not just the first) and `NORMAL` when rotation is disabled
- [x] Live on dev with the **exact reported config** (4 pages checked, `rotation_interval_seconds=5`, `debounce_seconds=6`): `refresh_count` grew by 20 over ~80s post-restart, a dramatic change from the previous skip-every-other-page pattern - confirms rotation ticks are no longer being dropped. Rotation disabled and display returned to Status afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)