### PR TITLE
fix: weather icon shifts to temperature; e-paper node name keeps its case

### DIFF
--- a/modules/display/renderer.py
+++ b/modules/display/renderer.py
@@ -179,12 +179,17 @@ def draw_node_header(image: Image.Image, node_name: str) -> None:
     """WeAct UI Design doc, section 3: the permanent inverse header - solid
     black across the full width, the node's name in white bold, centered,
     always one line (never wrapped - a long name gets a smaller font
-    instead, via fit_font(), down to a 14px floor)."""
+    instead, via fit_font(), down to a 14px floor).
+
+    Displayed in its own original case (e.g. "Flint TAP2"), not forced
+    uppercase - found live: a real node's name reads correctly in the
+    web UI/Meshtastic app in mixed case, and ALL-CAPS on the panel looked
+    wrong/unfamiliar next to it (user's own report)."""
     w, _h = image.size
     draw = ImageDraw.Draw(image)
     draw.rectangle([0, 0, w, NODE_HEADER_HEIGHT - 1], fill="black")
 
-    name = (node_name or "-").upper()
+    name = node_name or "-"
     available_width = w - 16
     font = fit_font(name, available_width, _NODE_HEADER_FONT_SIZES, bold=True)
 

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -1257,10 +1257,6 @@
         gap: 8px;
     }
 
-    .weather-current--compact {
-        min-width: 118px;
-    }
-
     .weather-current--compact .weather-icon { font-size: 32px; }
     .weather-current--compact .weather-temperature { font-size: 26px; }
 }
@@ -2105,11 +2101,21 @@ html[data-theme="dark"] .system-log-panel {
 .weather-location-block.reference-is-disabled .weather-location-coordinates { color: #8a96a5; }
 
 .weather-current--compact {
+    /* min-width was 132px - reserved more width than the icon+temperature
+       actually need, and since .weather-summary's location column is
+       minmax(0, 1fr) (grid-template-columns: minmax(0, 1fr) auto), every
+       px reserved here is a px NOT available to the location name -
+       found live: the icon sat with a gap of unused space to its left
+       instead of hugging the temperature, while "Erlangen, Germany" got
+       clipped for room that was never actually needed on this side
+       (user's own screenshot). Shrunk to fit content, gap tightened -
+       the icon now sits right next to the temperature instead of
+       floating with slack space between them. */
     display: grid;
     grid-template-columns: auto auto;
     align-items: center;
-    gap: 9px;
-    min-width: 132px;
+    gap: 5px;
+    min-width: 0;
     padding: 0;
     text-align: right;
 }
@@ -2122,7 +2128,12 @@ html[data-theme="dark"] .system-log-panel {
     line-height: 1;
 }
 .weather-current--compact .weather-condition {
-    /* Was a single forced-nowrap line with an ellipsis - a longer
+    /* max-width also sets the width of the whole temperature+condition
+       column (.weather-current-copy auto-sizes to its widest child) -
+       112px was wider than it needs to be now that the text wraps to 2
+       lines instead of demanding a single unbroken line, and every px
+       here is a px the icon (and, past that, the location name) don't
+       get. Was a single forced-nowrap line with an ellipsis - a longer
        translated condition string ("облачно с прояснениями") ran out of
        the fixed 112px column and got clipped mid-word, and on a narrower
        card the same squeeze pushed the location name (.weather-location-
@@ -2136,7 +2147,7 @@ html[data-theme="dark"] .system-log-panel {
        height). display:-webkit-box + line-clamp is the standard (if
        oddly-prefixed) cross-browser way to keep the ellipsis-on-overflow
        behavior at 2 lines instead of 1. */
-    max-width: 112px;
+    max-width: 88px;
     margin-top: 5px;
     overflow: hidden;
     font-size: 11px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260821-style-split">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260821-style-split">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260823-weather-condition-wrap">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260823-weather-icon-shift">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260822-weather-key-button">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=stage2c7-4-unified-popovers-20260725">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">


### PR DESCRIPTION
## Summary
Two follow-ups from live review of the previous two merged fixes.

**1. Weather card icon still crowded, location name still clipped** - the 2-line condition wrap (previous PR) fixed clipping the condition text itself, but `.weather-current--compact` still reserved more width than it actually needed:
- `min-width: 132px` (plus a 118px override on narrow viewports) removed - pure unused reservation once the content wraps instead of demanding a single line.
- `.weather-condition`'s `max-width` (112px) also sets the width of the whole temperature+condition column (it auto-sizes to its widest child) - narrowed to 88px, since text now wraps to 2 lines anyway.
- icon-to-copy `gap` tightened 9px → 5px.

Live-measured on camtest: the icon+temperature block shrank from 174.7px to 150.7px; "Erlangen, Germany" (previously clipped to "Erlangen, Ger...") now renders in full with room to spare, icon sitting close to the temperature instead of floating with unused space to its left.

**2. E-paper node name was forced uppercase** - `draw_node_header()` (task 37) called `.upper()` on the node name, so "Flint TAP2" rendered as "FLINT TAP2" on the physical panel. Removed - the panel now shows the name exactly as configured, matching the web UI and the Meshtastic app.

## Test plan
- [x] `python3 -m compileall .` / `python3 -m pytest -q` - 243 passed / 19 skipped locally; 262 passed / 0 skipped on camtest (real Linux)
- [x] Live on camtest: measured via devtools - `weatherLocation` no longer truncated (190px content in a 190px+ available column) with the exact "Erlangen, Germany" + "облачно с прояснениями" strings from the original bug report; confirmed via zoomed screenshot
- [x] `draw_node_header()` renders a mixed-case name without error on camtest (direct render call); pushed the RADIO page live

🤖 Generated with [Claude Code](https://claude.com/claude-code)