### PR TITLE
fix: drop nonexistent meshtastic[ble] extra, bleak is a base dependency

### DIFF
--- a/adapters/meshtastic/requirements.txt
+++ b/adapters/meshtastic/requirements.txt
@@ -4,12 +4,16 @@
 # venv (see requirements.txt) so GPLv3 code never gets imported into
 # Core's own process.
 #
-# [ble] extra pulls in bleak - adapters/meshtastic/ble_transport.py
-# imports meshtastic.ble_interface.BLEInterface, which is meshtastic's
-# own wrapper around bleak; bare `meshtastic` does NOT install bleak,
-# it's an optional extra. Without it, BLE would silently fail with an
-# ImportError surfaced as an opaque ADAPTER_UNAVAILABLE, not a clear
-# "install the [ble] extra" message.
+# adapters/meshtastic/ble_transport.py imports
+# meshtastic.ble_interface.BLEInterface, meshtastic's own wrapper around
+# bleak. No [ble] extra needed - live-verified on a real node (task 48
+# follow-up) that bleak is an unconditional base dependency of meshtastic
+# 2.7.x (`pip show meshtastic` lists it under plain "Requires:", with no
+# extras marker at all - `pip install meshtastic[ble]` just warns
+# "does not provide the extra 'ble'" and installs bleak anyway). An
+# earlier version of this file specified meshtastic[ble], based on an
+# unverified assumption that bleak was extras-gated - it wasn't; this is
+# the corrected, actually-checked version.
 #
 # Pinned to the 2.7.x line, not just >=: server.py's listen_meshtastic()
 # (Core-side, still shells out to the CLI binary this venv provides)
@@ -18,4 +22,4 @@
 # change that output format and break parsing with no warning. Currently
 # deployed: 2.7.9 (prod), 2.7.11 (dev/camtest, also the latest 2.7.x on
 # PyPI as of 2026-08) - this range covers both without floating past 2.7.
-meshtastic[ble]>=2.7.9,<2.8.0
+meshtastic>=2.7.9,<2.8.0

--- a/install.sh
+++ b/install.sh
@@ -359,8 +359,9 @@ step_venv() {
 }
 
 # ─── Step 5b: Meshtastic adapter virtualenv (Task 48) ─────────────────────────
-# Separate venv for adapters/meshtastic/*.py's GPLv3 meshtastic[ble]
-# dependency, isolated from Core's MIT-licensed venv above - see CLAUDE.md
+# Separate venv for adapters/meshtastic/*.py's GPLv3 meshtastic
+# dependency (which pulls in bleak as a base dependency, for BLE), isolated
+# from Core's MIT-licensed venv above - see CLAUDE.md
 # and meshsrv/adapter_ipc_client.py's module docstring for why. Must run
 # before step_detect_radio(): both that step and the listener started by
 # a normal service run need the `meshtastic` CLI binary this venv

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -57,9 +57,9 @@ if [ -x "${ADAPTER_VENV}/bin/python" ]; then
         bad "meshtastic package not importable inside ${ADAPTER_VENV} — run: ${ADAPTER_VENV}/bin/pip install -r adapters/meshtastic/requirements.txt"
     fi
     if "${ADAPTER_VENV}/bin/python" -c "from meshtastic.ble_interface import BLEInterface" >/dev/null 2>&1; then
-        ok "BLE support (bleak, via the [ble] extra) importable inside the adapter venv"
+        ok "BLE support (bleak, a base meshtastic dependency) importable inside the adapter venv"
     else
-        bad "BLE support not importable inside ${ADAPTER_VENV} — bare 'meshtastic' was likely installed instead of 'meshtastic[ble]' (see adapters/meshtastic/requirements.txt); BLE radios will fail with an opaque ADAPTER_UNAVAILABLE"
+        bad "BLE support not importable inside ${ADAPTER_VENV} — meshtastic itself may be missing/broken (bleak is a base dependency, not an extra - see adapters/meshtastic/requirements.txt); run: ${ADAPTER_VENV}/bin/pip install -r adapters/meshtastic/requirements.txt"
     fi
     if [ -x "${ADAPTER_VENV}/bin/meshtastic" ]; then
         ok "meshtastic CLI present at ${ADAPTER_VENV}/bin/meshtastic"


### PR DESCRIPTION
## Summary
- PR #119's `adapters/meshtastic/requirements.txt` used `meshtastic[ble]`, based on an unverified assumption that `bleak` was gated behind an optional extra.
- Caught while manually provisioning the adapter venv on TAP2 (Task 48 live verification, step 1): `pip install meshtastic[ble]` prints `WARNING: meshtastic 2.7.11 does not provide the extra 'ble'`. `pip show meshtastic` confirms `bleak` is a plain, unconditional `Requires:` dependency - no extras marker at all in the package's real metadata.
- Functionally harmless (bleak was installed anyway, `BLEInterface` imports fine) but the extra syntax was simply wrong and printed a confusing warning on every future install. Corrected the pin and the comments/`verify-install.sh` messaging that repeated the same unverified claim.

## Test plan
- [x] Live-verified against the real PyPI package on TAP2 (`pip show meshtastic`/`pip show bleak`), not just re-reading docs.
- [x] `bash -n install.sh scripts/verify-install.sh`
- [x] Full suite - 304 passed, 24 skipped (no Python behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)