### PR TITLE
fix: correct misleading claim in degraded-startup warning text

### DIFF
--- a/server.py
+++ b/server.py
@@ -211,9 +211,15 @@ except RuntimeError as error:
     print(
         "Starting anyway in a degraded state - camera, e-paper, and the "
         "web interface will work normally; the radio connection will "
-        "report an error until a Meshtastic device is connected and the "
-        "service is restarted, or a transport is explicitly reconnected "
-        "via Settings.",
+        "report an error. If the serial cable was disconnected and "
+        "reconnected, restarting the MeshCenter service is required - "
+        "switching transports in Settings does not reopen the port (that "
+        "only works between transports that are already physically "
+        "reachable, e.g. Serial<->BLE when both are actually connected; "
+        "live-verified in Task 47 that it does NOT recover a serial port "
+        "that only just came back after being physically absent at "
+        "boot - hot-reconnect without a restart is a separate, not yet "
+        "implemented, future task, see the plan doc).",
         flush=True,
     )
     print("=" * 60, flush=True)


### PR DESCRIPTION
## Summary
Live-caught right after PR #113 itself shipped: the warning text claimed a missing serial port could be recovered "or a transport is explicitly reconnected via Settings" - tested that claim live on TAP2 and it's false. `POST /api/meshtastic/transport {"type":"serial"}` does not reopen the port or re-run identity detection (that only happens once inside `start_runtime()`); confirmed a full service restart is the only recovery path once the cable is physically reconnected.

Text corrected to state the actual limitation. Full hot-reconnect is a separate, not yet implemented future task - deliberately not folded into this fix.

## Test plan
- [x] Full `pytest`: 274 passed, 24 skipped (no regressions, text-only change)
- [ ] Live deploy to all three nodes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>