### PR TITLE
🛡️ Sentinel: Fix directory path deletion risk in camera gallery

### DIFF
--- a/camera/camera.py
+++ b/camera/camera.py
@@ -787,7 +787,7 @@ def capture_screenshot():
 
 def screenshot_exists(filename):
     filepath = safe_screenshot_path(filename)
-    return filepath is not None and os.path.exists(filepath)
+    return filepath is not None and os.path.isfile(filepath)
 
 
 def list_screenshots():
@@ -819,7 +819,7 @@ def list_screenshots():
 def delete_screenshot(filename):
     filepath = safe_screenshot_path(filename)
 
-    if filepath is None or not os.path.exists(filepath):
+    if filepath is None or not os.path.isfile(filepath):
         return {"ok": False, "error": "File not found"}, 404
 
     os.remove(filepath)

--- a/tests/test_camera_security.py
+++ b/tests/test_camera_security.py
@@ -1,0 +1,39 @@
+import os
+import tempfile
+
+
+def test_safe_screenshot_path_traversal(server_module):
+    """Verify safe_screenshot_path rejects path traversal attempts."""
+    import camera.camera as camera_module
+    assert camera_module.safe_screenshot_path("../etc/passwd") is None
+    assert camera_module.safe_screenshot_path("..\\windows\\system32") is None
+    assert camera_module.safe_screenshot_path("../../file.jpg") is None
+
+
+def test_screenshot_exists_directory_rejection(server_module, monkeypatch):
+    """Verify screenshot_exists returns False for directories."""
+    import camera.camera as camera_module
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setattr(camera_module, "SCREENSHOTS_DIR", tmpdir)
+
+        # Create a directory inside SCREENSHOTS_DIR
+        sub_dir = os.path.join(tmpdir, "subdir")
+        os.makedirs(sub_dir, exist_ok=True)
+
+        assert camera_module.screenshot_exists("subdir") is False
+
+
+def test_delete_screenshot_directory_rejection(server_module, monkeypatch):
+    """Verify delete_screenshot returns 404/error when given a directory path."""
+    import camera.camera as camera_module
+    with tempfile.TemporaryDirectory() as tmpdir:
+        monkeypatch.setattr(camera_module, "SCREENSHOTS_DIR", tmpdir)
+
+        # Create a directory inside SCREENSHOTS_DIR
+        sub_dir = os.path.join(tmpdir, "subdir")
+        os.makedirs(sub_dir, exist_ok=True)
+
+        res, status = camera_module.delete_screenshot("subdir")
+        assert status == 404
+        assert res["ok"] is False
+        assert os.path.exists(sub_dir)


### PR DESCRIPTION
Fix path traversal and directory rejection in `camera/camera.py` by replacing `os.path.exists` with `os.path.isfile` in `screenshot_exists` and `delete_screenshot`. Add unit tests to verify directory path rejection.

---
*PR created automatically by Jules for task [13020208312063798077](https://jules.google.com/task/13020208312063798077) started by @FlintUA*