### PR TITLE
fix: e-paper node-name header grows to 2 lines for long node names

### DIFF
--- a/modules/display/pages/alert.py
+++ b/modules/display/pages/alert.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    NODE_HEADER_HEIGHT,
     draw_node_header,
     draw_text,
     fit_font,
@@ -60,13 +59,13 @@ def render(caps: DisplayCapabilities, data: AlertScreenData, locale: str = DEFAU
     # on a color panel it stays legible white-on-black same as the rest
     # of this screen's text, since draw_node_header() always paints its
     # own black block first regardless of what's already behind it).
-    draw_node_header(image, data.node_name)
+    header_height = draw_node_header(image, data.node_name)
 
     available_width = w - 16
     title_font = fit_font(data.title, available_width, _TITLE_FONT_SIZES, bold=True)
     label_font = load_font(11)
 
-    y = NODE_HEADER_HEIGHT + 8
+    y = header_height + 8
     draw_text(image, (8, y), data.title, "white", title_font)
     y += 24
 

--- a/modules/display/pages/message.py
+++ b/modules/display/pages/message.py
@@ -15,8 +15,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    CONTENT_Y,
-    SEPARATOR_Y,
     draw_node_header,
     draw_page_header,
     draw_separator,
@@ -44,12 +42,21 @@ def render(caps: DisplayCapabilities, data: MessageScreenData, locale: str = DEF
     image, _draw = new_canvas(caps)
     w, h = image.size
 
-    draw_node_header(image, data.node_name)
-    draw_page_header(image, t("message", locale))
-    draw_separator(image, SEPARATOR_Y)
+    # Task 42: header height (and everything below it) is dynamic - see
+    # status.py's render() for the shared rationale. The message body's
+    # own fit_text_to_box() call below already shrinks to whatever
+    # vertical room is left, so a taller header here just leaves less
+    # room for the body - no separate overflow risk to account for.
+    header_height = draw_node_header(image, data.node_name)
+    page_header_y = header_height + 2
+    separator_y = header_height + 24
+    content_y = header_height + 30
+
+    draw_page_header(image, t("message", locale), y=page_header_y)
+    draw_separator(image, separator_y)
 
     meta_font = load_font(13, bold=True)
-    y = CONTENT_Y
+    y = content_y
 
     direction_label = "TX" if data.direction == "tx" else "RX"
     if data.direction == "tx":

--- a/modules/display/pages/power.py
+++ b/modules/display/pages/power.py
@@ -20,8 +20,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    CONTENT_Y,
-    SEPARATOR_Y,
     draw_label_value,
     draw_node_header,
     draw_page_header,
@@ -68,17 +66,23 @@ def render(caps: DisplayCapabilities, data: PowerScreenData, locale: str = DEFAU
     w, h = image.size
     right = w - 4
 
-    draw_node_header(image, data.node_name)
+    # Task 42: header height (and everything below it) is dynamic - see
+    # status.py's render() for the shared rationale.
+    header_height = draw_node_header(image, data.node_name)
+    page_header_y = header_height + 2
+    separator_y = header_height + 24
+    content_y = header_height + 30
+
     # Distinct key from "power" below (the CURRENT/POWER wattage pair's own
     # label, correctly "Мощность"/"Leistung" - actual wattage) - the page
     # title means "power supply status" as a whole, not the wattage value
     # specifically, and RU/UK's "Мощность"/"Потужність" read wrong there
     # (found live - user wanted "Питание", not "Мощность", for the title).
-    draw_page_header(image, t("power_page_title", locale))
-    draw_separator(image, SEPARATOR_Y)
+    draw_page_header(image, t("power_page_title", locale), y=page_header_y)
+    draw_separator(image, separator_y)
 
     has_current_power = data.current is not None or data.power is not None
-    y = CONTENT_Y
+    y = content_y
 
     # HERO voltage, centered - bigger still when current/power aren't
     # available (doc section 8's fallback: "автоматически перестраивать

--- a/modules/display/pages/radio.py
+++ b/modules/display/pages/radio.py
@@ -12,8 +12,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    CONTENT_Y,
-    SEPARATOR_Y,
     draw_inverted_status,
     draw_label_value,
     draw_node_header,
@@ -54,12 +52,18 @@ def render(caps: DisplayCapabilities, data: RadioScreenData, locale: str = DEFAU
     w, h = image.size
     right = w - 4
 
-    draw_node_header(image, data.node_name)
-    draw_page_header(image, t("radio", locale))
-    draw_separator(image, SEPARATOR_Y)
+    # Task 42: header height (and everything below it) is dynamic - see
+    # status.py's render() for the shared rationale.
+    header_height = draw_node_header(image, data.node_name)
+    page_header_y = header_height + 2
+    separator_y = header_height + 24
+    content_y = header_height + 30
+
+    draw_page_header(image, t("radio", locale), y=page_header_y)
+    draw_separator(image, separator_y)
 
     status_label = t(data.status, locale).upper()
-    y = CONTENT_Y
+    y = content_y
     if data.status == "online":
         status_font = fit_font(status_label, w - 16, _STATUS_SIZES, bold=True)
         tw = text_width(status_label, status_font)

--- a/modules/display/pages/status.py
+++ b/modules/display/pages/status.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    CONTENT_Y,
-    SEPARATOR_Y,
     draw_inverted_status,
     draw_label_value,
     draw_node_header,
@@ -50,15 +48,24 @@ def render(caps: DisplayCapabilities, data: StatusScreenData, locale: str = DEFA
     w, h = image.size
     right = w - 4
 
-    draw_node_header(image, data.node_name)
-    draw_page_header(image, t("status", locale))
-    draw_separator(image, SEPARATOR_Y)
+    # Task 42: the node-name header can grow to 2 lines for a long name -
+    # everything below it computes its own Y from the header's actual
+    # height (the same +2/+24/+30 deltas the old fixed
+    # PAGE_HEADER_Y/SEPARATOR_Y/CONTENT_Y constants used) instead of
+    # assuming it's always the compact single-line height.
+    header_height = draw_node_header(image, data.node_name)
+    page_header_y = header_height + 2
+    separator_y = header_height + 24
+    content_y = header_height + 30
+
+    draw_page_header(image, t("status", locale), y=page_header_y)
+    draw_separator(image, separator_y)
 
     # 12px, not 14 - "LETZTER EMPFANG" (de "Last RX") needs the extra room
     # to leave any space at all for its value on a 200px row at any
     # _PRIMARY_SIZES size (found via live i18n PNG review, task 37).
     label_font = load_font(12, bold=True)
-    y = CONTENT_Y
+    y = content_y
 
     radio_label = t(data.radio_status, locale).upper()
     if data.radio_status == "online":

--- a/modules/display/pages/system.py
+++ b/modules/display/pages/system.py
@@ -13,8 +13,6 @@ from dataclasses import dataclass
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.i18n import DEFAULT_LOCALE, t
 from modules.display.renderer import (
-    CONTENT_Y,
-    SEPARATOR_Y,
     draw_node_header,
     draw_page_header,
     draw_progress_bar,
@@ -78,15 +76,21 @@ def render(caps: DisplayCapabilities, data: SystemScreenData, locale: str = DEFA
     image, _draw = new_canvas(caps)
     w, h = image.size
 
-    draw_node_header(image, data.node_name)
-    draw_page_header(image, t("system", locale))
-    draw_separator(image, SEPARATOR_Y)
+    # Task 42: header height (and everything below it) is dynamic - see
+    # status.py's render() for the shared rationale.
+    header_height = draw_node_header(image, data.node_name)
+    page_header_y = header_height + 2
+    separator_y = header_height + 24
+    content_y = header_height + 30
+
+    draw_page_header(image, t("system", locale), y=page_header_y)
+    draw_separator(image, separator_y)
 
     label_font = load_font(13, bold=True)
     value_font = load_font(23, bold=True)
     bar_x, bar_width, bar_height = 4, w - 8, 9
 
-    y = CONTENT_Y
+    y = content_y
 
     def metric_row(label: str, percent: float | None, y: int) -> int:
         text = f"{percent:.0f}%" if percent is not None else "--"

--- a/modules/display/renderer.py
+++ b/modules/display/renderer.py
@@ -95,16 +95,26 @@ def text_width(text: str, font) -> int:
 # WeAct 200x200 UI Design doc, section 2 - the common frame all five pages
 # (plus alert.py, per this session's decision) build on: an inverse node-
 # name header, a page-title/clock row, a 1px separator, then whatever
-# content the page wants. Exported so time_helper.py's draw_epaper_clock()
-# can share PAGE_HEADER_Y instead of hardcoding a second copy of it - the
-# clock is drawn by a separate call, after content-hash time (see
-# service.py's _mark_dirty_with_clock()), but on the same row as the page
-# title drawn by draw_page_header() below.
-NODE_HEADER_HEIGHT = 30
-PAGE_HEADER_Y = 32
+# content the page wants.
+#
+# Task 42: the node-name header's height is no longer a single fixed
+# constant - a name that doesn't fit one line grows the header to a
+# second line instead of silently overflowing/shrinking past readability
+# (see node_header_layout() below). PAGE_HEADER_Y/SEPARATOR_Y/CONTENT_Y
+# below are the *single-line* header's own Y values - the same +2/+24/+30
+# deltas from the header's actual height apply whether it ended up single
+# or double, so callers that need to be correct for either case compute
+# their own `page_header_y = header_height + 2` etc. from
+# draw_node_header()'s return value (see pages/*.py) rather than using
+# these constants directly. These names stay as backward-compatible
+# defaults for callers that only ever draw a short/known-single-line name
+# (draw_page_header()'s own `y` default, tests, standalone PNG tools).
+NODE_HEADER_HEIGHT_SINGLE = 30
+NODE_HEADER_HEIGHT_DOUBLE = 46
+PAGE_HEADER_Y = NODE_HEADER_HEIGHT_SINGLE + 2
 PAGE_HEADER_CLOCK_FONT_SIZE = 12
-SEPARATOR_Y = 54
-CONTENT_Y = 60
+SEPARATOR_Y = NODE_HEADER_HEIGHT_SINGLE + 24
+CONTENT_Y = NODE_HEADER_HEIGHT_SINGLE + 30
 
 _NODE_HEADER_FONT_SIZES = (22, 20, 18, 16, 14)
 
@@ -175,37 +185,110 @@ def fit_text_to_box(
     return lines[:max_lines], font, line_height
 
 
-def draw_node_header(image: Image.Image, node_name: str) -> None:
+def node_header_layout(node_name: str, width: int) -> tuple[int, list[str], ImageFont.FreeTypeFont]:
+    """Pure - no Image/ImageDraw touched - the sizing decision behind
+    draw_node_header(), split out so service.py can compute the same
+    header_height (and therefore the same page_header_y for the live
+    clock overlay) without rendering anything (see that module's
+    _mark_dirty_with_clock()/build_status_image_now()/
+    build_page_image_now()).
+
+    Returns (header_height, lines, font):
+      - header_height is NODE_HEADER_HEIGHT_SINGLE or _DOUBLE - never
+        anything else, a hard ceiling of 2 lines applies regardless of
+        how long/unbreakable `node_name` is (see the fallback below).
+      - lines is what to draw, 1 or 2 strings, one per line.
+      - font is the single ImageFont used for every returned line.
+
+    Real Meshtastic names can run well past what fits one line even at
+    the smallest candidate size (e.g. "[de.nby.n.RiBeNet.cb] SolisCultor
+    c87b", a real region-prefix + name + short-ID convention, task 42) -
+    tried single-line first (matches the old always-one-line behavior
+    exactly for anything that still fits), then 2 lines word-wrapped via
+    _wrap_to_width(), largest font that keeps both lines within width.
+    If even 2 lines at the smallest size doesn't hold the whole name, the
+    *last* line is ellipsis-truncated character by character rather than
+    letting the header grow a third line or overflow the canvas edge -
+    truncating the last (not first) line is deliberate: in the
+    "[prefix] Name" convention above, the prefix is the disposable part,
+    the meaningful text comes after it.
+    """
+    name = node_name or "-"
+    available_width = width - 16
+
+    for size in _NODE_HEADER_FONT_SIZES:
+        font = load_font(size, bold=True)
+        if text_width(name, font) <= available_width:
+            return NODE_HEADER_HEIGHT_SINGLE, [name], font
+
+    for size in _NODE_HEADER_FONT_SIZES:
+        font = load_font(size, bold=True)
+        lines = _wrap_to_width(name, font, available_width)
+        if len(lines) <= 2 and all(text_width(line, font) <= available_width for line in lines):
+            return NODE_HEADER_HEIGHT_DOUBLE, lines, font
+
+    font = load_font(_NODE_HEADER_FONT_SIZES[-1], bold=True)
+    lines = _wrap_to_width(name, font, available_width)
+    kept = lines[:2]
+    idx = len(kept) - 1
+    line = kept[idx]
+    while line and text_width(line + "…", font) > available_width:
+        line = line[:-1]
+    kept[idx] = (line + "…") if line else "…"
+    height = NODE_HEADER_HEIGHT_DOUBLE if len(kept) == 2 else NODE_HEADER_HEIGHT_SINGLE
+    return height, kept, font
+
+
+def draw_node_header(image: Image.Image, node_name: str) -> int:
     """WeAct UI Design doc, section 3: the permanent inverse header - solid
-    black across the full width, the node's name in white bold, centered,
-    always one line (never wrapped - a long name gets a smaller font
-    instead, via fit_font(), down to a 14px floor).
+    black across the full width, the node's name in white bold, centered.
+    Up to 2 lines (see node_header_layout()) instead of always exactly
+    one - a name too long even at the smallest single-line size now grows
+    the header to a second line instead of shrinking further or silently
+    overflowing the canvas edge (task 42 - found live: a real ~38-char
+    node name did exactly that under the old always-one-line behavior).
 
     Displayed in its own original case (e.g. "Flint TAP2"), not forced
     uppercase - found live: a real node's name reads correctly in the
     web UI/Meshtastic app in mixed case, and ALL-CAPS on the panel looked
-    wrong/unfamiliar next to it (user's own report)."""
+    wrong/unfamiliar next to it (user's own report).
+
+    Returns the header's actual height in px (NODE_HEADER_HEIGHT_SINGLE
+    or _DOUBLE) - callers use this to compute page_header_y/separator_y/
+    content_y for everything drawn below the header, since a 2-line
+    header pushes all of that down (see pages/*.py's render()s and
+    service.py's clock-overlay call sites)."""
     w, _h = image.size
     draw = ImageDraw.Draw(image)
-    draw.rectangle([0, 0, w, NODE_HEADER_HEIGHT - 1], fill="black")
+    header_height, lines, font = node_header_layout(node_name, w)
+    draw.rectangle([0, 0, w, header_height - 1], fill="black")
 
-    name = node_name or "-"
-    available_width = w - 16
-    font = fit_font(name, available_width, _NODE_HEADER_FONT_SIZES, bold=True)
+    line_gap = 2
+    bboxes = [draw.textbbox((0, 0), line, font=font) for line in lines]
+    line_heights = [bbox[3] - bbox[1] for bbox in bboxes]
+    total_text_height = sum(line_heights) + line_gap * (len(lines) - 1)
+    y = max(2, (header_height - total_text_height) // 2)
+    for line, bbox, line_h in zip(lines, bboxes, line_heights):
+        text_w = bbox[2] - bbox[0]
+        x = max(4, (w - text_w) // 2)
+        draw_text(image, (x, y - bbox[1]), line, "white", font)
+        y += line_h + line_gap
 
-    bbox = draw.textbbox((0, 0), name, font=font)
-    text_w = bbox[2] - bbox[0]
-    text_h = bbox[3] - bbox[1]
-    x = max(4, (w - text_w) // 2)
-    y = max(2, (NODE_HEADER_HEIGHT - text_h) // 2 - bbox[1])
-    draw_text(image, (x, y), name, "white", font)
+    return header_height
 
 
-def draw_page_header(image: Image.Image, page_title: str, clock_text: str | None = None) -> None:
+def draw_page_header(image: Image.Image, page_title: str, clock_text: str | None = None, y: int = PAGE_HEADER_Y) -> None:
     """WeAct UI Design doc, section 4: page title (upper-cased for display
     only - t() still returns the normal-case translated string, see this
     module's callers) at the left, clock at the right, on the row directly
     under draw_node_header()'s block.
+
+    `y` defaults to PAGE_HEADER_Y (the single-line header's own row) for
+    backward compatibility (standalone PNG tools, tests that only ever
+    draw a short name) - real page render()s (task 42) compute their own
+    `page_header_y = header_height + 2` from draw_node_header()'s return
+    value and pass it explicitly, since a 2-line node-name header pushes
+    this whole row down.
 
     clock_text is optional and deliberately NOT how the live poll path
     draws the clock - service.py's _mark_dirty_with_clock() overlays it
@@ -215,16 +298,16 @@ def draw_page_header(image: Image.Image, page_title: str, clock_text: str | None
     that don't go through that hash-then-overlay pipeline."""
     w, _h = image.size
     title_font = load_font(15, bold=True)
-    draw_text(image, (4, PAGE_HEADER_Y), page_title.upper(), "black", title_font)
+    draw_text(image, (4, y), page_title.upper(), "black", title_font)
 
     if clock_text:
-        # Same y draw_epaper_clock() uses by default - kept in sync so a
-        # standalone render (clock_text passed here) and the live overlay
-        # path (time_helper.draw_epaper_clock(), drawn separately after
-        # content-hash time) land on the identical row.
+        # Same y draw_epaper_clock() must be called with by its caller
+        # (service.py, computed from the same header_height) - kept in
+        # sync here so a standalone render (clock_text passed here) and
+        # the live overlay path land on the identical row.
         clock_font = load_font(PAGE_HEADER_CLOCK_FONT_SIZE)
         x = max(4, w - text_width(clock_text, clock_font) - 4)
-        draw_text(image, (x, PAGE_HEADER_Y), clock_text, "black", clock_font)
+        draw_text(image, (x, y), clock_text, "black", clock_font)
 
 
 def draw_separator(image: Image.Image, y: int) -> None:

--- a/modules/display/service.py
+++ b/modules/display/service.py
@@ -40,7 +40,7 @@ from modules.display.pages import power as power_page
 from modules.display.pages import radio as radio_page
 from modules.display.pages import system as system_page
 from modules.display.pages.status import StatusScreenData, render
-from modules.display.renderer import load_font
+from modules.display.renderer import load_font, node_header_layout
 from modules.display.time_helper import draw_epaper_clock, format_epaper_time
 
 # meshsrv.time_service (Stage 2 of the Time System feature) is the single
@@ -169,7 +169,8 @@ _CLOCK_FONT_SIZE = 12
 
 
 def _mark_dirty_with_clock(
-    manager: DisplayManager, image, time_str: str, priority: EventPriority = EventPriority.NORMAL,
+    manager: DisplayManager, image, time_str: str, local_node_name: str,
+    priority: EventPriority = EventPriority.NORMAL,
 ) -> None:
     """Overlay the live clock onto an already-fully-rendered page image,
     then hand it to DisplayManager.mark_dirty() - hashing the *pre-overlay*
@@ -189,7 +190,13 @@ def _mark_dirty_with_clock(
     since drawing happens in-place on the same object passed to
     mark_dirty()."""
     content_hash = hashlib.sha256(image.tobytes()).hexdigest()
-    draw_epaper_clock(image, time_str, load_font(_CLOCK_FONT_SIZE))
+    # Task 42: the node-name header can be 1 or 2 lines - the clock must
+    # line up with whichever height this node's name actually produced,
+    # not the old fixed single-line offset (node_header_layout() is the
+    # same pure sizing decision draw_node_header() used to render the
+    # header already baked into `image`, just without touching an Image).
+    header_height, _lines, _font = node_header_layout(local_node_name, image.size[0])
+    draw_epaper_clock(image, time_str, load_font(_CLOCK_FONT_SIZE), y=header_height + 2)
     manager.mark_dirty(image, priority=priority, content_hash=content_hash)
 
 
@@ -513,12 +520,12 @@ def _poll_once(
             get_battery_percent, get_radio_identity, get_uptime_seconds,
         )
         if image is not None:
-            _mark_dirty_with_clock(manager, image, clock_text, priority=priority)
+            _mark_dirty_with_clock(manager, image, clock_text, local_node_name, priority=priority)
             return
 
     data.last_update = content_state.stamp(content_key)
     image = render(manager.capabilities, data, locale=locale)
-    _mark_dirty_with_clock(manager, image, clock_text, priority=priority)
+    _mark_dirty_with_clock(manager, image, clock_text, local_node_name, priority=priority)
 
 
 def build_status_image_now(
@@ -546,7 +553,8 @@ def build_status_image_now(
     image = render(manager.capabilities, data, locale=locale)
     time_status = get_time_status() or {}
     clock_text = format_epaper_time(time_format, time_status.get("timezone", "UTC"))
-    draw_epaper_clock(image, clock_text, load_font(_CLOCK_FONT_SIZE))
+    header_height, _lines, _font = node_header_layout(local_node_name, image.size[0])
+    draw_epaper_clock(image, clock_text, load_font(_CLOCK_FONT_SIZE), y=header_height + 2)
     return image
 
 
@@ -580,5 +588,6 @@ def build_page_image_now(
         return None
     time_status = get_time_status() or {}
     clock_text = format_epaper_time(time_format, time_status.get("timezone", "UTC"))
-    draw_epaper_clock(image, clock_text, load_font(_CLOCK_FONT_SIZE))
+    header_height, _lines, _font = node_header_layout(local_node_name, image.size[0])
+    draw_epaper_clock(image, clock_text, load_font(_CLOCK_FONT_SIZE), y=header_height + 2)
     return image

--- a/tests/test_epaper_renderer.py
+++ b/tests/test_epaper_renderer.py
@@ -19,7 +19,8 @@ pytestmark = pytest.mark.skipif(
 from modules.display.drivers.base import DisplayCapabilities
 from modules.display.renderer import (
     CONTENT_Y,
-    NODE_HEADER_HEIGHT,
+    NODE_HEADER_HEIGHT_DOUBLE,
+    NODE_HEADER_HEIGHT_SINGLE,
     PAGE_HEADER_Y,
     SEPARATOR_Y,
     draw_node_header,
@@ -29,6 +30,7 @@ from modules.display.renderer import (
     fit_text_to_box,
     load_font,
     new_canvas,
+    node_header_layout,
     text_width,
 )
 
@@ -92,21 +94,72 @@ def test_draw_node_header_paints_full_width_black_band():
     # regardless of where the centered text itself landed.
     assert image.getpixel((0, 0)) == (0, 0, 0)
     assert image.getpixel((w - 1, 0)) == (0, 0, 0)
-    assert image.getpixel((0, NODE_HEADER_HEIGHT - 1)) == (0, 0, 0)
+    assert image.getpixel((0, NODE_HEADER_HEIGHT_SINGLE - 1)) == (0, 0, 0)
+
+
+def test_draw_node_header_short_name_stays_single_line():
+    image, _draw = new_canvas(WEACT_CAPS)
+    height = draw_node_header(image, "Flint TAP2")
+    assert height == NODE_HEADER_HEIGHT_SINGLE
 
 
 def test_draw_node_header_below_band_is_untouched():
     image, _draw = new_canvas(WEACT_CAPS)
     draw_node_header(image, "Flint TAP2")
-    assert image.getpixel((0, NODE_HEADER_HEIGHT + 5)) == (255, 255, 255)
+    assert image.getpixel((0, NODE_HEADER_HEIGHT_SINGLE + 5)) == (255, 255, 255)
 
 
-def test_draw_node_header_long_name_does_not_crash_and_stays_one_line():
+def test_draw_node_header_long_name_grows_to_two_lines_and_returns_height():
+    # Task 42: a name too long even at the smallest single-line size now
+    # grows the header to a genuine second line (rather than the old
+    # always-one-line, silently-overflowing behavior) - and the caller
+    # gets the actual height back so it can lay out everything below it.
     image, _draw = new_canvas(WEACT_CAPS)
-    # Should shrink the font (fit_font) rather than wrap or overflow -
-    # just confirm it doesn't raise and the band is still fully painted.
-    draw_node_header(image, "AN EXTREMELY LONG NODE NAME FOR TESTING")
+    height = draw_node_header(image, "AN EXTREMELY LONG NODE NAME FOR TESTING")
+    assert height == NODE_HEADER_HEIGHT_DOUBLE
     assert image.getpixel((0, 0)) == (0, 0, 0)
+    assert image.getpixel((0, height - 1)) == (0, 0, 0)
+    # Band's bottom edge is exactly at `height` - nothing black leaks
+    # past it into what should still be blank canvas.
+    assert image.getpixel((0, height + 4)) == (255, 255, 255)
+
+
+# ---------------- node_header_layout() ----------------
+
+def test_node_header_layout_short_name_is_single_line():
+    height, lines, _font = node_header_layout("Flint TAP2", 200)
+    assert height == NODE_HEADER_HEIGHT_SINGLE
+    assert lines == ["Flint TAP2"]
+
+
+def test_node_header_layout_real_long_name_wraps_to_two_lines():
+    # Real Meshtastic naming convention from the user's own mesh: a
+    # region/route prefix in brackets + human name + short ID - not a
+    # rare edge case, this is what triggered task 42.
+    name = "[de.nby.n.RiBeNet.cb] SolisCultor c87b"
+    height, lines, font = node_header_layout(name, 200)
+    assert height == NODE_HEADER_HEIGHT_DOUBLE
+    assert len(lines) == 2
+    available_width = 200 - 16
+    for line in lines:
+        assert text_width(line, font) <= available_width
+
+
+def test_node_header_layout_extreme_name_truncates_last_line_with_ellipsis():
+    # Even 2 lines at the smallest candidate size can't hold this - the
+    # hard ceiling of 2 lines must still hold, with the last line
+    # ellipsis-truncated rather than a 3rd line or an overflowed edge.
+    # Deliberately multi-word (not one unbreakable token) so
+    # _wrap_to_width() actually produces more than 2 candidate lines and
+    # the fallback path's kept=lines[:2] has 2 elements to truncate.
+    name = "Word " * 40
+    height, lines, font = node_header_layout(name, 200)
+    assert height == NODE_HEADER_HEIGHT_DOUBLE
+    assert len(lines) == 2
+    assert lines[-1].endswith("…")
+    available_width = 200 - 16
+    for line in lines:
+        assert text_width(line, font) <= available_width
 
 
 # ---------------- draw_page_header() / draw_separator() ----------------
@@ -121,6 +174,21 @@ def test_draw_page_header_draws_title_text():
     assert (0, 0, 0) in row_pixels
 
 
+def test_draw_page_header_honors_explicit_y():
+    # Task 42: real page render()s pass a dynamic y (header_height + 2)
+    # instead of always relying on the single-line PAGE_HEADER_Y default -
+    # confirm draw_page_header() actually draws at the y it's given, not
+    # always at the default.
+    image, _draw = new_canvas(WEACT_CAPS)
+    custom_y = PAGE_HEADER_Y + 16
+    draw_page_header(image, "status", y=custom_y)
+    row_pixels = [image.getpixel((x, custom_y + 4)) for x in range(4, 60)]
+    assert (0, 0, 0) in row_pixels
+    # And nothing was painted at the old default row instead.
+    default_row_pixels = [image.getpixel((x, PAGE_HEADER_Y + 4)) for x in range(4, 60)]
+    assert (0, 0, 0) not in default_row_pixels
+
+
 def test_draw_separator_draws_a_full_width_line():
     image, _draw = new_canvas(WEACT_CAPS)
     w, _h = image.size
@@ -133,4 +201,4 @@ def test_draw_separator_draws_a_full_width_line():
 def test_content_y_is_below_separator():
     # Layout sanity: the content area must start after the separator, not
     # overlap the page-header row above it.
-    assert CONTENT_Y > SEPARATOR_Y > PAGE_HEADER_Y > NODE_HEADER_HEIGHT
+    assert CONTENT_Y > SEPARATOR_Y > PAGE_HEADER_Y > NODE_HEADER_HEIGHT_SINGLE


### PR DESCRIPTION
## Summary

- `draw_node_header()` in `modules/display/renderer.py` was always single-line — for a name too long even at the smallest 14px font, it silently drew text wider than the header band, no wrapping/ellipsis. This isn't a rare edge case: `[de.nby.n.RiBeNet.cb] SolisCultor c87b` (region-prefix + name + short-ID) is a normal Meshtastic naming convention, and it's a real name from the user's own mesh network.
- New pure `node_header_layout(node_name, width)` picks: single line if it fits (identical result to old behavior for short names), else a word-wrapped 2-line layout (rejecting any candidate size where either wrapped line still overflows), else — as a last resort — the first 2 wrapped lines at 14px with the *last* line ellipsis-truncated character-by-character. Hard ceiling: never more than 2 lines.
- `draw_node_header()` now returns the actual header height (`NODE_HEADER_HEIGHT_SINGLE = 30` or `NODE_HEADER_HEIGHT_DOUBLE = 46`) instead of `None`, so callers compute their own `page_header_y`/`separator_y`/`content_y` from it (same `+2`/`+24`/`+30` deltas as before, just relative to the real height) instead of relying on fixed constants.
- All 6 known call sites updated: `status.py`, `power.py`, `system.py`, `message.py`, `radio.py` (all five: `draw_page_header(..., y=page_header_y)`, `draw_separator(image, separator_y)`, `y = content_y`), and `alert.py` (`y = header_height + 8` instead of the removed `NODE_HEADER_HEIGHT` constant).
- The 3 live-clock overlay call sites in `service.py` (`_mark_dirty_with_clock()`, `build_status_image_now()`, `build_page_image_now()`) now compute `header_height` via the new pure `node_header_layout()` (no `Image` touched — this runs before the pre-clock hash used for refresh dedup) and pass `y=header_height + 2` to `draw_epaper_clock()` instead of relying on its old single-line default. Missing this would have made the clock silently collide with a 2-line header's second line on the real panel.

## Verification

- `python -m compileall .` clean (Windows dev + real node).
- `pytest -q`: 243 passed / 24 skipped locally (Windows, no DejaVu font); **267 passed / 0 skipped** on a live node with the real font (was 262 before this change — 5 new tests for `node_header_layout()` short/long/extreme-ellipsis cases + `draw_page_header()` honoring an explicit `y`). Existing `draw_node_header()` tests adapted (not removed) for the new 2-line behavior.
- PNG renders (real DejaVu font, live node): short name on Status keeps the exact same compact 1-line layout; the real long name on Status wraps cleanly to 2 lines with the page title/separator correctly pushed down, no overlap; same long name on Alert renders correctly with header/layout intact.
- **Known, reported-not-fixed**: `system.py`'s bottom TEMP/UPTIME row was already on a tight vertical budget (task 37). With a 2-line header the extra 16px pushes it to ~0px margin from the canvas bottom edge — verified via PNG that it does *not* actually overflow (bottom text pixel lands at y≈199 of 200), but there's no room to spare. Not fixed here per scope (page content logic below the header is explicitly untouched, only where it sources its starting Y from).
- **Skipped**: live node-rename check. Renaming a real node's name broadcasts to the entire mesh (visible to other participants), not just this test setup — the PNG renders already exercise the identical `render()`/`service.py` code paths the physical panel uses, so the incremental value didn't justify a real broadcast-identity change.

## Test plan

- [x] `pytest -q` green on Windows and on a live node with the real font
- [x] `python -m compileall .` clean
- [x] PNG renders reviewed: short name (Status), long name (Status), long name (Alert)
- [x] `system.py` overflow risk investigated and confirmed non-overflowing (documented above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)