### PR TITLE
fix: claim the serial port across the process boundary before adapter IPC calls (Task 48 follow-up)

### DIFF
--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -57,9 +57,75 @@ is complete:
 Neither layer is optional-if-the-other-exists; they cover genuinely
 different deployment shapes.
 
-Not wired into server.py yet - this is the Core-side proxy itself,
-buildable and testable independent of server.py's construction site,
-which is the next increment.
+SERIAL PORT CLAIM ACROSS THE PROCESS BOUNDARY (Task 48 follow-up, a real
+gap live-caught on TAP2, not theoretical): radio_lock/pause_listen are
+plain threading primitives - they cannot cross into the adapter's own
+process, so Core's own listener subprocess (still running, Stage A) and
+the adapter's freshly-opened SerialInterface had nothing coordinating
+which of them actually owns /dev/ttyACM0 at a given moment. Live symptom
+before this fix: a real set_device_time() call raced the listener, hit
+its own internal watchdog timeout, got killed per tier (b) above, and
+the very next serial-type call (get_channels) lost the same race on the
+respawned process. AdapterIPCTransport._call() now wraps every
+SERIAL-type call in core_serial_transport.claim_for_external_command()
+(SerialTransport.claim_for_external_command(), Task 48's original
+design intent, previously written but never actually called from
+anywhere - confirmed by grep before this fix) - pause Core's own
+listener, confirm the port is genuinely free, only then let the adapter
+open its own SerialInterface. BLE gets no such wrapping - it never
+shares Core's listener/serial port.
+
+Budget split for this claim is DYNAMIC, mirroring TransportRouter.
+_delegate()'s existing remaining = timeout - elapsed mechanic (Task
+47.5), not a fixed proportion of the caller's declared timeout: the
+claim itself gets its own small, independent budget (claim_for_
+external_command()'s own default, ~8s - unrelated to the caller's
+timeout, since "wait for the listener to actually let go of the port"
+is a fixed-magnitude operation, not something that should shrink just
+because the caller declared a short timeout) using time.monotonic() to
+measure what it *actually* took, and the delegated IPC call then gets
+max(1.0, caller_timeout - actual_claim_elapsed) - never a stacked flat
+addition (which would silently inflate a caller's declared budget) and
+never a fixed percentage (which would starve the actual operation after
+a fast claim, or overrun the caller's stated budget after a slow one -
+the same class of bug already fixed once in TransportRouter._delegate()
+during Task 47.5's review). A claim that fails to free the port in time
+raises TransportError(BUSY) - _claim_radio()'s existing, unchanged
+behavior; nothing here catches or reclassifies it, it propagates through
+_call()'s existing TransportError handling exactly like any other
+failure.
+
+KNOWN TRADE-OFF, explicitly accepted rather than silently introduced
+(Task 48 follow-up review): server.py's own radio_lock/pause_listen are
+the SAME objects passed into Core's own SerialTransport instance
+(`SerialTransport(radio_lock=radio_lock, pause_listen=pause_listen,
+...)` in server.py) - the same lock server.py's radio_session()
+acquires for the send worker, channel discovery, and
+api/api_node_tools.py's traceroute/telemetry actions
+(`radio_session(timeout=10, ...)`). Since claim_for_external_command()
+holds that same radio_lock for the FULL duration of the wrapped IPC call
+(not just the port-preparation phase - releasing it earlier would
+reopen exactly the race this fix closes), a Node Tools action that
+starts while a long serial IPC call (e.g. connect/reconnect, tens of
+seconds) is in flight now waits on an *unbounded* `with radio_lock:`
+acquire - server.py's radio_lock is a plain threading.RLock with no
+timeout on acquisition, so radio_session()'s own timeout=10 parameter
+(which only bounds the port-release-polling phase, entered only AFTER
+the lock is already held) does not help here. Previously, in the
+single-process model, radio_lock was only ever held for a fast, local
+SerialInterface open/close - this widens that window to a full
+process-boundary round-trip. Accepted for this fix because narrowing it
+back down would mean not holding the lock for the adapter's actual
+serial work, reopening the contention bug this change exists to close -
+but this is a real, load-bearing UX regression risk for Node Tools
+(a traceroute button could now hang up to the same duration as a
+concurrent connect/reconnect instead of failing fast), not dismissed as
+hypothetical. Follow-up needed: bound radio_session()'s lock acquisition
+itself (e.g. radio_lock.acquire(timeout=...) instead of a bare `with`)
+so Node Tools fails fast with "radio busy" instead of blocking
+indefinitely - out of scope for this fix since it touches radio_session()
+callers well beyond this module (send worker, channel discovery, --info
+calls) and deserves its own focused review.
 """
 from __future__ import annotations
 
@@ -71,6 +137,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 from typing import Callable, Optional, Sequence
 
@@ -375,10 +442,17 @@ class AdapterIPCTransport(RadioTransport):
         supervisor: AdapterSupervisor,
         *,
         ble_address_provider: Optional[Callable[[], Optional[str]]] = None,
+        core_serial_transport: Optional[object] = None,
     ) -> None:
         self._transport_type = transport_type
         self._supervisor = supervisor
         self._ble_address_provider = ble_address_provider
+        # Only ever passed for the SERIAL instance - duck-typed (needs
+        # only .claim_for_external_command()), not imported for typing,
+        # to keep this Core-side module decoupled from adapters/*.py -
+        # see this module's own SERIAL PORT CLAIM docstring section for
+        # why this exists.
+        self._core_serial_transport = core_serial_transport
         self._cached_info = _adapter_unavailable_info()
 
     def _ble_cleanup_address(self) -> Optional[str]:
@@ -387,17 +461,33 @@ class AdapterIPCTransport(RadioTransport):
         return self._ble_address_provider() if self._ble_address_provider else None
 
     def _call(self, operation: str, params: dict, timeout: float):
-        request = {
-            "protocol_version": ipc_protocol.PROTOCOL_VERSION,
-            "operation": operation,
-            "transport_type": self._transport_type.value,
-            "params": params,
-            "timeout": timeout,
-        }
-        try:
-            response = self._supervisor.call(
-                request, timeout=timeout, ble_address_for_cleanup=self._ble_cleanup_address()
+        def _do_call(call_timeout: float) -> dict:
+            request = {
+                "protocol_version": ipc_protocol.PROTOCOL_VERSION,
+                "operation": operation,
+                "transport_type": self._transport_type.value,
+                "params": params,
+                "timeout": call_timeout,
+            }
+            return self._supervisor.call(
+                request, timeout=call_timeout, ble_address_for_cleanup=self._ble_cleanup_address()
             )
+
+        try:
+            if self._transport_type == ConnectionType.SERIAL and self._core_serial_transport is not None:
+                start = time.monotonic()
+                # Own independent budget (claim_for_external_command()'s
+                # own default, ~8s) - NOT sliced from the caller's
+                # timeout, since freeing the port is a fixed-magnitude
+                # operation. What it actually took IS subtracted from the
+                # caller's budget below - dynamic, not a fixed
+                # proportion (see module docstring).
+                with self._core_serial_transport.claim_for_external_command():
+                    elapsed = time.monotonic() - start
+                    remaining = max(1.0, timeout - elapsed)
+                    response = _do_call(remaining)
+            else:
+                response = _do_call(timeout)
         except TransportError as error:
             self._cached_info = ConnectionInfo(
                 state=ConnectionState.ERROR,

--- a/server.py
+++ b/server.py
@@ -829,7 +829,18 @@ adapter_supervisor = AdapterSupervisor(
 # isn't populated from disk until load_settings() runs inside
 # start_runtime() (well after this module-level code), but that's fine -
 # this lambda is only ever actually called later, by which point it is.
-serial_ipc_transport = AdapterIPCTransport(ConnectionType.SERIAL, adapter_supervisor)
+# core_serial_transport=serial_transport (Task 48 follow-up, live-caught
+# gap): pauses Core's own listener via claim_for_external_command()
+# before delegating a serial-type call to the adapter subprocess -
+# without this, Core's listener and the adapter's own SerialInterface
+# raced for the same physical port with nothing coordinating them. See
+# meshsrv/adapter_ipc_client.py's module docstring ("SERIAL PORT CLAIM
+# ACROSS THE PROCESS BOUNDARY") for the live symptom, the fix, and the
+# accepted Node Tools trade-off. BLE gets no such wrapping - it never
+# shares Core's listener/serial port.
+serial_ipc_transport = AdapterIPCTransport(
+    ConnectionType.SERIAL, adapter_supervisor, core_serial_transport=serial_transport
+)
 ble_ipc_transport = AdapterIPCTransport(
     ConnectionType.BLUETOOTH,
     adapter_supervisor,

--- a/tests/test_adapter_ipc_client.py
+++ b/tests/test_adapter_ipc_client.py
@@ -5,6 +5,8 @@ dependency, runs on any platform including this project's Windows dev
 machine), not a mocked-out simulation of subprocess behavior.
 """
 import sys
+import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -39,6 +41,32 @@ def _make_supervisor(**overrides):
     )
     kwargs.update(overrides)
     return AdapterSupervisor(**kwargs)
+
+
+class _FakeCoreSerialTransport:
+    """Stand-in for Core's own SerialTransport instance -
+    claim_for_external_command() is the only method AdapterIPCTransport
+    ever calls on it (see meshsrv/adapter_ipc_client.py's SERIAL PORT
+    CLAIM docstring section). Records each call and can simulate the
+    claim itself taking real wall-clock time (to prove the budget split
+    actually measures elapsed time via time.monotonic(), not a fixed
+    proportion of the caller's timeout) or failing the way the real
+    _claim_radio() does (TransportError(BUSY), raised before yield -
+    i.e. before the wrapped call ever runs)."""
+
+    def __init__(self, claim_delay: float = 0.0, raise_busy: bool = False):
+        self.claim_calls = 0
+        self._claim_delay = claim_delay
+        self._raise_busy = raise_busy
+
+    @contextmanager
+    def claim_for_external_command(self, *, timeout: float = 8, cooldown: float = 2.0):
+        self.claim_calls += 1
+        if self._claim_delay:
+            time.sleep(self._claim_delay)
+        if self._raise_busy:
+            raise TransportError(TransportErrorCode.BUSY, "Serial port busy: /dev/ttyFAKE")
+        yield
 
 
 def test_scan_sends_the_scan_operation_with_this_proxys_own_transport_type():
@@ -284,3 +312,100 @@ def test_spawn_only_passes_preexec_fn_on_linux():
         ble_address_for_cleanup=None,
     )
     assert response["ok"] is True
+
+
+# --- Task 48 follow-up: serial port claim across the process boundary -----
+
+
+def test_serial_call_is_wrapped_in_claim_for_external_command():
+    """The live-caught gap this follow-up fixes: a SERIAL-type call with
+    a core_serial_transport given must go through
+    claim_for_external_command() before ever reaching the adapter."""
+    supervisor = _make_supervisor()
+    core_serial = _FakeCoreSerialTransport()
+    transport = AdapterIPCTransport(ConnectionType.SERIAL, supervisor, core_serial_transport=core_serial)
+
+    result = transport.get_metadata(timeout=5.0)
+
+    assert result["echo"] == {}
+    assert core_serial.claim_calls == 1
+
+
+def test_bluetooth_call_is_never_wrapped_in_claim_even_if_core_serial_transport_given():
+    """Defensive, matching scan()'s own guard elsewhere: BLE never shares
+    Core's listener/serial port, so it must never pay this cost - checked
+    even for the (production-impossible, but worth proving) case where a
+    core_serial_transport was mistakenly passed to a BLUETOOTH instance."""
+    supervisor = _make_supervisor()
+    core_serial = _FakeCoreSerialTransport()
+    transport = AdapterIPCTransport(ConnectionType.BLUETOOTH, supervisor, core_serial_transport=core_serial)
+
+    transport.get_metadata(timeout=5.0)
+
+    assert core_serial.claim_calls == 0
+
+
+def test_serial_call_without_core_serial_transport_behaves_exactly_as_before():
+    """Backward-compat: core_serial_transport is optional and defaults to
+    None (matches every pre-existing test in this file, none of which
+    pass it) - no wrapping, no behavior change for callers that don't
+    supply one."""
+    supervisor = _make_supervisor()
+    transport = AdapterIPCTransport(ConnectionType.SERIAL, supervisor)
+
+    result = transport.get_metadata(timeout=5.0)
+
+    assert result["echo"] == {}
+
+
+def test_claim_budget_split_is_dynamic_not_a_fixed_proportion():
+    """Task 48 follow-up review requirement: the delegated call's budget
+    must be caller_timeout - ACTUAL claim elapsed time (measured via
+    time.monotonic()), not a fixed percentage split - matching
+    TransportRouter._delegate()'s existing remaining = timeout - elapsed
+    mechanic (Task 47.5). Proven here by making the claim itself take a
+    real, measurable delay and asserting the adapter actually received a
+    reduced timeout reflecting that delay, not the original caller
+    timeout unchanged and not some fixed fraction of it."""
+    supervisor = _make_supervisor()
+    core_serial = _FakeCoreSerialTransport(claim_delay=1.0)
+    transport = AdapterIPCTransport(ConnectionType.SERIAL, supervisor, core_serial_transport=core_serial)
+
+    captured_requests = []
+    original_call = supervisor.call
+
+    def _spy_call(request, **kwargs):
+        captured_requests.append(dict(request))
+        return original_call(request, **kwargs)
+
+    supervisor.call = _spy_call
+
+    transport.get_metadata(timeout=5.0)
+
+    sent_timeout = captured_requests[0]["timeout"]
+    # Caller declared 5.0s, the claim itself measurably took ~1.0s - the
+    # delegated call must have received noticeably less than 5.0s (proves
+    # elapsed time was actually subtracted), but comfortably more than a
+    # naive fixed-percentage split would leave (proves it's not just
+    # e.g. "70% of 5.0 = 3.5" by coincidence) - bounds wide enough to
+    # absorb real scheduling jitter without being a no-op assertion.
+    assert 3.0 < sent_timeout < 4.5, f"expected ~4.0s (5.0 - ~1.0 claim delay), got {sent_timeout}"
+
+
+def test_claim_busy_error_propagates_unchanged_without_reaching_the_adapter():
+    """Task 48 follow-up review requirement: a claim that fails to free
+    the port raises TransportError(BUSY) - _claim_radio()'s existing,
+    unchanged behavior. Nothing in AdapterIPCTransport should catch and
+    reclassify it; it must propagate through the same TransportError
+    handling every other failure in _call() already uses, and the
+    adapter must never even be contacted (the claim fails before yield)."""
+    supervisor = _make_supervisor()
+    core_serial = _FakeCoreSerialTransport(raise_busy=True)
+    transport = AdapterIPCTransport(ConnectionType.SERIAL, supervisor, core_serial_transport=core_serial)
+
+    with pytest.raises(TransportError) as excinfo:
+        transport.get_metadata(timeout=5.0)
+
+    assert excinfo.value.code == TransportErrorCode.BUSY
+    assert supervisor._proc is None  # never spawned - the claim failed before any IPC attempt
+    assert transport.get_connection_info().last_error.code == TransportErrorCode.BUSY


### PR DESCRIPTION
## Summary
- Live-caught on TAP2 during Task 48 acceptance testing: `claim_for_external_command()` was added to `SerialTransport` and documented in `ipc_server.py`'s own comment as the mechanism Core would use to pause its listener before a serial-type IPC call, but nothing ever called it (confirmed by grep). Core's own listener subprocess and the adapter's freshly-opened `SerialInterface` raced for `/dev/ttyACM0` with no coordination.
- Observed live: a real `set_device_time()` call hit its own internal watchdog timeout (genuine radio-side stall, not a timeout-math bug), got killed per the existing three-tier contract from PR #117, and the very next serial-type call (`get_channels`) lost the same race on the respawned adapter (`adapter subprocess closed its output unexpectedly`). Core itself never crashed - the kill/respawn machinery absorbed it correctly - but the underlying operation kept failing.
- `AdapterIPCTransport._call()` now wraps every SERIAL-type call in `core_serial_transport.claim_for_external_command()` - pause Core's listener, confirm the port is free, only then let the adapter open its own `SerialInterface`. BLE gets no such wrapping (no shared port with Core's listener).
- Budget split is dynamic: `time.monotonic()`-measured elapsed time for the claim itself is subtracted from the caller's declared timeout, mirroring `TransportRouter._delegate()`'s existing mechanic from Task 47.5 - not a fixed proportion (would either starve the real operation after a fast claim, or silently overrun the caller's stated budget after a slow one).
- A failed claim raises `TransportError(BUSY)` unchanged - `_claim_radio()`'s existing behavior - propagating through the same handling every other `_call()` failure already uses.
- **Known, explicitly-documented trade-off, not silently introduced**: `claim_for_external_command()` holds the same `radio_lock` `server.py`'s `radio_session()` uses for Node Tools (traceroute/telemetry)/send worker/channel discovery, for the *full duration* of the wrapped IPC call. A Node Tools action concurrent with a long serial IPC call (e.g. connect/reconnect) now waits on an unbounded lock acquire instead of failing fast. Documented in `meshsrv/adapter_ipc_client.py`'s module docstring as a follow-up: bound `radio_session()`'s own lock acquisition (`radio_lock.acquire(timeout=...)`) - out of scope here since it touches call sites beyond this module.

## Test plan
- [x] New tests: `test_serial_call_is_wrapped_in_claim_for_external_command`, `test_bluetooth_call_is_never_wrapped_in_claim_even_if_core_serial_transport_given`, `test_serial_call_without_core_serial_transport_behaves_exactly_as_before`, `test_claim_budget_split_is_dynamic_not_a_fixed_proportion` (proves real elapsed time is subtracted, not a fixed percentage), `test_claim_busy_error_propagates_unchanged_without_reaching_the_adapter` (proves the adapter is never contacted on a failed claim).
- [x] `pytest tests/test_adapter_ipc_client.py` - 19 passed.
- [x] Full suite - 309 passed, 24 skipped.
- [ ] Live re-verification on TAP2 (next step): the exact scenario that caught this - time-sync firing after a listener reconnect, overlapping a serial IPC call - re-run with the fix in place, not just trusting green unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)