### PR TITLE
BLETransport - RadioTransport over BLEInterface (Task 45)

### DIFF
--- a/adapters/meshtastic/_timeout_support.py
+++ b/adapters/meshtastic/_timeout_support.py
@@ -1,0 +1,85 @@
+"""Shared tier-1 timeout enforcement (docs/BACKEND_API.md "Timeouts") for
+every RadioTransport implementation in this package.
+
+Extracted from adapters/meshtastic/serial_transport.py (Task 44) during
+Task 45, so BLETransport doesn't duplicate the same watchdog pattern - and
+so a future TCP transport has it for free too. Behavior is unchanged: see
+tests/test_serial_transport_timeout.py, which still exercises this exact
+code through SerialTransport and is required to pass unmodified after this
+extraction.
+
+HOTFIX (caught live during Task 45's BLETransport smoke test, affects the
+already-deployed SerialTransport too - see
+test_call_with_timeout_thread_is_a_daemon_and_does_not_block_process_exit):
+this originally used concurrent.futures.ThreadPoolExecutor. Its worker
+threads are NOT daemon threads, and concurrent.futures.thread registers an
+atexit hook (_python_exit()) that waits for every worker thread of every
+ThreadPoolExecutor ever created, regardless of that executor's own
+shutdown() state, before the process is allowed to exit. A genuinely
+hung tier-1-abandoned call (live-observed: BLEInterface.close()'s
+self._eventThread.join() with no timeout of its own) therefore blocked
+clean process exit - not "wait longer", an unconditional hang requiring
+kill -9. A prior review suggested overriding ThreadPoolExecutor's private
+_thread_class attribute to mark workers as daemon threads; that attribute
+does not exist on this project's Python version (3.14 - confirmed via
+`hasattr(ThreadPoolExecutor(), '_thread_class')` == False), so this
+module does not use ThreadPoolExecutor at all: each call gets its own
+plain `threading.Thread(daemon=True)`, resulted via a one-slot
+`queue.Queue`, with no pooling and no private API surface to break on a
+future Python version.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Callable
+
+from meshsrv.radio_transport import TransportError, TransportErrorCode
+
+
+class TimeoutEnforced:
+    """Mixin providing _call_with_timeout(). Non-blocking return to the
+    caller only - see docs/BACKEND_API.md "Timeouts" for why this does
+    NOT guarantee the wrapped call actually stops (tier 1 vs tier 2)."""
+
+    def __init__(self, thread_name_prefix: str) -> None:
+        self._timeout_thread_name_prefix = thread_name_prefix
+        self._timeout_call_counter = 0
+        self._timeout_call_counter_lock = threading.Lock()
+
+    def _call_with_timeout(self, fn: Callable[[], object], timeout: float, what: str):
+        result_box: "queue.Queue[tuple[str, object]]" = queue.Queue(maxsize=1)
+
+        def _run():
+            try:
+                result_box.put(("ok", fn()))
+            except BaseException as exc:  # noqa: BLE001 - deliberately catch-all, re-raised on the caller's thread below
+                result_box.put(("error", exc))
+
+        with self._timeout_call_counter_lock:
+            self._timeout_call_counter += 1
+            thread_name = f"{self._timeout_thread_name_prefix}-{self._timeout_call_counter}"
+
+        # daemon=True is the entire point of this module: if `fn` never
+        # returns (the tier-2 gap documented on every transport's
+        # connect()/disconnect()), this thread is abandoned exactly like
+        # before, but a daemon thread never blocks process exit - see
+        # this module's HOTFIX docstring.
+        thread = threading.Thread(target=_run, name=thread_name, daemon=True)
+        thread.start()
+
+        try:
+            status, payload = result_box.get(timeout=timeout)
+        except queue.Empty:
+            raise TransportError(
+                TransportErrorCode.TIMEOUT, f"{what} exceeded {timeout}s"
+            ) from None
+
+        if status == "error":
+            raise payload
+        return payload
+
+    def _shutdown_executor(self) -> None:
+        """No pooled executor to shut down anymore (see this module's
+        HOTFIX docstring) - kept as a no-op so close() in every transport
+        (which calls this) doesn't need its own version check."""

--- a/adapters/meshtastic/ble_transport.py
+++ b/adapters/meshtastic/ble_transport.py
@@ -1,0 +1,572 @@
+"""BLETransport — the RadioTransport implementation over
+`meshtastic.ble_interface.BLEInterface`.
+
+Task 45: happy-path only, per section 5 of the license/BLE plan. Wraps
+BLEInterface - does not implement GATT itself. No pairing/PIN UI: this
+transport connects to a device already paired at the OS (BlueZ) level,
+confirmed sufficient by the live Task 43 test on TAP2 (`bluetoothctl pair`
+with the node's PIN, then `meshtastic --ble <addr> --info` succeeded).
+
+OWNERSHIP MODEL - different from SerialTransport, on purpose (per review
+discussion ahead of implementation): SerialTransport opens a fresh
+SerialInterface inside every send_*/get_* call and closes it in a
+`finally` (radio_lock-guarded, because it competes with the --listen
+subprocess and api/api_chat.py for the one serial port). BLETransport
+has no such competitor and BLE connection setup is comparatively
+expensive/slow (live-tested: several seconds, and reopening on every call
+risks reproducing the >90s hang from Task 43). So here, a single
+`self._interface` is opened once in connect() and reused by every
+subsequent call until disconnect()/close(). Any send_*/get_* called while
+`self._state != ConnectionState.CONNECTED` raises/returns
+TransportError(NOT_CONNECTED) - it never tries to auto-connect.
+
+One consequence: send_messages()'s "one connection for the whole batch"
+requirement (docs/BACKEND_API.md "Batching") is trivial here - it is
+already one persistent connection for *everything*, not just one batch.
+No _claim_radio()-style prepare/cooldown choreography is needed or
+present.
+
+NOT this class's responsibility: a Meshtastic node accepts only one
+active link (serial OR BLE) at a time - confirmed live in Task 43 (BLE
+connect failed until the USB cable was physically removed). BLETransport
+does not check or enforce this; Core (Task 46/47) is responsible for
+making sure SerialTransport's listener is fully stopped before a
+BLETransport connect is attempted.
+"""
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from typing import Callable, Optional, Sequence
+
+from adapters.meshtastic._timeout_support import TimeoutEnforced
+from meshsrv.node_time_sync import try_sync as try_node_time_sync
+from meshsrv.radio_transport import (
+    ChannelInfo,
+    ConnectionDescriptor,
+    ConnectionInfo,
+    ConnectionState,
+    ConnectionType,
+    NodeInfo,
+    NodeUser,
+    OutgoingMessage,
+    OutgoingWaypoint,
+    RadioTransport,
+    SendResult,
+    TransportError,
+    TransportErrorCode,
+    WaypointResult,
+)
+
+# Fixed reconnect attempts with growing backoff - "naive reconnect" per
+# plan section 5.5, not exponential/jittered/configurable.
+_RECONNECT_DELAYS_S = (1.0, 2.0, 4.0)
+
+
+class BLETransport(TimeoutEnforced, RadioTransport):
+    def __init__(
+        self,
+        address: str,
+        name: str = "",
+        expected_node_id: Optional[str] = None,
+        on_log: Optional[Callable[[str, str], None]] = None,
+    ) -> None:
+        TimeoutEnforced.__init__(self, thread_name_prefix="ble-transport-watchdog")
+        self._address = address
+        self._name = name
+        self._expected_node_id = expected_node_id
+        self._on_log = on_log or (lambda msg, level="INFO": None)
+
+        # Guards every mutation of _interface/_state (connect/disconnect/
+        # close) and every read+use of _interface (_require_connected()
+        # and all send_*/get_* bodies). Added per review: without it,
+        # a concurrent disconnect()/reconnect() (e.g. a user hitting
+        # "Switch to Serial" in the UI, Task 46/47) could null out
+        # self._interface while a send_*/get_* call already in flight is
+        # still using it - the same class of bug already caught and
+        # fixed once in SerialTransport's _prepare_radio_command() race
+        # (Task 44 review). NOT reentrant - _require_connected() must
+        # only ever be called by code that already holds this lock, never
+        # acquires it itself.
+        self._lock = threading.Lock()
+
+        self._interface = None
+        self._state = ConnectionState.DISCONNECTED
+        self._connected_since: Optional[float] = None
+        self._last_error: Optional[TransportError] = None
+        self._node_id: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _require_connected(self) -> None:
+        """Caller MUST already hold self._lock - this does not acquire
+        it (self._lock is a plain, non-reentrant Lock)."""
+        if self._state != ConnectionState.CONNECTED or self._interface is None:
+            raise TransportError(TransportErrorCode.NOT_CONNECTED, "BLETransport is not connected")
+
+    def _force_disconnect_os_level(self) -> None:
+        """Live Task 43 finding: a stale OS-level (BlueZ) GATT session
+        from a previous attempt silently blocked a fresh connect until
+        `bluetoothctl disconnect <address>` was run. connect(force=True)
+        reproduces that exact fix instead of assuming a clean slate."""
+        try:
+            subprocess.run(
+                ["bluetoothctl", "disconnect", self._address],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception as e:
+            print(f"[BLETransport] force disconnect warning: {e}", flush=True)
+
+    @staticmethod
+    def _local_node_id(interface) -> Optional[str]:
+        my_info = getattr(interface, "myInfo", None)
+        num = getattr(my_info, "my_node_num", None)
+        if num is None:
+            return None
+        return f"!{int(num):08x}"
+
+    def _detach_and_close_async(self, *, timeout: float) -> None:
+        """Synchronously detaches self._interface and flips self._state
+        to DISCONNECTED (under self._lock, so no other call can ever
+        observe a stale CONNECTED pointing at an interface mid-teardown -
+        the exact bug this replaced, per review), THEN closes the
+        detached interface in the background via _call_with_timeout.
+        `timeout` bounds how long the CALLER waits for that close() to
+        actually finish - it never affects the correctness of this
+        transport's own state, which is already updated before this
+        method's background call even starts. Used by both disconnect()
+        and connect(force=True)'s teardown of a stale interface - neither
+        one may block its caller's thread for the full close() duration
+        (live-measured on TAP2 at 60s+) without this timeout wrapper."""
+        with self._lock:
+            interface_to_close = self._interface
+            self._interface = None
+            self._state = ConnectionState.DISCONNECTED
+            self._connected_since = None
+
+        def _do_close():
+            if interface_to_close is not None:
+                try:
+                    interface_to_close.close()
+                except Exception:
+                    pass
+
+        try:
+            self._call_with_timeout(_do_close, timeout=timeout, what="close interface")
+        except TransportError as error:
+            # Own state is already correct (detached above) regardless -
+            # this is purely "how long did the background close() take",
+            # not a correctness signal, so it's logged, not re-raised.
+            self._on_log(f"BLE interface close() did not finish within {timeout}s: {error}", "WARNING")
+
+    # ------------------------------------------------------------------
+    # RadioTransport - connection lifecycle
+    # ------------------------------------------------------------------
+    def connect(
+        self, descriptor: ConnectionDescriptor, *, force: bool = False, timeout: float = 90.0
+    ) -> ConnectionInfo:
+        """Default raised from the ABC docstring's 30.0 to 90.0 - the ABC
+        only requires the method to exist, Python doesn't enforce
+        subclasses matching its documented default. Live-measured on
+        TAP2 twice, consistently: a real connect() took 71.5-71.8s. With
+        the ABC default, this isn't "a bit slow" - a caller that doesn't
+        remember to override `timeout` on every single call gets
+        TransportError(TIMEOUT) on fully working hardware, nearly always.
+        Same reasoning as disconnect()'s 15s -> 30s raise: not chasing an
+        exact number, taking a reasonable margin over what was actually
+        observed twice."""
+        if descriptor.type != ConnectionType.BLUETOOTH:
+            raise TransportError(
+                TransportErrorCode.UNSUPPORTED, f"BLETransport cannot connect to {descriptor.type}"
+            )
+        self._address = descriptor.address or self._address
+        self._name = descriptor.label or self._name
+        with self._lock:
+            self._state = ConnectionState.CONNECTING
+
+        if force:
+            self._detach_and_close_async(timeout=timeout)
+            self._force_disconnect_os_level()
+
+        def _do_connect():
+            from meshtastic.ble_interface import BLEInterface
+
+            return BLEInterface(address=self._address, timeout=int(timeout))
+
+        try:
+            interface = self._call_with_timeout(_do_connect, timeout=timeout, what="connect()")
+        except TransportError as error:
+            with self._lock:
+                self._state = ConnectionState.ERROR
+                self._last_error = error
+            raise
+
+        node_id = self._local_node_id(interface)
+
+        if self._expected_node_id and node_id != self._expected_node_id:
+            # IDENTITY MISMATCH TEARDOWN (per review discussion): close
+            # the just-opened GATT session before reporting ERROR - never
+            # leave a live connection to the wrong device dangling, same
+            # spirit as the ABC's disconnect()/close() completion
+            # guarantee.
+            try:
+                interface.close()
+            except Exception:
+                pass
+            error = TransportError(
+                TransportErrorCode.IDENTITY_MISMATCH,
+                f"Connected BLE node {node_id!r} does not match expected {self._expected_node_id!r}",
+            )
+            with self._lock:
+                self._state = ConnectionState.ERROR
+                self._last_error = error
+            raise error
+
+        with self._lock:
+            self._interface = interface
+            self._node_id = node_id
+            self._state = ConnectionState.CONNECTED
+            self._connected_since = time.time()
+            self._last_error = None
+        return self.get_connection_info()
+
+    def disconnect(self, *, timeout: float = 30.0) -> None:
+        """Default raised from 15s to 30s (live-measured on TAP2: a real
+        BLEInterface.close() call took 60s+ once) - moderate, not a
+        guess at a number that will never time out (variance observed
+        was too large for that to be realistic on this hardware). Since
+        the fix below makes this transport's own state correct
+        regardless of how long the background close() actually takes,
+        `timeout` only controls UI responsiveness, not correctness - see
+        docs/BACKEND_API.md and Task 47 for surfacing "this can take up
+        to a minute on some devices" in the UI rather than chasing a
+        timeout number that covers every observed case.
+
+        OWNERSHIP TRANSFER (fixed per review, was a real bug): does
+        NOT do "call interface.close() -> then update state", because if
+        that close() timed out, the state update after it would never
+        run - self._state would stay CONNECTED and self._interface would
+        stay pointing at an object a now-abandoned daemon thread is
+        concurrently closing in the background. Anything calling
+        is_connected()/_require_connected() right after a timed-out
+        disconnect() would see a stale CONNECTED and race that same
+        background thread for self._interface - the exact class of bug
+        self._lock exists to prevent, so this fix and that lock depend
+        on each other. See _detach_and_close_async()."""
+        self._detach_and_close_async(timeout=timeout)
+
+    def reconnect(self, *, timeout: float = 90.0) -> ConnectionInfo:
+        """Naive reconnect (plan section 5.5): fixed attempts with
+        growing backoff, not exponential/unbounded.
+
+        Default raised to match connect()'s (see that method's
+        docstring) - this `timeout` is passed straight through to each
+        connect() attempt in the retry loop below, so leaving this at
+        the old 30.0 would silently reintroduce the same "fails on fully
+        working hardware" defect connect() itself just had fixed."""
+        self.disconnect(timeout=min(timeout, 30.0))
+
+        last_error: Optional[TransportError] = None
+        for attempt, delay in enumerate(_RECONNECT_DELAYS_S, start=1):
+            try:
+                return self.connect(
+                    ConnectionDescriptor(type=ConnectionType.BLUETOOTH, address=self._address, label=self._name),
+                    force=True,
+                    timeout=timeout,
+                )
+            except TransportError as error:
+                last_error = error
+                self._on_log(f"BLE reconnect attempt {attempt} failed: {error}", "WARNING")
+                time.sleep(delay)
+
+        with self._lock:
+            self._state = ConnectionState.ERROR
+            self._last_error = last_error
+        raise last_error or TransportError(TransportErrorCode.CONNECT_FAILED, "reconnect() exhausted all attempts")
+
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._state == ConnectionState.CONNECTED and self._interface is not None
+
+    def get_connection_info(self) -> ConnectionInfo:
+        with self._lock:
+            return ConnectionInfo(
+                state=self._state,
+                descriptor=ConnectionDescriptor(type=ConnectionType.BLUETOOTH, address=self._address, label=self._name),
+                node_id=self._node_id,
+                connected_since=self._connected_since,
+                last_error=self._last_error,
+            )
+
+    def close(self) -> None:
+        self.disconnect(timeout=30.0)
+        self._shutdown_executor()
+
+    # ------------------------------------------------------------------
+    # NOT part of the RadioTransport ABC: device discovery for the
+    # future Settings "Scan" button (Task 46). Live-tested against
+    # meshtastic.ble_interface.BLEInterface.scan() (re-read fresh ahead
+    # of this implementation, not from memory): a @staticmethod, no
+    # arguments, blocks ~10s, already filters by the Meshtastic service
+    # UUID internally. Returns a list of bleak BLEDevice objects - a
+    # third-party library type, so reduced to plain dicts here per the
+    # same "no library types out of the transport" rule as everywhere
+    # else in this package.
+    # ------------------------------------------------------------------
+    def scan(self, *, timeout: float = 15.0) -> list[dict]:
+        def _do_scan():
+            from meshtastic.ble_interface import BLEInterface
+
+            devices = BLEInterface.scan()
+            return [{"name": d.name, "address": d.address} for d in devices]
+
+        return self._call_with_timeout(_do_scan, timeout=timeout, what="scan()")
+
+    # ------------------------------------------------------------------
+    # RadioTransport - sending. Persistent self._interface (see module
+    # docstring's OWNERSHIP MODEL) - not reopened per call.
+    # ------------------------------------------------------------------
+    def send_text(self, message: OutgoingMessage, *, timeout: float = 15.0) -> SendResult:
+        results = self.send_messages([message], timeout=timeout)
+        return results[0]
+
+    def send_packet(
+        self,
+        payload: bytes,
+        destination_id: str,
+        *,
+        port_num: int,
+        want_ack: bool = False,
+        timeout: float = 15.0,
+    ) -> SendResult:
+        def _do_send():
+            with self._lock:
+                self._require_connected()
+                sent = self._interface.sendData(
+                    payload,
+                    destinationId=destination_id,
+                    portNum=port_num,
+                    wantAck=want_ack,
+                )
+                packet_id = getattr(sent, "id", None)
+                return SendResult(accepted=True, packet_id=int(packet_id) if packet_id is not None else None)
+
+        try:
+            return self._call_with_timeout(_do_send, timeout=timeout, what="send_packet()")
+        except TransportError as error:
+            return SendResult(accepted=False, error=error)
+
+    def send_messages(
+        self, messages: Sequence[OutgoingMessage], *, timeout: float = 30.0
+    ) -> list[SendResult]:
+        """Trivial loop over the already-open self._interface - no
+        connect/disconnect-per-batch choreography needed (see module
+        docstring's OWNERSHIP MODEL); "one connection for the whole
+        batch" is automatically true because it's one connection for
+        everything until disconnect()."""
+
+        def _do_send_all():
+            with self._lock:
+                self._require_connected()
+                results: list[SendResult] = []
+                for message in messages:
+                    try:
+                        sent = self._interface.sendText(
+                            text=message.text,
+                            destinationId=message.destination_id,
+                            wantAck=message.want_ack,
+                            channelIndex=message.channel_index,
+                            replyId=message.reply_id,
+                        )
+                        packet_id = getattr(sent, "id", None)
+                        results.append(
+                            SendResult(accepted=True, packet_id=int(packet_id) if packet_id is not None else None)
+                        )
+                    except Exception as e:
+                        results.append(SendResult(accepted=False, error=TransportError(TransportErrorCode.UNKNOWN, str(e))))
+                return results
+
+        try:
+            return self._call_with_timeout(_do_send_all, timeout=timeout, what="send_messages()")
+        except TransportError as error:
+            return [SendResult(accepted=False, error=error) for _ in messages]
+
+    def send_waypoint(self, waypoint: OutgoingWaypoint, *, timeout: float = 15.0) -> WaypointResult:
+        import secrets
+
+        def _waypoint_id() -> int:
+            return secrets.randbelow(1_000_000_000 - 1) + 1
+
+        def _do_send():
+            with self._lock:
+                self._require_connected()
+                waypoint_id = int(waypoint.waypoint_id or _waypoint_id())
+                waypoint_packet = self._interface.sendWaypoint(
+                    name=waypoint.name,
+                    description=waypoint.description,
+                    icon=int(waypoint.icon),
+                    expire=int(waypoint.expire_at),
+                    waypoint_id=waypoint_id,
+                    latitude=float(waypoint.latitude),
+                    longitude=float(waypoint.longitude),
+                    channelIndex=int(waypoint.channel_index),
+                    wantAck=True,
+                    wantResponse=False,
+                )
+
+                notification_packet_id = None
+                if waypoint.post_notification and waypoint.notification_text.strip():
+                    notification_packet = self._interface.sendText(
+                        text=waypoint.notification_text,
+                        destinationId="^all",
+                        channelIndex=int(waypoint.channel_index),
+                        wantAck=False,
+                        wantResponse=False,
+                    )
+                    notification_packet_id = int(notification_packet.id)
+
+                return WaypointResult(
+                    waypoint_id=waypoint_id,
+                    waypoint_packet_id=int(waypoint_packet.id),
+                    notification_packet_id=notification_packet_id,
+                )
+
+        return self._call_with_timeout(_do_send, timeout=timeout, what="send_waypoint()")
+
+    # ------------------------------------------------------------------
+    # RadioTransport - reads. Same "not wired to any Core call site yet"
+    # status as SerialTransport's - Task 46 territory.
+    # ------------------------------------------------------------------
+    def get_nodes(self, *, timeout: float = 15.0) -> list[NodeInfo]:
+        def _do_get():
+            with self._lock:
+                self._require_connected()
+                raw_nodes = getattr(self._interface, "nodes", None) or {}
+                return [self._to_node_info(node_id, data) for node_id, data in raw_nodes.items()]
+
+        return self._call_with_timeout(_do_get, timeout=timeout, what="get_nodes()")
+
+    def get_local_node(self, *, timeout: float = 15.0) -> NodeInfo:
+        def _do_get():
+            with self._lock:
+                self._require_connected()
+                local = getattr(self._interface, "localNode", None)
+                node_num = getattr(local, "nodeNum", None)
+                raw_nodes = getattr(self._interface, "nodes", None) or {}
+                for node_id, data in raw_nodes.items():
+                    if data.get("num") == node_num:
+                        return self._to_node_info(node_id, data)
+                raise TransportError(TransportErrorCode.UNKNOWN, "Local node not found in node list")
+
+        return self._call_with_timeout(_do_get, timeout=timeout, what="get_local_node()")
+
+    def get_channels(self, *, timeout: float = 15.0) -> list[ChannelInfo]:
+        def _do_get():
+            with self._lock:
+                self._require_connected()
+                raw_channels = getattr(getattr(self._interface, "localNode", None), "channels", None) or []
+                channels = []
+                for fallback_index, channel in enumerate(raw_channels):
+                    index = getattr(channel, "index", fallback_index)
+                    try:
+                        index = int(index)
+                    except (TypeError, ValueError):
+                        index = fallback_index
+                    if index < 0 or index > 7:
+                        continue
+                    settings_obj = getattr(channel, "settings", None)
+                    name = getattr(settings_obj, "name", "") if settings_obj is not None else ""
+                    role = getattr(channel, "role", None)
+                    # Same role-int-to-name mapping as SerialTransport.get_channels()
+                    # (live-tested in Task 44) - mesh_pb2.Channel.Role: 0=DISABLED,
+                    # 1=PRIMARY, 2=SECONDARY.
+                    role_name = {0: "DISABLED", 1: "PRIMARY", 2: "SECONDARY"}.get(role, str(role))
+                    if role == 0:
+                        continue
+                    channels.append(ChannelInfo(index=index, name=name, role=role_name))
+                return channels
+
+        return self._call_with_timeout(_do_get, timeout=timeout, what="get_channels()")
+
+    def get_metadata(self, *, timeout: float = 15.0) -> dict:
+        """Unlike SerialTransport.get_metadata() (which shells out to a
+        second, independent `meshtastic --info` CLI call), this does NOT
+        open a second BLE connection to fetch metadata - a Meshtastic
+        node's BLE stack was not verified to accept concurrent
+        connections, and doing so while self._interface already holds
+        one risks reproducing the Task 43 hang. Instead this reads the
+        already-open self._interface's own `.metadata` field (a
+        `mesh_pb2.DeviceMetadata` populated from the config stream during
+        connect() - see meshtastic/mesh_interface.py's onResponseTryConfig
+        `fromRadio.HasField("metadata")` handler), same source the CLI's
+        own `--info` "Metadata:" line uses internally
+        (mesh_interface.py's getLongName()-adjacent showInfo(), which
+        calls the same MessageToJson on self.metadata).
+
+        NAMED GAP, same spirit as SerialTransport.get_metadata(): returns
+        the metadata as a JSON *string* (via protobuf's MessageToJson),
+        not a parsed dict with individual fields - whoever wires this
+        into Core in Task 46 must parse it if structured fields are
+        needed."""
+
+        def _do_get():
+            with self._lock:
+                self._require_connected()
+                from google.protobuf.json_format import MessageToJson
+
+                metadata = getattr(self._interface, "metadata", None)
+                if metadata is None:
+                    return {"metadata_json": ""}
+                return {"metadata_json": MessageToJson(metadata)}
+
+        return self._call_with_timeout(_do_get, timeout=timeout, what="get_metadata()")
+
+    @staticmethod
+    def _to_node_info(node_id: str, data: dict) -> NodeInfo:
+        user_data = data.get("user") or {}
+        user = NodeUser(
+            id=user_data.get("id", node_id),
+            long_name=user_data.get("longName", ""),
+            short_name=user_data.get("shortName", ""),
+            hw_model=user_data.get("hwModel", ""),
+            is_licensed=bool(user_data.get("isLicensed", False)),
+        ) if user_data else None
+        return NodeInfo(
+            node_id=node_id,
+            num=data.get("num", 0),
+            user=user,
+            last_heard=data.get("lastHeard"),
+            snr=data.get("snr"),
+            rssi=data.get("rssi"),
+            hop_count=data.get("hopsAway"),
+            is_favorite=bool(data.get("isFavorite", False)),
+            device_metrics=data.get("deviceMetrics") or {},
+            environment_metrics=data.get("environmentMetrics") or {},
+            power_metrics=data.get("powerMetrics") or {},
+            position=data.get("position"),
+        )
+
+    # ------------------------------------------------------------------
+    # RadioTransport - device time
+    # ------------------------------------------------------------------
+    def set_device_time(self, epoch_seconds: int, *, timeout: float = 15.0) -> bool:
+        """Same KNOWN SIGNATURE MISMATCH as SerialTransport.set_device_time()
+        (epoch_seconds accepted per the ABC but not passed through -
+        try_sync() derives system time itself and gates on is_trusted()/
+        MIN_SYNC_INTERVAL_S) - see that method's docstring for the full
+        rationale, unchanged here."""
+
+        def _do_sync():
+            with self._lock:
+                self._require_connected()
+                outcome = try_node_time_sync(
+                    interface=self._interface,
+                    log_fn=lambda msg, level="INFO": self._on_log(msg, level),
+                )
+                return outcome == "synced"
+
+        return self._call_with_timeout(_do_sync, timeout=timeout, what="set_device_time()")

--- a/adapters/meshtastic/serial_transport.py
+++ b/adapters/meshtastic/serial_transport.py
@@ -38,11 +38,10 @@ from __future__ import annotations
 import subprocess
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import contextmanager
 from typing import Callable, Optional, Sequence
 
+from adapters.meshtastic._timeout_support import TimeoutEnforced
 from meshsrv import meshtastic_transport
 from meshsrv.node_time_sync import try_sync as try_node_time_sync
 from meshsrv.radio_transport import (
@@ -64,7 +63,7 @@ from meshsrv.radio_transport import (
 from meshsrv.runtime_identity import meshtastic_command
 
 
-class SerialTransport(RadioTransport):
+class SerialTransport(TimeoutEnforced, RadioTransport):
     def __init__(
         self,
         cli_path: str,
@@ -86,34 +85,13 @@ class SerialTransport(RadioTransport):
         self._listen_process: Optional[subprocess.Popen] = None
         self._connected_since: Optional[float] = None
         self._last_error: Optional[TransportError] = None
-        # NOT max_workers=1: with a single shared worker, a call queued
-        # behind an already-running one would have its own `timeout`
-        # measured from submission, not from when it actually starts
-        # executing - a slow-but-healthy call (e.g. a 20s send_messages
-        # batch) would make an unrelated concurrent call (e.g. get_nodes
-        # (timeout=15)) raise TransportError(TIMEOUT) purely from
-        # queueing, misreported as if the radio itself had hung. Real
-        # hardware serialization is already radio_lock's job (see
-        # _claim_radio); this pool exists only to give each call its own
-        # thread to abandon on timeout (see class docstring's tier-1/
-        # tier-2 split), not to serialize calls itself. Verified by
-        # tests/test_serial_transport_timeout.py::
-        # test_concurrent_calls_do_not_spuriously_timeout_each_other.
-        self._executor = ThreadPoolExecutor(thread_name_prefix="serial-transport-watchdog")
-
-    # ------------------------------------------------------------------
-    # Tier-1 timeout enforcement (docs/BACKEND_API.md "Timeouts").
-    # Non-blocking return to the caller only - see that section for why
-    # this does NOT guarantee the wrapped call actually stops.
-    # ------------------------------------------------------------------
-    def _call_with_timeout(self, fn: Callable[[], object], timeout: float, what: str):
-        future = self._executor.submit(fn)
-        try:
-            return future.result(timeout=timeout)
-        except FutureTimeoutError:
-            raise TransportError(
-                TransportErrorCode.TIMEOUT, f"{what} exceeded {timeout}s"
-            ) from None
+        # _call_with_timeout()/_executor now live in TimeoutEnforced
+        # (adapters/meshtastic/_timeout_support.py, extracted in Task 45
+        # so BLETransport doesn't duplicate the same watchdog pattern).
+        # Real hardware serialization is still this class's own job (see
+        # _claim_radio's radio_lock) - the shared mixin only gives each
+        # call its own thread to abandon on timeout, never serializes.
+        TimeoutEnforced.__init__(self, thread_name_prefix="serial-transport-watchdog")
 
     # ------------------------------------------------------------------
     # Internal radio-claim helpers - own copies of server.py's former
@@ -312,7 +290,7 @@ class SerialTransport(RadioTransport):
 
     def close(self) -> None:
         self.disconnect(timeout=15.0)
-        self._executor.shutdown(wait=False)
+        self._shutdown_executor()
 
     # ------------------------------------------------------------------
     # RadioTransport - listener (Stage A: this class owns the subprocess

--- a/tests/test_ble_transport.py
+++ b/tests/test_ble_transport.py
@@ -1,0 +1,261 @@
+"""Tests for adapters/meshtastic/ble_transport.py's connection lifecycle -
+happy path, identity mismatch teardown, and NOT_CONNECTED guard on the
+persistent-interface ownership model. Uses a fake BLEInterface (mocked at
+the meshtastic.ble_interface module boundary) rather than real hardware -
+the live smoke test on TAP2 covers the real BLEInterface/bluetoothctl
+integration this can't.
+"""
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+from adapters.meshtastic.ble_transport import BLETransport
+from meshsrv.radio_transport import (
+    ConnectionDescriptor,
+    ConnectionState,
+    ConnectionType,
+    OutgoingMessage,
+    TransportError,
+    TransportErrorCode,
+)
+
+
+class _FakeMyInfo:
+    def __init__(self, my_node_num):
+        self.my_node_num = my_node_num
+
+
+class _FakePacket:
+    id = 12345
+
+
+class _FakeBLEInterface:
+    """Stands in for meshtastic.ble_interface.BLEInterface. Records
+    close() calls so identity-mismatch teardown can be asserted."""
+
+    instances = []
+
+    def __init__(self, address, timeout=300):
+        self.address = address
+        self.timeout = timeout
+        self.myInfo = _FakeMyInfo(my_node_num=0x756F9960)
+        self.nodes = {}
+        self.localNode = types.SimpleNamespace(nodeNum=0x756F9960, channels=[])
+        self.metadata = None
+        self.closed = False
+        _FakeBLEInterface.instances.append(self)
+
+    def sendText(self, **kwargs):
+        return _FakePacket()
+
+    def sendData(self, *args, **kwargs):
+        return _FakePacket()
+
+    def sendWaypoint(self, **kwargs):
+        return _FakePacket()
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _fake_ble_interface_module(monkeypatch):
+    _FakeBLEInterface.instances = []
+    fake_module = types.ModuleType("meshtastic.ble_interface")
+    fake_module.BLEInterface = _FakeBLEInterface
+    monkeypatch.setitem(sys.modules, "meshtastic.ble_interface", fake_module)
+    yield
+    monkeypatch.delitem(sys.modules, "meshtastic.ble_interface", raising=False)
+
+
+def _descriptor(address="3C:DC:75:6F:99:61"):
+    return ConnectionDescriptor(type=ConnectionType.BLUETOOTH, address=address)
+
+
+def test_connect_happy_path_opens_one_persistent_interface():
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+
+    info = transport.connect(_descriptor(), timeout=5)
+
+    assert info.state == ConnectionState.CONNECTED
+    assert info.node_id == "!756f9960"
+    assert transport.is_connected()
+    assert len(_FakeBLEInterface.instances) == 1
+
+
+def test_send_text_reuses_the_same_interface_not_a_new_one():
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+    transport.connect(_descriptor(), timeout=5)
+
+    transport.send_text(OutgoingMessage(text="hi", destination_id="^all"), timeout=5)
+    transport.send_text(OutgoingMessage(text="hi again", destination_id="^all"), timeout=5)
+
+    # Ownership model: one interface opened in connect(), reused by every
+    # subsequent call - never reopened per send.
+    assert len(_FakeBLEInterface.instances) == 1
+
+
+def test_send_text_before_connect_returns_not_connected_without_opening_interface():
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+
+    result = transport.send_text(OutgoingMessage(text="hi", destination_id="^all"), timeout=5)
+
+    assert result.accepted is False
+    assert result.error.code == TransportErrorCode.NOT_CONNECTED
+    assert len(_FakeBLEInterface.instances) == 0
+
+
+def test_get_nodes_before_connect_raises_not_connected():
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+
+    with pytest.raises(TransportError) as excinfo:
+        transport.get_nodes(timeout=5)
+    assert excinfo.value.code == TransportErrorCode.NOT_CONNECTED
+
+
+def test_identity_mismatch_closes_the_interface_before_raising():
+    transport = BLETransport(address="3C:DC:75:6F:99:61", expected_node_id="!deadbeef")
+
+    with pytest.raises(TransportError) as excinfo:
+        transport.connect(_descriptor(), timeout=5)
+
+    assert excinfo.value.code == TransportErrorCode.IDENTITY_MISMATCH
+    # Teardown: the just-opened interface must be closed, not left dangling.
+    assert len(_FakeBLEInterface.instances) == 1
+    assert _FakeBLEInterface.instances[0].closed is True
+    assert transport.get_connection_info().state == ConnectionState.ERROR
+    assert transport.is_connected() is False
+
+
+def test_disconnect_closes_interface_and_resets_state():
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+    transport.connect(_descriptor(), timeout=5)
+    interface = _FakeBLEInterface.instances[0]
+
+    transport.disconnect(timeout=5)
+
+    assert interface.closed is True
+    assert transport.is_connected() is False
+    assert transport.get_connection_info().state == ConnectionState.DISCONNECTED
+
+
+def test_disconnect_state_is_correct_even_when_close_never_returns():
+    """Regression test for the ownership-transfer bug (review, live-caught
+    on TAP2 - a real BLEInterface.close() took 60s+ once): before the
+    fix, self._state stayed CONNECTED and self._interface stayed set
+    until AFTER close() returned - so a disconnect() that timed out left
+    the transport reporting itself connected to an interface a now-
+    abandoned thread was still tearing down in the background. The fix
+    detaches synchronously before the (possibly slow/never-returning)
+    close() call even starts, so `timeout` only affects how long the
+    caller waits for close() to finish - never whether is_connected()/
+    get_connection_info() are correct immediately after disconnect()
+    returns, timeout or not.
+    """
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+    transport.connect(_descriptor(), timeout=5)
+    interface = _FakeBLEInterface.instances[0]
+
+    release_event = threading.Event()
+    interface.close = lambda: release_event.wait(timeout=5)  # never returns in time
+
+    transport.disconnect(timeout=0.2)  # must NOT raise - close() failures are logged, not propagated
+
+    # State must already be correct, immediately, even though the
+    # background close() call is still stuck.
+    assert transport.is_connected() is False
+    assert transport.get_connection_info().state == ConnectionState.DISCONNECTED
+
+    with pytest.raises(TransportError):
+        transport.get_nodes(timeout=1)  # NOT_CONNECTED, not a race on the old interface
+
+    release_event.set()  # let the stuck background thread finish
+
+
+def test_concurrent_send_and_disconnect_do_not_race_the_interface():
+    """Regression test for the review finding: without self._lock, a
+    concurrent disconnect() (e.g. user hits "Switch to Serial" in the UI,
+    Task 46/47) could null out self._interface while a send_* call
+    already in flight is still using it. Uses an exclusive-entry counter
+    (same technique as SerialTransport's
+    test_concurrent_connect_and_send_do_not_race_prepare_phase) - it
+    would go above 1 if send_text()'s and disconnect()'s use of
+    self._interface ever overlapped in wall-clock time.
+    """
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+    transport.connect(_descriptor(), timeout=5)
+    interface = _FakeBLEInterface.instances[0]
+
+    violations = []
+    in_critical_section = {"count": 0}
+    counter_lock = threading.Lock()
+
+    def _enter():
+        with counter_lock:
+            in_critical_section["count"] += 1
+            if in_critical_section["count"] > 1:
+                violations.append(in_critical_section["count"])
+
+    def _exit():
+        with counter_lock:
+            in_critical_section["count"] -= 1
+
+    def _tracked_send_text(**kwargs):
+        _enter()
+        time.sleep(0.15)
+        _exit()
+        return _FakePacket()
+
+    def _tracked_close():
+        _enter()
+        time.sleep(0.1)
+        interface.closed = True
+        _exit()
+
+    interface.sendText = _tracked_send_text
+    interface.close = _tracked_close
+
+    send_thread = threading.Thread(
+        target=lambda: transport.send_text(OutgoingMessage(text="hi", destination_id="^all"), timeout=5)
+    )
+    disconnect_thread = threading.Thread(target=lambda: transport.disconnect(timeout=5))
+
+    send_thread.start()
+    time.sleep(0.02)
+    disconnect_thread.start()
+    send_thread.join(timeout=5)
+    disconnect_thread.join(timeout=5)
+
+    assert not send_thread.is_alive() and not disconnect_thread.is_alive()
+    assert violations == [], (
+        "send_text() and disconnect() overlapped their use of self._interface - "
+        "self._lock is not actually serializing them"
+    )
+
+
+def test_reconnect_exhausts_fixed_attempts_then_raises(monkeypatch):
+    """Naive reconnect (plan 5.5): fixed attempts with growing backoff,
+    not infinite/exponential. Patch the delays away so the test doesn't
+    actually sleep ~7s."""
+    import adapters.meshtastic.ble_transport as ble_transport_module
+
+    monkeypatch.setattr(ble_transport_module, "_RECONNECT_DELAYS_S", (0.0, 0.0))
+
+    class _AlwaysFailBLEInterface(_FakeBLEInterface):
+        def __init__(self, address, timeout=300):
+            raise TransportError(TransportErrorCode.CONNECT_FAILED, "simulated failure")
+
+    fake_module = types.ModuleType("meshtastic.ble_interface")
+    fake_module.BLEInterface = _AlwaysFailBLEInterface
+    monkeypatch.setitem(sys.modules, "meshtastic.ble_interface", fake_module)
+
+    transport = BLETransport(address="3C:DC:75:6F:99:61")
+
+    with pytest.raises(TransportError) as excinfo:
+        transport.reconnect(timeout=5)
+
+    assert excinfo.value.code == TransportErrorCode.CONNECT_FAILED
+    assert transport.get_connection_info().state == ConnectionState.ERROR

--- a/tests/test_serial_transport_timeout.py
+++ b/tests/test_serial_transport_timeout.py
@@ -103,6 +103,56 @@ def test_concurrent_calls_do_not_spuriously_timeout_each_other():
     assert results.get("first") == "long-done"
 
 
+def test_call_with_timeout_thread_is_a_daemon_and_does_not_block_process_exit():
+    """Regression test for the HOTFIX in _timeout_support.py: a call that
+    never returns (the tier-2 gap - live-observed as BLEInterface.close()
+    hanging past its own timeout during Task 45's TAP2 smoke test) must
+    not require kill -9 to let the process exit. The old
+    ThreadPoolExecutor-based implementation failed this - its worker
+    threads are not daemon threads, and concurrent.futures.thread's
+    atexit hook waits for them regardless of shutdown() state. Verified
+    two ways: (1) the caller gets TransportError(TIMEOUT) back on time
+    even though the underlying call never finishes, (2) the thread
+    actually running that stuck call is introspected and confirmed
+    daemon=True - not a full process fork, but the property that matters.
+    """
+    transport = _make_transport()
+    thread_seen = {}
+    release_event = threading.Event()
+
+    def never_returns():
+        thread_seen["thread"] = threading.current_thread()
+        release_event.wait(timeout=5)  # keeps the thread alive briefly so
+        # the assertion below can inspect it; does not affect the
+        # timeout assertion, which already completed by then.
+        return "should never be observed by the caller"
+
+    start = time.monotonic()
+    with pytest.raises(TransportError) as excinfo:
+        transport._call_with_timeout(never_returns, timeout=0.2, what="never_returns()")
+    elapsed = time.monotonic() - start
+
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+    assert elapsed < 1.0, "the caller waited far longer than the requested timeout"
+
+    # Give the abandoned thread a moment to actually start running (the
+    # timeout above fires before it necessarily has).
+    for _ in range(50):
+        if "thread" in thread_seen:
+            break
+        time.sleep(0.02)
+    assert "thread" in thread_seen, "the abandoned call never actually started"
+    assert thread_seen["thread"].daemon is True, (
+        "the thread running a hung call is not a daemon thread - it will "
+        "block clean process exit exactly like the live TAP2 kill -9 case"
+    )
+
+    release_event.set()  # let the background thread finish so it's not
+    # left dangling for the rest of the test session (best-effort - even
+    # if it stayed stuck, being a daemon thread means it wouldn't hang
+    # the test process's own exit).
+
+
 def test_concurrent_connect_and_send_do_not_race_prepare_phase():
     """Regression test for the second review finding: with the executor
     no longer max_workers=1, connect(force=True)'s stop+wait teardown and


### PR DESCRIPTION
## Summary
- Adds `BLETransport` (`adapters/meshtastic/ble_transport.py`), implementing `RadioTransport` over `meshtastic.ble_interface.BLEInterface` - happy path per plan section 5 (connect/state machine/send/reconnect, no pairing UI).
- Extracts `_timeout_support.py`'s `TimeoutEnforced` mixin out of `SerialTransport` so both transports share the tier-1 timeout watchdog instead of duplicating it.
- Two bugs caught live on TAP2, fixed in this PR:
  - `_timeout_support.py` (shared with the already-deployed `SerialTransport`) used `ThreadPoolExecutor`, whose worker threads are not daemon - a genuinely hung call blocked clean process exit. Replaced with a plain daemon `Thread` + `Queue` per call.
  - `disconnect()`/`connect(force=True)` updated transport state *after* closing the interface; on a timeout the state update never ran, leaving `is_connected()` reporting stale `CONNECTED`. Fixed by detaching state synchronously before the slow `close()` call starts.
- Default timeouts for `connect()`/`reconnect()`/`disconnect()`/`close()` raised from the ABC's 30s/15s to 90s/30s - live-measured `connect()` at 71.5-71.8s twice, so the old defaults failed on fully working hardware nearly every call.

## Test plan
- [x] Full `pytest` - 261 passed, 24 skipped (platform-gated)
- [x] Live-verified on TAP2: happy path (connect → send_text/get_nodes/get_channels/get_metadata/scan → disconnect), node ID cross-check (`myInfo.my_node_num` vs `localNode.nodeNum` both resolve to the real node), identity-mismatch teardown, daemon-thread fix (clean process exit despite a genuinely hung `close()`), ownership-transfer fix (correct state immediately after a timed-out `disconnect()`)
- [x] `SerialTransport` refactor (mixin extraction) verified with its own unmodified test suite + a live smoke on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)