### PR TITLE
🛡️ Sentinel: Fix Open Redirect vulnerability in login route

### DIFF
--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -9,7 +9,7 @@ POST /api/settings merge-and-replace in api_settings.py, and the hash is
 never included in a settings.json snapshot handed back to the browser.
 """
 
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from flask import jsonify, redirect, request, render_template, session
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -45,6 +45,23 @@ def is_protected(auth_state):
     # An enabled flag with no usable hash never blocks access - avoids a
     # misconfigured/corrupted auth.json permanently locking out the UI.
     return bool(auth_state.get("enabled")) and bool(str(auth_state.get("password_hash") or "").strip())
+
+
+def is_safe_redirect_url(target):
+    """Validate redirect target URL to prevent Open Redirect vulnerabilities.
+
+    Only relative paths starting with a single '/' are allowed. Protocol-relative
+    URLs starting with '//' or '/\' and external schemes/netlocs are rejected.
+    """
+    if not target or not isinstance(target, str):
+        return False
+    if not target.startswith("/") or target.startswith(("//", "/\\")):
+        return False
+    try:
+        parsed = urlparse(target)
+        return not parsed.netloc and not parsed.scheme
+    except Exception:
+        return False
 
 
 def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, resolve_ui_language=None):
@@ -91,7 +108,7 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
             return redirect("/")
 
         next_url = request.values.get("next") or "/"
-        if not next_url.startswith("/") or next_url.startswith("//"):
+        if not is_safe_redirect_url(next_url):
             next_url = "/"
 
         error = None

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -8,7 +8,7 @@ import json
 
 from werkzeug.security import generate_password_hash
 
-from api.api_auth import is_protected, load_auth_state
+from api.api_auth import is_protected, is_safe_redirect_url, load_auth_state
 
 
 def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
@@ -66,3 +66,20 @@ def test_is_protected_tolerates_missing_keys():
     assert is_protected({}) is False
     assert is_protected({"enabled": True}) is False
     assert is_protected({"password_hash": "somehash"}) is False
+
+
+def test_is_safe_redirect_url():
+    # Safe relative paths
+    assert is_safe_redirect_url("/") is True
+    assert is_safe_redirect_url("/login") is True
+    assert is_safe_redirect_url("/api/settings?a=1#b") is True
+
+    # Unsafe external or protocol-relative targets
+    assert is_safe_redirect_url("//evil.com") is False
+    assert is_safe_redirect_url("/\\\\evil.com") is False
+    assert is_safe_redirect_url("/\\evil.com") is False
+    assert is_safe_redirect_url("http://evil.com") is False
+    assert is_safe_redirect_url("https://evil.com") is False
+    assert is_safe_redirect_url("javascript:alert(1)") is False
+    assert is_safe_redirect_url("") is False
+    assert is_safe_redirect_url(None) is False


### PR DESCRIPTION
### 🚨 Severity
HIGH

### 💡 Vulnerability
An Open Redirect vulnerability existed in `api/api_auth.py`'s `/login` endpoint due to insufficient validation of the `next` URL parameter. Targets starting with `/\` (e.g. `/\evil.com`) passed `next_url.startswith("/")` while bypassing `next_url.startswith("//")`, allowing browsers to interpret the redirect header as a protocol-relative external domain.

### 🎯 Impact
An attacker could craft a malicious link to `/login?next=/\evil.com`. After an authenticated user logs in, the server would issue a redirect to the external site, enabling phishing attacks.

### 🔧 Fix
- Added `is_safe_redirect_url(target)` in `api/api_auth.py` using `urllib.parse.urlparse` to ensure targets are strictly local relative paths with no `netloc` or `scheme` and do not start with `//` or `/\\`.
- Updated `/login` route to fall back to `/` if `next_url` is unsafe.

### ✅ Verification
- Added `test_is_safe_redirect_url` in `tests/test_api_auth.py` testing both safe relative paths and malicious external/protocol-relative targets.
- Verified all 302 unit tests pass (`python3 -m pytest`).

---
*PR created automatically by Jules for task [15237319589409477018](https://jules.google.com/task/15237319589409477018) started by @FlintUA*