### PR TITLE
fix: let the weather condition text wrap to 2 lines instead of clipping

### DIFF
--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -2122,13 +2122,30 @@ html[data-theme="dark"] .system-log-panel {
     line-height: 1;
 }
 .weather-current--compact .weather-condition {
+    /* Was a single forced-nowrap line with an ellipsis - a longer
+       translated condition string ("облачно с прояснениями") ran out of
+       the fixed 112px column and got clipped mid-word, and on a narrower
+       card the same squeeze pushed the location name (.weather-location-
+       name, its own separate nowrap/ellipsis) into visible overlap with
+       the icon next to it (found live, user's own side-by-side
+       screenshots). Wrapping to up to 2 lines instead gives long
+       descriptions room without growing the fixed-size icon/temperature
+       above it - .weather-summary's height simply grows to fit, no
+       overlap with .weather-state-group below (that's positioned in a
+       fixed-size reserved padding zone, not against this content's own
+       height). display:-webkit-box + line-clamp is the standard (if
+       oddly-prefixed) cross-browser way to keep the ellipsis-on-overflow
+       behavior at 2 lines instead of 1. */
     max-width: 112px;
     margin-top: 5px;
     overflow: hidden;
     font-size: 11px;
     line-height: 1.15;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    white-space: normal;
     text-overflow: ellipsis;
-    white-space: nowrap;
 }
 .weather-current-copy { min-width: 0; }
 .weather-state-group {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260821-style-split">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260821-style-split">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260822-time-source-row">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260823-weather-condition-wrap">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260822-weather-key-button">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">


### PR DESCRIPTION
## Summary
`.weather-current--compact .weather-condition` forced a single nowrap line with an ellipsis - a longer translated condition string (RU "Облачно с прояснениями и переменной облачностью") ran out of the fixed 112px column, and on a narrower card the same squeeze visually crowded the cloud icon against the location name next to it (user's own side-by-side screenshots comparing two locales/widths).

Replaced with `display:-webkit-box; -webkit-line-clamp:2` (the standard cross-browser way to allow up to N lines with an ellipsis only if it still overflows). `.weather-summary`'s height just grows a bit to fit the extra line - no overlap with `.weather-state-group` below it, which lives in a fixed-size reserved bottom padding zone, not against this content's own height.

## Test plan
- [x] `python3 -m compileall .` / `python3 -m pytest -q` - no regressions (pure CSS)
- [x] Live on camtest: a long RU condition string now wraps to 2 lines cleanly, icon stays its normal size, no crowding/overlap - confirmed via zoomed screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)