### PR TITLE
feat: warn in Settings that Bluetooth cannot receive messages

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -2496,6 +2496,16 @@ function _meshtasticUpdateTransportButtons(activeType) {
 
     const scanSection = document.getElementById('meshtasticBleScanSection');
     if (scanSection) scanSection.style.display = type === 'bluetooth' ? '' : 'none';
+
+    // Permanent, not a one-time confirm dialog (would be annoying on
+    // every switch) - visible for as long as Bluetooth is the selected
+    // transport, connected or not, since the receive gap exists
+    // whenever it's active, not just during a successful connection.
+    // Stage B (meshsrv.transport_router has no receive-path wiring for
+    // BLE at all yet - see MESHCENTER_FULL_PLAN_FOR_CODE.md) is what
+    // closes this, not a UI fix - see Task 47 live finding.
+    const receiveWarning = document.getElementById('meshtasticBleReceiveWarning');
+    if (receiveWarning) receiveWarning.style.display = type === 'bluetooth' ? '' : 'none';
 }
 
 function _meshtasticRenderConnectionStatus(connection) {

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -665,6 +665,7 @@
     "meshtastic_ble_connecting": "Verbinde…",
     "meshtastic_ble_connect_success": "Bluetooth-Gerät verbunden",
     "meshtastic_ble_connect_failed": "Verbindung nicht möglich",
+    "meshtastic_ble_receive_warning": "Eingehende Nachrichten werden bei aktivem Bluetooth nicht empfangen - du kannst senden, aber nicht empfangen. Wechsle zurück zu USB, um wieder Nachrichten zu empfangen.",
     "epaper_title": "E-Paper-Display",
     "epaper_description": "Einstellungen für Display und Informationsanzeige.",
     "epaper_enabled": "Aktiviert",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -665,6 +665,7 @@
     "meshtastic_ble_connecting": "Connecting…",
     "meshtastic_ble_connect_success": "Bluetooth device connected",
     "meshtastic_ble_connect_failed": "Unable to connect",
+    "meshtastic_ble_receive_warning": "Incoming messages are not received while Bluetooth is active - you can send, but not receive. Switch back to USB to receive messages again.",
     "epaper_title": "E-Paper Display",
     "epaper_description": "Display and information-display settings.",
     "epaper_enabled": "Enabled",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -665,6 +665,7 @@
     "meshtastic_ble_connecting": "Подключение…",
     "meshtastic_ble_connect_success": "Устройство Bluetooth подключено",
     "meshtastic_ble_connect_failed": "Не удалось подключиться",
+    "meshtastic_ble_receive_warning": "Входящие сообщения не принимаются, пока активен Bluetooth - вы можете отправлять, но не получать. Переключитесь обратно на USB, чтобы снова получать сообщения.",
     "epaper_title": "Дисплей E-Paper",
     "epaper_description": "Настройки дисплея и отображения информации.",
     "epaper_enabled": "Включено",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -665,6 +665,7 @@
     "meshtastic_ble_connecting": "Підключення…",
     "meshtastic_ble_connect_success": "Пристрій Bluetooth підключено",
     "meshtastic_ble_connect_failed": "Не вдалося підключитися",
+    "meshtastic_ble_receive_warning": "Вхідні повідомлення не приймаються, поки активний Bluetooth - ви можете надсилати, але не отримувати. Перемкніться назад на USB, щоб знову отримувати повідомлення.",
     "epaper_title": "Дисплей E-Paper",
     "epaper_description": "Налаштування дисплея та відображення інформації.",
     "epaper_enabled": "Увімкнено",

--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -3009,6 +3009,15 @@ body {
     background: rgba(31, 111, 229, 0.12);
 }
 
+.settings-card-note--warning {
+    color: #946316;
+    font-weight: 600;
+}
+
+html[data-theme="dark"] .settings-card-note--warning {
+    color: #f0c86a;
+}
+
 .telemetry-export-menu {
     position: absolute;
     right: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-meshtastic-transport">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260821-style-split">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260823-weather-icon-shift">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260822-weather-key-button">
@@ -1448,6 +1448,10 @@
 
                             <div class="reference-location-status" id="meshtasticConnectionStatus"></div>
 
+                            <div id="meshtasticBleReceiveWarning" class="settings-card-note settings-card-note--warning" style="display:none;">
+                                ⚠️ <span data-i18n="settings.meshtastic_ble_receive_warning">Incoming messages are not received while Bluetooth is active - you can send, but not receive. Switch back to USB to receive messages again.</span>
+                            </div>
+
                             <div id="meshtasticBleScanSection" style="display:none;">
                                 <button type="button"
                                         id="meshtasticBleScanButton"
@@ -2208,7 +2212,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260824-meshtastic-transport"></script>
+<script src="/static/chat.js?v=20260824-ble-receive-warning"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
Live-confirmed in Task 47 on TAP2: `BLETransport` has no receive-callback wiring at all, and `telemetry_worker()`/messages/nodeinfo all flow into Core exclusively through the serial `--listen` text stream, which is fully stopped (not paused) whenever Bluetooth is active. A message sent to a node while it's on BLE is lost permanently - verified twice live (TAP2 <-> Flint Base), never appearing during the BLE session or after switching back to USB. The existing "Bluetooth - Experimental" badge doesn't communicate this.

Adds a persistent warning line (not a one-time confirm dialog) next to the Bluetooth status in Settings, visible for as long as Bluetooth is the selected transport. i18n across all four catalogs.

## Test plan
- [x] `node --check static/chat.js`
- [x] JSON validity + exact key-parity check across all four i18n catalogs
- [x] Full `pytest`: 273 passed, 24 skipped (no regressions)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>