### PR TITLE
feat: split meshtastic (GPLv3) into its own venv, isolated from Core (Task 48)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -240,14 +240,25 @@ of this automatically.
    source venv/bin/activate
    python -m pip install --upgrade pip setuptools wheel
    python -m pip install -r requirements.txt
-   which meshtastic   # should print a path under ~/meshcenter/venv/bin/
+   deactivate
+   ```
+   > Core's own venv above deliberately does **not** include the
+   > `meshtastic` package (GPLv3) — see CLAUDE.md. It lives in a second,
+   > separate venv, created next.
+
+3b. [ ] **Meshtastic adapter environment** (Task 48 — isolated from Core's
+   venv above so GPLv3 code never gets imported into Core's own process)
+   ```bash
+   python3 -m venv adapters/meshtastic/venv
+   adapters/meshtastic/venv/bin/pip install --upgrade pip
+   adapters/meshtastic/venv/bin/pip install -r adapters/meshtastic/requirements.txt
+   which adapters/meshtastic/venv/bin/meshtastic   # should print a path under adapters/meshtastic/venv/bin/
    ```
 
 4. [ ] **Test the radio before configuring MeshCenter**
    ```bash
    ls -l /dev/ttyACM* /dev/ttyUSB* 2>/dev/null
-   source ~/meshcenter/venv/bin/activate
-   meshtastic --port /dev/ttyACM0 --info
+   adapters/meshtastic/venv/bin/meshtastic --port /dev/ttyACM0 --info
    ```
    Do not continue until this prints node info with no permission/serial
    errors. Note the local node ID, long name and short name.

--- a/README.md
+++ b/README.md
@@ -1496,14 +1496,18 @@ Full history and root-cause details for these and other known issues: see [KNOWN
 
 ### Meshtastic CLI not found
 
-Check that the CLI is installed inside the virtual environment:
+The `meshtastic` package lives in its own venv, separate from Core's
+(see CLAUDE.md's "process isolation" section) — check it's installed
+there:
 
 ```bash
-source venv/bin/activate
-which meshtastic
+which adapters/meshtastic/venv/bin/meshtastic
 ```
 
-Verify the configured path in `config.py`.
+If missing, provision it: `python3 -m venv adapters/meshtastic/venv &&
+adapters/meshtastic/venv/bin/pip install -r adapters/meshtastic/requirements.txt`
+(see INSTALL.md step 3b). Verify the configured path in `config.py` if
+you're pointing at a custom location.
 
 ### Radio not detected
 
@@ -1516,8 +1520,7 @@ ls /dev/ttyACM*
 Test communication:
 
 ```bash
-source venv/bin/activate
-meshtastic --info
+adapters/meshtastic/venv/bin/meshtastic --info
 ```
 
 ### Camera not working

--- a/adapters/meshtastic/requirements.txt
+++ b/adapters/meshtastic/requirements.txt
@@ -1,0 +1,21 @@
+# Dependencies for the Meshtastic adapter subprocess only (Task 48) -
+# installed into its own venv (adapters/meshtastic/venv, created by
+# install.sh's step_adapter_venv()), isolated from Core's MIT-licensed
+# venv (see requirements.txt) so GPLv3 code never gets imported into
+# Core's own process.
+#
+# [ble] extra pulls in bleak - adapters/meshtastic/ble_transport.py
+# imports meshtastic.ble_interface.BLEInterface, which is meshtastic's
+# own wrapper around bleak; bare `meshtastic` does NOT install bleak,
+# it's an optional extra. Without it, BLE would silently fail with an
+# ImportError surfaced as an opaque ADAPTER_UNAVAILABLE, not a clear
+# "install the [ble] extra" message.
+#
+# Pinned to the 2.7.x line, not just >=: server.py's listen_meshtastic()
+# (Core-side, still shells out to the CLI binary this venv provides)
+# parses the CLI's human-readable stdout line-by-line (see CLAUDE.md's
+# "fragile by nature" note) - a future minor version bump could silently
+# change that output format and break parsing with no warning. Currently
+# deployed: 2.7.9 (prod), 2.7.11 (dev/camtest, also the latest 2.7.x on
+# PyPI as of 2026-08) - this range covers both without floating past 2.7.
+meshtastic[ble]>=2.7.9,<2.8.0

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -211,16 +211,27 @@ python3 -m venv --system-site-packages venv
 source venv/bin/activate
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -r requirements.txt
+deactivate
 ```
 
-Confirm that the Meshtastic CLI was installed inside the virtual environment:
+The `meshtastic` package (GPLv3) is deliberately not part of Core's own
+venv above — it lives in a second, isolated venv:
 
 ```bash
-which meshtastic
-meshtastic --version
+python3 -m venv adapters/meshtastic/venv
+adapters/meshtastic/venv/bin/pip install --upgrade pip
+adapters/meshtastic/venv/bin/pip install -r adapters/meshtastic/requirements.txt
 ```
 
-`which meshtastic` should report a path under `~/meshcenter/venv/bin/`.
+Confirm that the Meshtastic CLI was installed there:
+
+```bash
+which adapters/meshtastic/venv/bin/meshtastic
+adapters/meshtastic/venv/bin/meshtastic --version
+```
+
+`which adapters/meshtastic/venv/bin/meshtastic` should report a path
+under `~/meshcenter/adapters/meshtastic/venv/bin/`.
 
 ### Find and test the USB radio
 
@@ -235,8 +246,7 @@ Most RAK4631-based USB installations appear as `/dev/ttyACM0`. Some radios use `
 Test communication before continuing:
 
 ```bash
-source ~/meshcenter/venv/bin/activate
-meshtastic --port /dev/ttyACM0 --info
+~/meshcenter/adapters/meshtastic/venv/bin/meshtastic --port /dev/ttyACM0 --info
 ```
 
 The command must display the local node information without permission, connection or serial-port errors. Record the local node ID, long name and short name from the output.
@@ -354,7 +364,7 @@ Do not add broad password-free sudo access. Only the commands listed in the supp
 
 Check the following items in order:
 
-1. `meshtastic --port /dev/ttyACM0 --info` can read the radio.
+1. `adapters/meshtastic/venv/bin/meshtastic --port /dev/ttyACM0 --info` can read the radio.
 2. `systemctl is-active meshcenter.service` reports `active`.
 3. The web interface opens at `http://<raspberry-pi-ip>:5000`.
 4. The bottom-right status indicator changes from `Checking` to an online state.
@@ -573,6 +583,11 @@ git pull --ff-only origin main
 git fetch --tags
 source venv/bin/activate
 python -m pip install -r requirements.txt
+deactivate
+# First update after upgrading past Task 48: this venv won't exist yet on
+# an older install (git pull never runs installer provisioning steps) -
+# create it once with: python3 -m venv adapters/meshtastic/venv
+adapters/meshtastic/venv/bin/pip install -r adapters/meshtastic/requirements.txt
 python -m compileall -q server.py api camera meshsrv storage telemetry utils
 sudo systemctl restart meshcenter.service
 sudo systemctl is-active meshcenter.service
@@ -610,8 +625,7 @@ Check the paths in the installed service and the values in `config.py`.
 ```bash
 ls -l /dev/ttyACM* /dev/ttyUSB* 2>/dev/null
 id
-source ~/meshcenter/venv/bin/activate
-meshtastic --port /dev/ttyACM0 --info
+~/meshcenter/adapters/meshtastic/venv/bin/meshtastic --port /dev/ttyACM0 --info
 ```
 
 Confirm that the user belongs to `dialout`, the USB cable carries data and `MESHTASTIC_PORT` matches the actual device.

--- a/install.sh
+++ b/install.sh
@@ -353,14 +353,54 @@ step_venv() {
 
     pip install --upgrade pip --quiet
     pip install -r "${INSTALL_DIR}/requirements.txt" --quiet
+    deactivate
 
     log "Python dependencies installed ✓"
+}
+
+# ─── Step 5b: Meshtastic adapter virtualenv (Task 48) ─────────────────────────
+# Separate venv for adapters/meshtastic/*.py's GPLv3 meshtastic[ble]
+# dependency, isolated from Core's MIT-licensed venv above - see CLAUDE.md
+# and meshsrv/adapter_ipc_client.py's module docstring for why. Must run
+# before step_detect_radio(): both that step and the listener started by
+# a normal service run need the `meshtastic` CLI binary this venv
+# provides (resolve_meshtastic_cli() checks this venv first, see
+# meshsrv/runtime_identity.py).
+#
+# Deliberately never calls fail() - a Core install must succeed even if
+# this venv can't be provisioned (no internet, PyPI hiccup, disk full on
+# a device already tight on space). MeshCenter's own design accounts for
+# this: Core starts normally and reports transport status
+# ADAPTER_UNAVAILABLE rather than crashing (Task 48 acceptance test) -
+# the installer should behave the same way, not be stricter than the app
+# it's installing.
+step_adapter_venv() {
+    progress "5b/9 Installing Meshtastic adapter dependencies..."
+
+    if ! python3 -m venv "${INSTALL_DIR}/adapters/meshtastic/venv" 2>>"$LOG_FILE"; then
+        warn "Could not create the Meshtastic adapter venv - MeshCenter will still start, but"
+        warn "radio connectivity will stay unavailable until this is fixed. Retry later with:"
+        warn "  python3 -m venv ${INSTALL_DIR}/adapters/meshtastic/venv"
+        warn "  ${INSTALL_DIR}/adapters/meshtastic/venv/bin/pip install -r ${INSTALL_DIR}/adapters/meshtastic/requirements.txt"
+        return 0
+    fi
+
+    if "${INSTALL_DIR}/adapters/meshtastic/venv/bin/pip" install --upgrade pip --quiet 2>>"$LOG_FILE" \
+        && "${INSTALL_DIR}/adapters/meshtastic/venv/bin/pip" install -r "${INSTALL_DIR}/adapters/meshtastic/requirements.txt" --quiet 2>>"$LOG_FILE"; then
+        log "Meshtastic adapter dependencies installed ✓"
+    else
+        warn "Meshtastic adapter dependencies failed to install - MeshCenter will still start, but"
+        warn "radio connectivity will stay unavailable until this is fixed. Retry later with:"
+        warn "  ${INSTALL_DIR}/adapters/meshtastic/venv/bin/pip install -r ${INSTALL_DIR}/adapters/meshtastic/requirements.txt"
+    fi
 }
 
 # ─── Step 6: Detect radio ─────────────────────────────────────────────────────
 # Runs before step_config() (swapped from the original 6/7 order) so a
 # connected radio can actually be queried for real config values below -
-# it needs the venv's `meshtastic` CLI from step_venv either way.
+# it needs the adapter venv's `meshtastic` CLI from step_adapter_venv
+# (falls back through resolve_meshtastic_cli()'s other candidates if that
+# venv failed to provision - see step_config_from_detected_radio() below).
 step_detect_radio() {
     progress "6/9 Detecting Meshtastic radio..."
 
@@ -432,6 +472,27 @@ step_config_from_detected_radio() (
     # shellcheck source=installer/common.sh
     source "${INSTALL_DIR}/installer/common.sh"
 
+    # Task 48: `meshtastic` is no longer guaranteed to be on PATH - Core's
+    # own venv (activated during step_venv, deactivated since) never had
+    # it, and this function historically relied on that activation's PATH
+    # leaking into this later step. Resolve the CLI the same way the app
+    # itself does at runtime (resolve_meshtastic_cli(), which checks the
+    # adapter venv from step_adapter_venv first) instead of a bare-name
+    # PATH lookup, using the system python3 - meshsrv/runtime_identity.py
+    # is stdlib-only, safe to import outside any venv.
+    local meshtastic_bin
+    meshtastic_bin="$(python3 -c "
+import sys
+sys.path.insert(0, '${INSTALL_DIR}')
+from meshsrv.runtime_identity import resolve_meshtastic_cli
+print(resolve_meshtastic_cli('', '${INSTALL_DIR}'))
+" 2>/dev/null)"
+
+    if [[ -z "$meshtastic_bin" ]]; then
+        log "Could not resolve the Meshtastic CLI binary (adapter venv may not have provisioned - see step 5b above)."
+        return 1
+    fi
+
     local info_file
     info_file="$(mktemp)"
 
@@ -442,11 +503,11 @@ step_config_from_detected_radio() (
     # (works if the user was already in dialout from a previous run).
     local probe_ok=0
     if command -v sg &>/dev/null; then
-        if timeout 30 sg dialout -c "meshtastic --port '$RADIO_PORT' --info" >"$info_file" 2>&1; then
+        if timeout 30 sg dialout -c "'$meshtastic_bin' --port '$RADIO_PORT' --info" >"$info_file" 2>&1; then
             probe_ok=1
         fi
     else
-        if timeout 30 meshtastic --port "$RADIO_PORT" --info >"$info_file" 2>&1; then
+        if timeout 30 "$meshtastic_bin" --port "$RADIO_PORT" --info >"$info_file" 2>&1; then
             probe_ok=1
         fi
     fi
@@ -630,6 +691,7 @@ main() {
     step_swap
     step_clone
     step_venv
+    step_adapter_venv
     step_detect_radio
     step_config
     step_systemd

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -520,8 +520,36 @@ runuser -u "$TARGET_USER" -- \
     "$INSTALL_DIR/venv/bin/python" -m pip install \
         -r "$INSTALL_DIR/requirements.txt" --quiet
 
-MESHTASTIC_BIN="$INSTALL_DIR/venv/bin/meshtastic"
-[[ -x "$MESHTASTIC_BIN" ]] || fail "Meshtastic CLI was not installed in the MeshCenter venv."
+# Task 48: meshtastic (GPLv3) moved out of the main venv above into its
+# own venv, isolated from Core's MIT-licensed code - see CLAUDE.md and
+# adapters/meshtastic/requirements.txt. Unlike install.sh's
+# step_adapter_venv() (which tolerates this failing, since that manual
+# path can finish with radio connectivity degraded and be fixed up
+# later), this unattended path genuinely cannot proceed without it: the
+# radio-probing loop just below needs this CLI to ever produce a valid
+# config.py, and this script's own stated design (see the "Important"
+# note above) never falls back to a placeholder config - so a failure
+# here must fail loudly now, not time out mysteriously in the probing
+# loop below.
+log "Creating Meshtastic adapter virtual environment..."
+
+runuser -u "$TARGET_USER" -- \
+    env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" \
+    python3 -m venv "$INSTALL_DIR/adapters/meshtastic/venv"
+
+log "Installing Meshtastic adapter dependencies..."
+
+runuser -u "$TARGET_USER" -- \
+    env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" \
+    "$INSTALL_DIR/adapters/meshtastic/venv/bin/python" -m pip install --upgrade pip --quiet
+
+runuser -u "$TARGET_USER" -- \
+    env HOME="$TARGET_HOME" USER="$TARGET_USER" LOGNAME="$TARGET_USER" \
+    "$INSTALL_DIR/adapters/meshtastic/venv/bin/python" -m pip install \
+        -r "$INSTALL_DIR/adapters/meshtastic/requirements.txt" --quiet
+
+MESHTASTIC_BIN="$INSTALL_DIR/adapters/meshtastic/venv/bin/meshtastic"
+[[ -x "$MESHTASTIC_BIN" ]] || fail "Meshtastic CLI was not installed in the adapter venv."
 
 log "Python environment ready."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,15 @@ Flask>=3.0.0
 Pillow>=10.0.0
 requests>=2.31.0
 psutil>=5.9.0
-# Pinned to the 2.7.x line, not just >=: server.py's listen_meshtastic()
-# parses the CLI's human-readable stdout line-by-line (see CLAUDE.md's
-# "fragile by nature" note) - a future minor version bump could silently
-# change that output format and break parsing with no warning. Currently
-# deployed: 2.7.9 (prod), 2.7.11 (dev/camtest, also the latest 2.7.x on
-# PyPI as of 2026-08) - this range covers both without floating past 2.7.
-meshtastic>=2.7.9,<2.8.0
+# Task 48: the meshtastic package (GPLv3) no longer lives in Core's own
+# venv - Core never imports it directly (adapters/meshtastic/*.py are the
+# only modules that do, and they run in a separate process/venv, see
+# meshsrv/adapter_ipc_client.py). See
+# adapters/meshtastic/requirements.txt for the actual pin. Core still
+# shells out to the `meshtastic` CLI *binary* for the listener and
+# --info calls (arm's-length subprocess invocation, not an import) -
+# meshsrv/runtime_identity.py's resolve_meshtastic_cli() finds that
+# binary in the adapter venv created by install.sh's step_adapter_venv().
 v4l2py>=3.0.0
 # Production WSGI server (see gunicorn.conf.py / deploy/meshcenter.service).
 # Pinned to the 23.x line - gunicorn's own worker/arbiter internals (the

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -33,18 +33,41 @@ if [ -x "venv/bin/python" ]; then
     else
         bad "flask not importable inside venv — run: source venv/bin/activate && pip install -r requirements.txt"
     fi
+    # Task 48: meshtastic (GPLv3) no longer belongs in Core's own venv -
+    # Core never imports it directly. Its presence here isn't wrong (a
+    # pre-split install or a leftover from before the split still has it,
+    # harmlessly), but it's no longer required, so this is informational
+    # only, never `bad`.
     if venv/bin/python -c "import meshtastic" >/dev/null 2>&1; then
-        ok "meshtastic package importable inside venv"
-    else
-        bad "meshtastic package not importable inside venv"
-    fi
-    if [ -x "venv/bin/meshtastic" ]; then
-        ok "meshtastic CLI present at venv/bin/meshtastic"
-    else
-        warn "no venv/bin/meshtastic — CLI may resolve from elsewhere (MESHTASTIC_CMD in config.py)"
+        warn "meshtastic package is importable inside Core's venv — harmless leftover from a pre-split install, no longer required here (see adapters/meshtastic/venv below)"
     fi
 else
     bad "venv/bin/python missing — venv was not created (see INSTALL.md step 3)"
+fi
+echo
+
+# --- 1b. Meshtastic adapter virtual environment (Task 48 venv-split) --------
+echo "Meshtastic adapter environment (Task 48 venv-split)"
+ADAPTER_VENV="adapters/meshtastic/venv"
+if [ -x "${ADAPTER_VENV}/bin/python" ]; then
+    ok "${ADAPTER_VENV}/bin/python exists"
+    if "${ADAPTER_VENV}/bin/python" -c "import meshtastic" >/dev/null 2>&1; then
+        ok "meshtastic package importable inside the adapter venv"
+    else
+        bad "meshtastic package not importable inside ${ADAPTER_VENV} — run: ${ADAPTER_VENV}/bin/pip install -r adapters/meshtastic/requirements.txt"
+    fi
+    if "${ADAPTER_VENV}/bin/python" -c "from meshtastic.ble_interface import BLEInterface" >/dev/null 2>&1; then
+        ok "BLE support (bleak, via the [ble] extra) importable inside the adapter venv"
+    else
+        bad "BLE support not importable inside ${ADAPTER_VENV} — bare 'meshtastic' was likely installed instead of 'meshtastic[ble]' (see adapters/meshtastic/requirements.txt); BLE radios will fail with an opaque ADAPTER_UNAVAILABLE"
+    fi
+    if [ -x "${ADAPTER_VENV}/bin/meshtastic" ]; then
+        ok "meshtastic CLI present at ${ADAPTER_VENV}/bin/meshtastic"
+    else
+        warn "no ${ADAPTER_VENV}/bin/meshtastic — CLI may resolve from elsewhere (MESHTASTIC_CMD in config.py, see resolve_meshtastic_cli())"
+    fi
+else
+    bad "${ADAPTER_VENV}/bin/python missing — the adapter venv was not created. Core will still start (transport status ADAPTER_UNAVAILABLE, by design) but the radio will not connect. Run: python3 -m venv ${ADAPTER_VENV} && ${ADAPTER_VENV}/bin/pip install -r adapters/meshtastic/requirements.txt (see install.sh's step_adapter_venv — a plain 'git pull' update never runs this step on an existing install, same class of gap as task 39's sudoers checks above)"
 fi
 echo
 


### PR DESCRIPTION
## Summary
- `install.sh`: new `step_adapter_venv()` (creates `adapters/meshtastic/venv`, installs `adapters/meshtastic/requirements.txt`), run between `step_venv` and `step_detect_radio`. Non-fatal to the Core install if it fails - matches the app's own `ADAPTER_UNAVAILABLE` degraded-start design (PR #117/#118) rather than being stricter than the app it installs.
- `step_config_from_detected_radio()` now resolves the CLI via `resolve_meshtastic_cli()` (imported from `meshsrv/runtime_identity.py` using the system `python3`, stdlib-only) instead of a bare `meshtastic` PATH lookup - Core's own venv (deactivated after `step_venv` now) no longer has it.
- `meshcenter-firstboot.sh` (unattended/cloud-init provisioning) gets the same split, but **fails loudly** if the adapter venv can't be provisioned - unlike `install.sh`'s manual path, firstboot can never produce a valid `config.py` without a working CLI to probe the radio (its own documented design never falls back to a placeholder config).
- `requirements.txt`: `meshtastic` removed - Core never imports it directly. New `adapters/meshtastic/requirements.txt`: `meshtastic[ble]>=2.7.9,<2.8.0` - the `[ble]` extra is required, not optional: `ble_transport.py` imports `meshtastic.ble_interface.BLEInterface`, which needs `bleak`, an extra bare `meshtastic` does not install (would otherwise silently degrade BLE to an opaque `ADAPTER_UNAVAILABLE`).
- `scripts/verify-install.sh`: new section checking the adapter venv (python/meshtastic import/BLE extra/CLI binary), mirroring Task 39's sudoers checks - a plain `git pull` on an existing install never runs `step_adapter_venv`, so this catches the same class of silent gap that task closed for sudoers.
- `INSTALL.md`/`README.md`/`docs/User_Guide.md` updated - manual venv setup, CLI troubleshooting, and the documented update procedure all still pointed at the old single-venv layout.

## Test plan
- [x] `bash -n` on `install.sh`, `meshcenter-firstboot.sh`, `scripts/verify-install.sh`
- [x] `python -m compileall -q .`
- [x] Full suite - 304 passed, 24 skipped (no test changes needed; this PR is installer/docs, no Python behavior change beyond what #117/#118 already covered)
- [ ] Live verification (next step): manually provision the adapter venv on dev/camtest/prod via SSH (mirroring what `step_adapter_venv()` will do on future clean installs), confirm the acceptance test - Core running normally, transport reporting a real connection instead of `ADAPTER_UNAVAILABLE`, radio send/receive working - then `scripts/verify-install.sh` reporting the new adapter-venv section clean on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)