### PR TITLE
fix: wrap non-TransportError exceptions in _call_with_timeout, roll back BLE address on failed connect

### DIFF
--- a/adapters/meshtastic/_timeout_support.py
+++ b/adapters/meshtastic/_timeout_support.py
@@ -76,7 +76,27 @@ class TimeoutEnforced:
             ) from None
 
         if status == "error":
-            raise payload
+            # HOTFIX (live Task 47 finding on TAP2): this used to `raise
+            # payload` unconditionally, re-raising whatever `fn` happened
+            # to throw - fine for TransportError (raised deliberately by
+            # a transport's own code), but any OTHER exception type
+            # (e.g. BLEInterface() raising bleak's own "device not
+            # found" error) came back to the caller in its raw,
+            # un-typed form. Every caller up the stack - connect()'s own
+            # `except TransportError`, api/api_meshtastic.py's fail-
+            # closed switch() recovery - only ever catches TransportError,
+            # so an unwrapped exception skipped all of that and reached
+            # Flask's generic error handler instead, silently bypassing
+            # the entire recovery path this was built for. Live-caught:
+            # a forced switch to a nonexistent BLE address left both
+            # transports down with no recovery attempt, because the
+            # "device not found" exception was never a TransportError to
+            # begin with. Wrap anything that isn't already one.
+            if isinstance(payload, TransportError):
+                raise payload
+            raise TransportError(
+                TransportErrorCode.UNKNOWN, f"{what} failed: {payload}"
+            ) from payload
         return payload
 
     def _shutdown_executor(self) -> None:

--- a/adapters/meshtastic/ble_transport.py
+++ b/adapters/meshtastic/ble_transport.py
@@ -183,19 +183,58 @@ class BLETransport(TimeoutEnforced, RadioTransport):
             raise TransportError(
                 TransportErrorCode.UNSUPPORTED, f"BLETransport cannot connect to {descriptor.type}"
             )
+
+        # ROLLBACK (live Task 47 finding on TAP2): self._address/_name are
+        # about to be overwritten unconditionally below, before the new
+        # address has even been tried - a failed connect() used to leave
+        # them pointing at the bad value permanently, so a later bare
+        # reconnect() (which by contract reuses self._address, not a
+        # fresh descriptor) would retry the same bad address forever
+        # instead of the last-known-good one. Snapshot before any
+        # mutation - not just under force=True, since the mutation two
+        # lines down is unconditional for every connect() call, forced
+        # or not - and restore on every failure path below.
+        previous_address, previous_name = self._address, self._name
+
         self._address = descriptor.address or self._address
         self._name = descriptor.label or self._name
         with self._lock:
             self._state = ConnectionState.CONNECTING
 
         if force:
+            # Deliberately not fixed: tearing down a known-good session
+            # before confirming the new address is reachable is a real
+            # window (the old link is gone before the new one is proven),
+            # but there is no cheap way to validate a BLE address's
+            # connectability without actually attempting the connection -
+            # scan() doesn't guarantee connectability and adds ~10s to
+            # every call. Same trade-off already accepted elsewhere this
+            # project (predictable failure over a hidden race) - the
+            # caller is responsible for its own recovery (see
+            # api/api_meshtastic.py's fail-closed switch() recovery),
+            # this method does not attempt to silently restore the old
+            # connection itself.
             self._detach_and_close_async(timeout=timeout)
             self._force_disconnect_os_level()
 
         def _do_connect():
             from meshtastic.ble_interface import BLEInterface
 
-            return BLEInterface(address=self._address, timeout=int(timeout))
+            try:
+                return BLEInterface(address=self._address, timeout=int(timeout))
+            except Exception as exc:
+                # Point recognition for the single most common real
+                # failure (per review): map it to the ABC's already-
+                # defined-but-previously-never-raised DEVICE_NOT_FOUND
+                # instead of letting it fall through to the generic
+                # UNKNOWN wrap in _call_with_timeout. Anything else
+                # (adapter off, permission error, etc.) still falls
+                # through to UNKNOWN there.
+                message = str(exc)
+                lowered = message.lower()
+                if "no meshtastic ble peripheral" in lowered or "not found" in lowered or "no such device" in lowered:
+                    raise TransportError(TransportErrorCode.DEVICE_NOT_FOUND, message) from exc
+                raise
 
         try:
             interface = self._call_with_timeout(_do_connect, timeout=timeout, what="connect()")
@@ -203,6 +242,7 @@ class BLETransport(TimeoutEnforced, RadioTransport):
             with self._lock:
                 self._state = ConnectionState.ERROR
                 self._last_error = error
+                self._address, self._name = previous_address, previous_name
             raise
 
         node_id = self._local_node_id(interface)
@@ -224,6 +264,7 @@ class BLETransport(TimeoutEnforced, RadioTransport):
             with self._lock:
                 self._state = ConnectionState.ERROR
                 self._last_error = error
+                self._address, self._name = previous_address, previous_name
             raise error
 
         with self._lock:

--- a/tests/test_ble_transport.py
+++ b/tests/test_ble_transport.py
@@ -130,6 +130,57 @@ def test_identity_mismatch_closes_the_interface_before_raising():
     assert transport.is_connected() is False
 
 
+def test_reconnect_after_failed_connect_targets_last_known_good_address_not_the_failed_one(monkeypatch):
+    """Regression test for the Task 47 live finding on TAP2: connect()
+    used to overwrite self._address/_name unconditionally before
+    attempting the new connection, with no rollback on failure - so a
+    subsequent bare reconnect() (which reuses self._address/_name by
+    contract, see reconnect()'s own docstring - it builds its
+    ConnectionDescriptor from them, not a fresh caller-supplied address)
+    would retry the address that just failed instead of the last one
+    that actually worked. Also covers DEVICE_NOT_FOUND point-recognition
+    for the real error text observed live: "No Meshtastic BLE peripheral
+    with identifier or address '...' found. Try --ble-scan to find it."
+    """
+    good_address = "3C:DC:75:6F:99:61"
+    bad_address = "00:11:22:33:44:55"
+
+    class _FlakyBLEInterface(_FakeBLEInterface):
+        def __init__(self, address, timeout=300):
+            if address == bad_address:
+                raise Exception(
+                    f"No Meshtastic BLE peripheral with identifier or address '{address}' "
+                    "found. Try --ble-scan to find it."
+                )
+            super().__init__(address, timeout=timeout)
+
+    monkeypatch.setattr(sys.modules["meshtastic.ble_interface"], "BLEInterface", _FlakyBLEInterface)
+
+    transport = BLETransport(address=good_address)
+    transport.connect(_descriptor(good_address), timeout=5)
+    assert transport.get_connection_info().state == ConnectionState.CONNECTED
+
+    # Force-switch to a bad address - simulates POST /bluetooth/connect
+    # to a mistyped/out-of-range device while already connected to a
+    # working one (exactly what happened live on TAP2).
+    with pytest.raises(TransportError) as excinfo:
+        transport.connect(_descriptor(bad_address), force=True, timeout=5)
+    assert excinfo.value.code == TransportErrorCode.DEVICE_NOT_FOUND
+
+    # self._address must have rolled back to the last-known-good value,
+    # not stayed on the address that just failed.
+    info_after_failure = transport.get_connection_info()
+    assert info_after_failure.descriptor.address == good_address
+    assert info_after_failure.state == ConnectionState.ERROR
+
+    # reconnect() takes no address argument - by contract it rebuilds its
+    # descriptor from self._address/_name. This must now succeed against
+    # the good address, not retry the one that just failed.
+    info = transport.reconnect(timeout=5)
+    assert info.state == ConnectionState.CONNECTED
+    assert _FakeBLEInterface.instances[-1].address == good_address
+
+
 def test_disconnect_closes_interface_and_resets_state():
     transport = BLETransport(address="3C:DC:75:6F:99:61")
     transport.connect(_descriptor(), timeout=5)

--- a/tests/test_timeout_support.py
+++ b/tests/test_timeout_support.py
@@ -1,0 +1,76 @@
+"""Tests for adapters/meshtastic/_timeout_support.py's TimeoutEnforced
+mixin directly (not through SerialTransport/BLETransport) - the shared
+watchdog used by both concrete transports.
+
+Regression coverage for the Task 47 live finding on TAP2: a forced BLE
+switch to a nonexistent address raised the underlying library's own
+exception type (not TransportError) from inside the watchdog thread,
+which _call_with_timeout used to re-raise unmodified. Every caller up
+the stack - connect()'s own `except TransportError`, api_meshtastic.py's
+fail-closed switch() recovery - only ever catches TransportError, so the
+unwrapped exception silently bypassed the entire recovery path and
+landed in Flask's generic error handler instead, leaving both
+transports down with nothing having attempted recovery.
+"""
+import pytest
+
+from adapters.meshtastic._timeout_support import TimeoutEnforced
+from meshsrv.radio_transport import TransportError, TransportErrorCode
+
+
+class _Watchdog(TimeoutEnforced):
+    def __init__(self):
+        super().__init__(thread_name_prefix="test-watchdog")
+
+
+def test_arbitrary_exception_is_wrapped_as_transport_error_unknown():
+    watchdog = _Watchdog()
+
+    def _raises_something_unrelated():
+        raise ValueError("device not found: not a TransportError at all")
+
+    with pytest.raises(TransportError) as excinfo:
+        watchdog._call_with_timeout(_raises_something_unrelated, timeout=5, what="test op")
+
+    assert excinfo.value.code == TransportErrorCode.UNKNOWN
+    assert "test op failed" in str(excinfo.value)
+    assert "device not found" in str(excinfo.value)
+
+
+def test_transport_error_raised_by_fn_passes_through_unwrapped():
+    watchdog = _Watchdog()
+    original = TransportError(TransportErrorCode.DEVICE_NOT_FOUND, "no such device")
+
+    def _raises_transport_error():
+        raise original
+
+    with pytest.raises(TransportError) as excinfo:
+        watchdog._call_with_timeout(_raises_transport_error, timeout=5, what="test op")
+
+    # Must be the exact same TransportError, not double-wrapped into
+    # another TransportError(UNKNOWN, "...TransportError(...)...").
+    assert excinfo.value is original
+    assert excinfo.value.code == TransportErrorCode.DEVICE_NOT_FOUND
+
+
+def test_real_timeout_still_raises_timeout_not_unknown():
+    import time
+
+    watchdog = _Watchdog()
+
+    def _slow():
+        time.sleep(0.5)
+        return "done"
+
+    with pytest.raises(TransportError) as excinfo:
+        watchdog._call_with_timeout(_slow, timeout=0.1, what="slow op")
+
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+
+
+def test_successful_call_returns_its_value_unmodified():
+    watchdog = _Watchdog()
+
+    result = watchdog._call_with_timeout(lambda: {"ok": True}, timeout=5, what="fast op")
+
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
Live-caught on TAP2 during Task 47 item 6 (forced switch failure to a nonexistent BLE address): `_call_with_timeout()` re-raised whatever the wrapped call threw unmodified. A non-`TransportError` exception (e.g. `BLEInterface()` raising bleak's own "device not found" error) skipped every caller up the stack that only catches `TransportError` - `connect()`'s own except clause, `api/api_meshtastic.py`'s fail-closed `switch()` recovery - and reached Flask's generic error handler instead, leaving both transports down with no recovery attempted.

- `adapters/meshtastic/_timeout_support.py`: wrap any non-`TransportError` exception from the worker thread as `TransportError(UNKNOWN)` instead of re-raising it raw; already-typed `TransportError` instances pass through unchanged.
- `adapters/meshtastic/ble_transport.py`: `BLETransport.connect()` also mutated `self._address`/`_name` unconditionally before attempting the new connection, with no rollback on failure - a later bare `reconnect()` (which reuses `self._address`/`_name` by contract) would retry the address that just failed rather than the last-known-good one. Snapshot before mutation, restore on every failure path. `DEVICE_NOT_FOUND` (defined in the ABC, never previously raised) now gets point-recognized for the real "no ... peripheral ... found" error text instead of falling through to generic `UNKNOWN`.

## Test plan
- [x] `tests/test_timeout_support.py` (new) - exercises `TimeoutEnforced._call_with_timeout()` directly, not through either transport
- [x] `tests/test_ble_transport.py` - new regression test proving `reconnect()` after a failed `connect()` targets the last-known-good address, not the failed one
- [x] Full `pytest`: 270 passed, 24 skipped (no regressions)
- [ ] Live re-run of Task 47 item 6 on TAP2 after merge/deploy (forced failure to a nonexistent BLE address) - confirming fail-closed recovery now actually fires
- [ ] Live serial-side smoke test: `SerialTransport.connect()` against a nonexistent port, confirming a structured `TransportError` comes back instead of a raw exception

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>