### PR TITLE
fix: wrap adapter subprocess spawn failure in TransportError

### DIFF
--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -272,7 +272,19 @@ class AdapterSupervisor:
         left waiting on the subprocess itself."""
         with self._proc_lock:
             if self._proc is None or self._proc.poll() is not None:
-                self._spawn_locked()
+                try:
+                    self._spawn_locked()
+                except Exception as error:
+                    # Most commonly: adapter_python doesn't exist yet (no
+                    # separate adapter venv provisioned) - must degrade to
+                    # the same clean, expected error every other failure
+                    # path in this method produces, not a raw
+                    # FileNotFoundError escaping to whichever caller
+                    # (including background threads like the node-time-sync
+                    # worker) didn't anticipate this specific failure mode.
+                    raise TransportError(
+                        TransportErrorCode.ADAPTER_UNAVAILABLE, f"failed to launch adapter subprocess: {error}"
+                    ) from error
             proc = self._proc
 
             try:

--- a/tests/test_adapter_ipc_client.py
+++ b/tests/test_adapter_ipc_client.py
@@ -158,6 +158,30 @@ def test_crashed_adapter_raises_adapter_unavailable_not_a_raw_exception():
     assert excinfo.value.code == TransportErrorCode.ADAPTER_UNAVAILABLE
 
 
+def test_spawn_failure_raises_adapter_unavailable_not_a_raw_exception():
+    """Real scenario for the current, pre-venv-split state of the live
+    nodes: adapter_python points at a well-known path
+    (resolve_adapter_venv_dir()) that doesn't exist yet until install.sh's
+    venv-split step runs. subprocess.Popen(nonexistent executable) raises
+    FileNotFoundError - this must degrade the same clean way every other
+    call() failure path does, not propagate a raw exception past a caller
+    (e.g. the node-time-sync background worker) that only expects
+    TransportError."""
+    supervisor = _make_supervisor(
+        adapter_python="/nonexistent/path/to/adapter/venv/bin/python", command=None
+    )
+
+    with pytest.raises(TransportError) as excinfo:
+        supervisor.call(
+            {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+            timeout=5.0,
+            ble_address_for_cleanup=None,
+        )
+
+    assert excinfo.value.code == TransportErrorCode.ADAPTER_UNAVAILABLE
+    assert supervisor._proc is None  # left in a clean, retryable state
+
+
 def test_kill_runs_bluetoothctl_disconnect_only_when_a_ble_address_is_given():
     supervisor = _make_supervisor()
 


### PR DESCRIPTION
## Summary
- Task 48 review finding, caught before touching live nodes: `AdapterSupervisor._spawn_locked()` (`subprocess.Popen`) wasn't wrapped in `call()`'s existing failure-handling pattern.
- On all three current nodes, no separate adapter venv exists yet (that's the next step, `install.sh`'s venv-split), so `adapter_python` points at a nonexistent path. The very first real spawn attempt - triggered automatically by `_attempt_node_time_sync()` after any listener reconnect, per PR #117's wiring - would raise a raw `FileNotFoundError` instead of the clean `TransportError(ADAPTER_UNAVAILABLE)` every other failure path in `call()` already produces.
- Fix: wrap `self._spawn_locked()` in the same try/except pattern, converting any spawn failure into `TransportError(ADAPTER_UNAVAILABLE, ...)`.

## Test plan
- [x] New test `test_spawn_failure_raises_adapter_unavailable_not_a_raw_exception` - real scenario, `adapter_python` pointed at a nonexistent path, asserts `TransportError(ADAPTER_UNAVAILABLE)` and `supervisor._proc is None` (clean, retryable state).
- [x] `pytest tests/test_adapter_ipc_client.py` - 14 passed.
- [x] Full suite - 304 passed, 24 skipped.
- [ ] Live verification on dev/camtest/prod after merge: confirm restart doesn't crash-loop, and that `_attempt_node_time_sync()`'s failure log stays bounded (already gated by the existing 300s attempt-cooldown, verified by reading the code - no log-storm risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)