### PR TITLE
fix: bound TransportRouter's lock-acquire wait by the caller's own timeout (Task 47.5)

### DIFF
--- a/meshsrv/transport_router.py
+++ b/meshsrv/transport_router.py
@@ -17,9 +17,16 @@ adapters/meshtastic/.
 from __future__ import annotations
 
 import threading
+import time
 from typing import Callable
 
-from meshsrv.radio_transport import RadioTransport
+from meshsrv.radio_transport import (
+    ConnectionInfo,
+    ConnectionState,
+    RadioTransport,
+    TransportError,
+    TransportErrorCode,
+)
 
 
 class TransportRouter(RadioTransport):
@@ -32,11 +39,54 @@ class TransportRouter(RadioTransport):
     call reaching the old transport mid-teardown while the new one is
     mid-connect would race for the same physical radio at the firmware
     level, not just in Python - locking only the pointer read/write would
-    not prevent that. A call landing during a switch blocks for as long
-    as the new transport's connect() takes (live-measured BLE: up to
-    ~90s) - a predictable wait, not a race that needs diagnosing later.
-    Same principle as SerialTransport._prepare_radio_command()'s fix in
-    Task 44."""
+    not prevent that.
+
+    BOUNDED WAIT (Task 47.5, review correction): the lock-acquire itself
+    used to be unconditional (`with self._lock:`), so a caller's own
+    `timeout` argument only ever bounded the operation *after* the lock
+    was acquired - it did not cover how long the call could sit waiting
+    for the lock at all. A send_text(timeout=30) landing during a 135s
+    switch() therefore actually waited up to 135+30=165s, not the 30s its
+    own signature promised - live-caught (thread-pool exhaustion on
+    dev/camtest, Task 47 item 3) because gunicorn's worker thread stays
+    consumed by that entire real wait; `curl --max-time` on the client
+    side does not cancel it.
+
+    Every method below now does `self._lock.acquire(timeout=...)` and
+    splits the caller's own already-existing `timeout` between the lock
+    wait and the delegated operation - the TOTAL wall-clock time (lock
+    wait + operation) is bounded by the same number the caller already
+    asked for, not a new, separately-invented threshold. If the lock
+    can't be acquired in time, raises TransportError(BUSY) - the caller
+    gets a bounded, honest "try again" instead of an unbounded hang, and
+    gunicorn releases the thread back to the pool.
+
+    get_connection_info()/is_connected() have no `timeout` parameter at
+    all per the ABC contract ("non-blocking... does not itself talk to
+    the radio") and must not raise (also per contract) - they get a
+    short, dedicated _INFO_LOCK_TIMEOUT_S and a synthetic fast response
+    on a busy lock instead: get_connection_info() reports state=CONNECTING
+    (a switch/connect genuinely is in progress) with the BUSY detail in
+    last_error; is_connected() reports False (fail-safe - never claim
+    connected when it can't be confirmed)."""
+
+    # How long GET /api/meshtastic/connection (loadMeshtasticConnectionStatus()
+    # polling) and is_connected() wait for the lock before giving up and
+    # returning a synthetic "busy" response - these have no timeout
+    # parameter of their own to split, so this is a dedicated constant.
+    # 3.0s: short enough that routine UI polling never piles up into the
+    # same thread-pool-exhaustion pattern that triggered this fix, long
+    # enough to not misreport "busy" for an ordinary few-hundred-ms
+    # delegated call under normal (non-switching) conditions.
+    _INFO_LOCK_TIMEOUT_S = 3.0
+
+    # switch() itself has no natural pre-existing `timeout` to split (it
+    # takes a zero-arg connect_new() callable whose own duration is
+    # entirely the caller's responsibility - see switch()'s docstring).
+    # A second switch() landing while one is already in progress should
+    # fail fast rather than queue for the first one's full ~90-135s only
+    # to then run its own full duration on top.
+    _SWITCH_LOCK_TIMEOUT_S = 5.0
 
     def __init__(self, initial: RadioTransport) -> None:
         self._lock = threading.Lock()
@@ -55,62 +105,117 @@ class TransportRouter(RadioTransport):
         this). This method only guarantees self._active's correctness,
         not that whatever it still points to is connected - the caller
         (server.py) is responsible for reconnecting the old transport on
-        a failed switch if it wants to leave the system usable."""
-        with self._lock:
+        a failed switch if it wants to leave the system usable.
+
+        Raises TransportError(BUSY) instead of blocking indefinitely if
+        another switch or long-running delegated call already holds the
+        lock - see class docstring's BOUNDED WAIT note."""
+        if not self._lock.acquire(timeout=self._SWITCH_LOCK_TIMEOUT_S):
+            raise TransportError(
+                TransportErrorCode.BUSY,
+                f"switch() could not acquire the router lock within {self._SWITCH_LOCK_TIMEOUT_S}s "
+                "- another switch or long-running call is already in progress",
+            )
+        try:
             old = self._active
             new = connect_new()
             self._active = new
-        return old
+            return old
+        finally:
+            self._lock.release()
 
-    def _delegate(self, name: str, *args, **kwargs):
-        with self._lock:
-            return getattr(self._active, name)(*args, **kwargs)
+    def _delegate(self, name: str, *args, timeout: float, **kwargs):
+        """Splits `timeout` (the caller's own already-existing budget for
+        this operation) between the lock-acquire wait and the delegated
+        call itself, so the TOTAL time this can hold a caller's thread is
+        bounded by `timeout`, not `timeout` twice over. See class
+        docstring's BOUNDED WAIT note - this is the Task 47.5 fix."""
+        start = time.monotonic()
+        if not self._lock.acquire(timeout=timeout):
+            raise TransportError(
+                TransportErrorCode.BUSY,
+                f"{name}() could not acquire the router lock within {timeout}s "
+                "- a switch or another long-running call is in progress",
+            )
+        try:
+            remaining = max(0.0, timeout - (time.monotonic() - start))
+            return getattr(self._active, name)(*args, timeout=remaining, **kwargs)
+        finally:
+            self._lock.release()
 
     # ------------------------------------------------------------------
     # RadioTransport - every method delegates to whichever concrete
-    # transport is currently active, under self._lock.
+    # transport is currently active, under self._lock. Each wrapper below
+    # supplies the same default `timeout` as the ABC method it mirrors
+    # (meshsrv/radio_transport.py), so an omitted timeout behaves exactly
+    # as it did before this fix - only now that number is a real total
+    # budget, not just the post-lock portion of one.
     # ------------------------------------------------------------------
-    def connect(self, *args, **kwargs):
-        return self._delegate("connect", *args, **kwargs)
+    def connect(self, *args, timeout: float = 30.0, **kwargs):
+        return self._delegate("connect", *args, timeout=timeout, **kwargs)
 
-    def disconnect(self, *args, **kwargs):
-        return self._delegate("disconnect", *args, **kwargs)
+    def disconnect(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("disconnect", *args, timeout=timeout, **kwargs)
 
-    def reconnect(self, *args, **kwargs):
-        return self._delegate("reconnect", *args, **kwargs)
+    def reconnect(self, *args, timeout: float = 30.0, **kwargs):
+        return self._delegate("reconnect", *args, timeout=timeout, **kwargs)
 
-    def is_connected(self):
-        return self._delegate("is_connected")
+    def send_text(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("send_text", *args, timeout=timeout, **kwargs)
 
-    def send_text(self, *args, **kwargs):
-        return self._delegate("send_text", *args, **kwargs)
+    def send_packet(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("send_packet", *args, timeout=timeout, **kwargs)
 
-    def send_packet(self, *args, **kwargs):
-        return self._delegate("send_packet", *args, **kwargs)
+    def send_messages(self, *args, timeout: float = 30.0, **kwargs):
+        return self._delegate("send_messages", *args, timeout=timeout, **kwargs)
 
-    def send_messages(self, *args, **kwargs):
-        return self._delegate("send_messages", *args, **kwargs)
+    def send_waypoint(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("send_waypoint", *args, timeout=timeout, **kwargs)
 
-    def send_waypoint(self, *args, **kwargs):
-        return self._delegate("send_waypoint", *args, **kwargs)
+    def get_nodes(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("get_nodes", *args, timeout=timeout, **kwargs)
 
-    def get_nodes(self, *args, **kwargs):
-        return self._delegate("get_nodes", *args, **kwargs)
+    def get_local_node(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("get_local_node", *args, timeout=timeout, **kwargs)
 
-    def get_local_node(self, *args, **kwargs):
-        return self._delegate("get_local_node", *args, **kwargs)
+    def get_channels(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("get_channels", *args, timeout=timeout, **kwargs)
 
-    def get_channels(self, *args, **kwargs):
-        return self._delegate("get_channels", *args, **kwargs)
+    def get_metadata(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("get_metadata", *args, timeout=timeout, **kwargs)
 
-    def get_metadata(self, *args, **kwargs):
-        return self._delegate("get_metadata", *args, **kwargs)
+    def set_device_time(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("set_device_time", *args, timeout=timeout, **kwargs)
 
-    def set_device_time(self, *args, **kwargs):
-        return self._delegate("set_device_time", *args, **kwargs)
+    def close(self, *args, timeout: float = 15.0, **kwargs):
+        return self._delegate("close", *args, timeout=timeout, **kwargs)
 
-    def get_connection_info(self):
-        return self._delegate("get_connection_info")
+    # ------------------------------------------------------------------
+    # Non-blocking per the ABC contract - must not raise, must not wait
+    # for the lock the same way the timeout-bearing methods above do.
+    # ------------------------------------------------------------------
+    def is_connected(self) -> bool:
+        if not self._lock.acquire(timeout=self._INFO_LOCK_TIMEOUT_S):
+            return False
+        try:
+            return self._active.is_connected()
+        finally:
+            self._lock.release()
 
-    def close(self):
-        return self._delegate("close")
+    def get_connection_info(self) -> ConnectionInfo:
+        if not self._lock.acquire(timeout=self._INFO_LOCK_TIMEOUT_S):
+            return ConnectionInfo(
+                state=ConnectionState.CONNECTING,
+                descriptor=None,
+                node_id=None,
+                connected_since=None,
+                last_error=TransportError(
+                    TransportErrorCode.BUSY,
+                    "status temporarily unavailable - a transport switch or "
+                    "another long-running call is in progress",
+                ),
+            )
+        try:
+            return self._active.get_connection_info()
+        finally:
+            self._lock.release()

--- a/tests/test_transport_router.py
+++ b/tests/test_transport_router.py
@@ -9,7 +9,12 @@ import time
 
 import pytest
 
-from meshsrv.radio_transport import ConnectionInfo, ConnectionState
+from meshsrv.radio_transport import (
+    ConnectionInfo,
+    ConnectionState,
+    TransportError,
+    TransportErrorCode,
+)
 from meshsrv.transport_router import TransportRouter
 
 
@@ -113,3 +118,75 @@ def test_concurrent_call_blocks_until_switch_completes_not_a_race():
 
     assert results["send"] == "sent-by-b", "call landed on the transport active after the switch, as required"
     assert elapsed >= 0.1
+
+
+def test_send_text_fails_fast_with_busy_within_its_own_timeout_not_the_lock_holders():
+    """Regression test for the Task 47.5 review finding: the lock-acquire
+    itself used to be unconditional, so a caller's own `timeout` only
+    ever bounded the operation *after* the lock was free - a send_text
+    landing during a long switch waited (switch duration + its own
+    timeout), not its own timeout alone. Proven here by holding the lock
+    far longer (10s) than the caller's declared budget (1s) and asserting
+    the caller still gets a bounded, fast TransportError(BUSY) - not by
+    literally reproducing a 135s switch, which would make this test slow
+    without testing anything the short version doesn't already prove."""
+    a = _FakeTransport("a")
+    router = TransportRouter(a)
+
+    lock_released = threading.Event()
+
+    def _hold_lock():
+        router._lock.acquire()
+        lock_released.wait(timeout=10)
+        router._lock.release()
+
+    holder = threading.Thread(target=_hold_lock, daemon=True)
+    holder.start()
+    time.sleep(0.1)  # let the holder actually acquire the lock first
+
+    start = time.monotonic()
+    with pytest.raises(TransportError) as excinfo:
+        router.send_text("hello", timeout=1.0)
+    elapsed = time.monotonic() - start
+
+    assert excinfo.value.code == TransportErrorCode.BUSY
+    assert elapsed < 2.0, f"took {elapsed:.2f}s - should fail within its own ~1s budget, not the holder's 10s"
+
+    lock_released.set()
+    holder.join(timeout=2)
+
+
+def test_get_connection_info_returns_synthetic_response_when_lock_busy_not_an_exception():
+    """get_connection_info() has no `timeout` parameter and must not
+    raise per the ABC contract - on a busy lock it must return a fast,
+    synthetic ConnectionInfo instead."""
+    a = _FakeTransport("a")
+    router = TransportRouter(a)
+
+    router._lock.acquire()
+    try:
+        start = time.monotonic()
+        info = router.get_connection_info()
+        elapsed = time.monotonic() - start
+
+        assert info.state == ConnectionState.CONNECTING
+        assert info.last_error.code == TransportErrorCode.BUSY
+        assert elapsed < router._INFO_LOCK_TIMEOUT_S + 1.0
+    finally:
+        router._lock.release()
+
+
+def test_is_connected_returns_false_when_lock_busy_not_an_exception():
+    a = _FakeTransport("a")
+    router = TransportRouter(a)
+
+    router._lock.acquire()
+    try:
+        start = time.monotonic()
+        result = router.is_connected()
+        elapsed = time.monotonic() - start
+
+        assert result is False
+        assert elapsed < router._INFO_LOCK_TIMEOUT_S + 1.0
+    finally:
+        router._lock.release()


### PR DESCRIPTION
## Summary
Live-caught on TAP2 (Task 47 item 3): `TransportRouter`'s lock-acquire was unconditional (`with self._lock:`), so a caller's own `timeout` argument only ever bounded the operation *after* the lock was acquired - not how long the call could sit waiting for the lock at all. A `send_text(timeout=30)` landing during a 135s `switch()` actually waited up to 135+30=165s, not the 30s its own signature promised. Confirmed empirically in the investigation round: 8 concurrent long-blocking calls against the router exhausted gunicorn's entire 8-thread pool, making even completely unrelated routes unresponsive.

Every method now does `self._lock.acquire(timeout=...)` and splits the caller's own already-existing `timeout` between the lock wait and the delegated operation - the total wall-clock time is bounded by the same number the caller already asked for, not a new invented threshold (a semaphore-with-arbitrary-cap design was considered and rejected in review in favor of this). Raises `TransportError(BUSY)` on a timed-out acquire.

`get_connection_info()`/`is_connected()` have no `timeout` parameter per the ABC contract and must not raise - they get a dedicated short constant (3.0s) and a synthetic fast response on a busy lock instead of blocking.

## Test plan
- [x] New unit tests: `send_text(timeout=1.0)` against a lock held for 10s fails fast with `BUSY` well under 2s; `get_connection_info()`/`is_connected()` against a busy lock return synthetic responses within ~3s, never raising
- [x] Full `pytest`: 277 passed, 24 skipped (no regressions)
- [ ] Live re-run of the controlled thread-pool-exhaustion experiment on dev after deploy - confirming unrelated routes stay responsive and `GET /api/meshtastic/connection` responds in ~3s during an active switch, not hanging with it

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>