### PR TITLE
fix: repair serial connect()/reconnect() through the IPC boundary + TransportError frozen-dataclass crash (Task 48 follow-up)

### DIFF
--- a/adapters/meshtastic/serial_transport.py
+++ b/adapters/meshtastic/serial_transport.py
@@ -288,12 +288,30 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
                 self._wait_serial_release(timeout=timeout)
 
         def _do_connect():
-            self._last_probe_ok = False
             interface = self._open_interface()  # blocks on the real handshake, raises on failure
             interface.close()
-            self._last_probe_ok = True
 
+        # Task 48 follow-up review requirement: _last_probe_ok must NOT be
+        # written from inside _do_connect() - that function runs on a
+        # tier-1-abandoned background thread (_call_with_timeout()'s own
+        # documented tier-1/tier-2 gap: a timeout releases the CALLER
+        # immediately, but does not kill the thread still running _fn_).
+        # Writing shared instance state from that thread would let it
+        # finish LATE - after the caller already received
+        # TransportError(TIMEOUT) - and silently overwrite
+        # _last_probe_ok back to True behind the caller's back.
+        #
+        # Both writes below happen on THIS (the calling) thread only,
+        # never inside _do_connect(): pessimistically False before the
+        # attempt (so a failed retry after a previous success correctly
+        # downgrades, instead of leaving a stale True), then True only
+        # if _call_with_timeout() actually returns - which happens ONLY
+        # on a genuine in-budget success. An abandoned thread that
+        # finishes later has nothing left to mutate, no matter how long
+        # it takes - _do_connect() itself never touches this field.
+        self._last_probe_ok = False
         self._call_with_timeout(_do_connect, timeout=timeout, what="connect()")
+        self._last_probe_ok = True
         self._connected_since = time.time()
         self._last_error = None
         return self.get_connection_info()

--- a/adapters/meshtastic/serial_transport.py
+++ b/adapters/meshtastic/serial_transport.py
@@ -85,6 +85,18 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
         self._listen_process: Optional[subprocess.Popen] = None
         self._connected_since: Optional[float] = None
         self._last_error: Optional[TransportError] = None
+        # Task 48 follow-up (live-caught): on the adapter-side instance
+        # (this one, never run_listener()'d - Stage A keeps that on
+        # Core's own separate instance), _listen_process is permanently
+        # None, so is_connected() could never have reflected reality
+        # here even after connect()'s probe fix stopped raising - it
+        # would have kept reporting DISCONNECTED after a proven-good
+        # connect(). This instance's role is fully stateless-per-call
+        # (open/use/close every time, same as send_packet()/get_*()) -
+        # _last_probe_ok is the ONLY state connect()/reconnect()/
+        # disconnect() track here, set explicitly by them, never
+        # inferred from a listener process this instance never owns.
+        self._last_probe_ok: bool = False
         # _call_with_timeout()/_executor now live in TimeoutEnforced
         # (adapters/meshtastic/_timeout_support.py, extracted in Task 45
         # so BLETransport doesn't duplicate the same watchdog pattern).
@@ -223,17 +235,40 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
     def connect(
         self, descriptor: ConnectionDescriptor, *, force: bool = False, timeout: float = 30.0
     ) -> ConnectionInfo:
-        """PRECONDITION carried over from today's behavior: this only
-        does something useful once run_listener() is already running in
-        its own (Core-owned) thread - same as server.py's listener
-        thread today, which starts unconditionally at process startup
-        whenever RADIO_IDENTITY_RESULT matches, with pause_listen
-        cleared by default (threading.Event() starts unset). There was
-        never a distinct "connect" action in the pre-migration code;
-        connect()/disconnect() here are the pause_listen.clear()/
-        stop_listener()+set() pair that already existed, reframed to fit
-        the ABC. Calling connect() before run_listener() has ever been
-        started will just time out waiting for is_connected()."""
+        """Task 48 follow-up (live-caught, two related but distinct bugs
+        fixed together): this used to poll is_connected(), which checked
+        self._listen_process - state that was a valid connectivity proxy
+        pre-Task-48 (single process, run_listener() shared this same
+        instance) but is permanently None on THIS instance post-split
+        (Stage A: run_listener() only ever runs on Core's own, separate
+        SerialTransport - see that method's docstring). Two consequences,
+        both fixed here: (1) the poll loop could never succeed, so
+        connect()/reconnect() always burned their full timeout and raised
+        TIMEOUT - confirmed live on TAP2, an 87s failure on a 90s budget,
+        not radio-side slowness. (2) even after fixing the probe itself,
+        the OLD final `return self.get_connection_info()` would still
+        have reported DISCONNECTED (same is_connected() problem) despite
+        a just-proven-good connection - the exact "state lies about a
+        successful call" class of bug Task 47's fail-closed recovery work
+        was built to prevent, just newly reintroduced at a different
+        layer.
+
+        Fix: connect() now actually PROVES connectivity by opening a real
+        SerialInterface and closing it - matching send_packet()/get_*()'s
+        already-established per-call open/use/close pattern. This is not
+        a bare OS-level port open: meshtastic.stream_interface.
+        StreamInterface.__init__ (default connectNow=True, noProto=False
+        - unchanged by _open_interface()) already calls connect()+
+        waitForConfig() synchronously inside the constructor and raises
+        if the device never responds (verified by reading the actually-
+        installed library source on TAP2, not assumed) - so a clean
+        open+close is a real protocol-level handshake, not a false
+        positive for "something else is plugged into this port". Success/
+        failure is recorded in self._last_probe_ok (see __init__), which
+        is_connected()/get_connection_info() now read instead of
+        _listen_process - this instance's role is fully stateless-per-
+        call, so that's the only state left for them to reflect.
+        """
         if descriptor.type != ConnectionType.SERIAL:
             raise TransportError(
                 TransportErrorCode.UNSUPPORTED, f"SerialTransport cannot connect to {descriptor.type}"
@@ -241,24 +276,22 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
         self._port = descriptor.address or self._port
 
         if force:
-            # Same reasoning as _claim_radio()'s "DELIBERATE DIVERGENCE"
-            # comment: hold radio_lock for the whole stop+wait sequence,
-            # not just individual reads/writes of _listen_process, so a
-            # concurrent send_text()/send_messages()/etc. (which now goes
-            # through _claim_radio() under the same lock) cannot race a
-            # force-reconnect's teardown.
+            # _wait_serial_release() (a real OS-level `lsof` check against
+            # a leftover process still holding the port) stays - genuinely
+            # useful regardless of which process's state is being asked
+            # about. _stop_listener_process() dropped: this instance's
+            # _listen_process is always None (see __init__), so it was
+            # already a guaranteed no-op here, just one that wasted 1.5s
+            # (self._pause_listen.set(); time.sleep(1.5)) setting a local
+            # Event nothing else in this process reads meaningfully.
             with self._radio_lock:
-                self._stop_listener_process()
                 self._wait_serial_release(timeout=timeout)
 
         def _do_connect():
-            self._pause_listen.clear()
-            deadline = time.time() + timeout
-            while time.time() < deadline:
-                if self.is_connected():
-                    return
-                time.sleep(0.2)
-            raise TransportError(TransportErrorCode.TIMEOUT, f"connect() exceeded {timeout}s")
+            self._last_probe_ok = False
+            interface = self._open_interface()  # blocks on the real handshake, raises on failure
+            interface.close()
+            self._last_probe_ok = True
 
         self._call_with_timeout(_do_connect, timeout=timeout, what="connect()")
         self._connected_since = time.time()
@@ -266,11 +299,16 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
         return self.get_connection_info()
 
     def disconnect(self, *, timeout: float = 15.0) -> None:
-        def _do_disconnect():
-            self._stop_listener_process()
-
-        self._call_with_timeout(_do_disconnect, timeout=timeout, what="disconnect()")
+        """No-op by design, not by accident (Task 48 follow-up, explicit
+        decision): this instance never holds a persistent interface
+        between calls (every operation opens/uses/closes its own, same as
+        send_packet()/get_*()/the fixed connect() above) - there is
+        nothing to release. Still marks _last_probe_ok False, so a
+        subsequent get_connection_info() (e.g. the one connect() itself
+        returns after a later reconnect()) doesn't keep reporting a stale
+        CONNECTED from before this call."""
         self._connected_since = None
+        self._last_probe_ok = False
 
     def reconnect(self, *, timeout: float = 30.0) -> ConnectionInfo:
         self.disconnect(timeout=min(timeout, 15.0))
@@ -281,9 +319,11 @@ class SerialTransport(TimeoutEnforced, RadioTransport):
         )
 
     def is_connected(self) -> bool:
-        with self._radio_lock:
-            proc = self._listen_process
-        return proc is not None and proc.poll() is None
+        # Task 48 follow-up: NOT self._listen_process (see __init__'s
+        # comment on _last_probe_ok) - this instance never runs
+        # run_listener(), so that state belongs exclusively to Core's own,
+        # separate SerialTransport instance and was never meaningful here.
+        return self._last_probe_ok
 
     def get_listener_pid(self) -> Optional[int]:
         """NOT part of the RadioTransport ABC - Serial-specific status

--- a/meshsrv/radio_transport.py
+++ b/meshsrv/radio_transport.py
@@ -62,8 +62,29 @@ class TransportErrorCode(str, Enum):
 # Neutral models — plain data, no protobuf/library types anywhere below.
 # ---------------------------------------------------------------------------
 
-@dataclass(frozen=True)
+@dataclass
 class TransportError(Exception):
+    """NOT frozen (Task 48 follow-up, live-caught): exception objects are
+    inherently mutable in a couple of places by Python's own machinery
+    (__traceback__, __cause__/__context__ via `raise ... from ...`) -
+    freezing this was a mismatch with that contract from the moment this
+    class was introduced (Task 43.5), just never triggered until a real
+    TransportError propagated out of a generator-based @contextmanager
+    (claim_for_external_command()/_claim_radio()) for the first time:
+    contextlib's _GeneratorContextManager.__exit__ does
+    `exc.__traceback__ = traceback` when letting an exception through
+    unchanged, which a frozen dataclass's __setattr__ rejects outright -
+    dataclasses.FrozenInstanceError, masking the real underlying error.
+    Reproduced in isolation and confirmed fixed by dropping frozen=True
+    before this change landed; see
+    tests/test_adapter_ipc_client.py::test_transport_error_raised_inside_claim_propagates_cleanly_not_frozeninstanceerror
+    for the real-path regression test (not just the isolated repro).
+
+    Losing frozen=True's hashability (eq=True + not frozen -> __hash__ is
+    None) is fine here - checked before this change: nothing in this
+    codebase uses a TransportError instance as a dict key or set member.
+    """
+
     code: TransportErrorCode
     message: str
 

--- a/tests/test_adapter_ipc_client.py
+++ b/tests/test_adapter_ipc_client.py
@@ -409,3 +409,39 @@ def test_claim_busy_error_propagates_unchanged_without_reaching_the_adapter():
     assert excinfo.value.code == TransportErrorCode.BUSY
     assert supervisor._proc is None  # never spawned - the claim failed before any IPC attempt
     assert transport.get_connection_info().last_error.code == TransportErrorCode.BUSY
+
+
+def test_transport_error_raised_inside_claim_propagates_cleanly_not_frozeninstanceerror():
+    """Real-path regression test for the live-caught FrozenInstanceError
+    bug (Task 48 follow-up review requirement - the isolated minimal
+    repro proved the mechanism, this proves the fix closes it in this
+    codebase's actual code path, not just in principle).
+
+    _FakeCoreSerialTransport.claim_for_external_command() is decorated
+    with @contextlib.contextmanager, exactly like the real
+    SerialTransport._claim_radio() it stands in for - a generator-based
+    context manager, not a class-based one. That distinction is exactly
+    what matters here: contextlib's _GeneratorContextManager.__exit__
+    does `exc.__traceback__ = traceback` when letting an exception
+    through unchanged, which used to crash on TransportError's old
+    frozen=True with dataclasses.FrozenInstanceError, masking whatever
+    the real error was.
+
+    This test forces the wrapped IPC call itself to raise a real
+    TransportError(TIMEOUT) - via fake_adapter.py's "hang" behavior and
+    a short timeout, the same mechanism (AdapterSupervisor.call() timing
+    out) that produced the live 87s timeout on TAP2 - from *inside* the
+    real `with core_serial_transport.claim_for_external_command():`
+    block, then asserts a clean TransportError(TIMEOUT) with its
+    original message reaches the caller - not FrozenInstanceError, not
+    any other masking exception."""
+    supervisor = _make_supervisor()
+    core_serial = _FakeCoreSerialTransport()
+    transport = AdapterIPCTransport(ConnectionType.SERIAL, supervisor, core_serial_transport=core_serial)
+
+    with pytest.raises(TransportError) as excinfo:
+        transport._call("get_metadata", {"_test_behavior": "hang"}, 1.0)
+
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+    assert "did not respond within" in excinfo.value.message
+    assert core_serial.claim_calls == 1

--- a/tests/test_serial_transport_timeout.py
+++ b/tests/test_serial_transport_timeout.py
@@ -14,6 +14,7 @@ import pytest
 from adapters.meshtastic.serial_transport import SerialTransport
 from meshsrv.radio_transport import (
     ConnectionDescriptor,
+    ConnectionState,
     ConnectionType,
     OutgoingMessage,
     TransportError,
@@ -218,7 +219,15 @@ def test_concurrent_connect_and_send_do_not_race_prepare_phase():
                 timeout=0.3,
             )
         except TransportError:
-            pass  # expected: no run_listener() thread here to ever report is_connected()
+            # Task 48 follow-up: connect() now actually opens/closes
+            # _open_interface() (stubbed above) instead of polling
+            # is_connected() against a listener process this instance
+            # never owns - with a fake interface that never raises, this
+            # should succeed well within 0.3s, so this except is no
+            # longer the expected path (kept defensively: this test's
+            # actual point is the critical-section overlap check below,
+            # not connect()'s own success/failure).
+            pass
 
     def run_send():
         transport.send_text(
@@ -239,3 +248,87 @@ def test_concurrent_connect_and_send_do_not_race_prepare_phase():
         "overlapped - radio_lock is not fully serializing the prepare "
         "sequence, reintroducing the serial-port-contention risk"
     )
+
+
+# --- Task 48 follow-up: connect()/disconnect() state correctness ----------
+
+
+def test_connect_reports_state_connected_not_disconnected_after_a_real_probe():
+    """Task 48 follow-up review requirement: proving connect() no longer
+    raises is not enough - it must also report the RIGHT state
+    afterward, not silently fall back to DISCONNECTED via a dead
+    is_connected() check against a listener process this instance never
+    owns (the second, distinct bug found alongside the polling-loop
+    fix). Full path through the real connect() (not a mock of
+    connect() itself) with only _open_interface() stubbed - proves
+    is_connected()/get_connection_info() correctly derive from the new
+    _last_probe_ok state set by _do_connect()'s real body."""
+    transport = _make_transport()
+
+    class _FakeInterface:
+        def close(self):
+            pass
+
+    transport._open_interface = lambda: _FakeInterface()
+
+    info = transport.connect(
+        ConnectionDescriptor(type=ConnectionType.SERIAL, address="/dev/ttyFAKE"),
+        timeout=5.0,
+    )
+
+    assert info.state == ConnectionState.CONNECTED
+    assert transport.is_connected() is True
+
+
+def test_connect_reports_state_disconnected_when_the_probe_fails():
+    """Mirror of the success case: a failing probe (device never
+    responds - matches StreamInterface.__init__ raising when the real
+    handshake fails) must leave is_connected() reporting False, not a
+    stale True from a previous successful connect()."""
+    transport = _make_transport()
+
+    class _FakeInterface:
+        def close(self):
+            pass
+
+    transport._open_interface = lambda: _FakeInterface()
+    transport.connect(
+        ConnectionDescriptor(type=ConnectionType.SERIAL, address="/dev/ttyFAKE"), timeout=5.0
+    )
+    assert transport.is_connected() is True  # sanity: really was connected first
+
+    def _raise_open():
+        raise TransportError(TransportErrorCode.DEVICE_NOT_FOUND, "radio did not respond")
+
+    transport._open_interface = _raise_open
+
+    with pytest.raises(TransportError):
+        transport.connect(
+            ConnectionDescriptor(type=ConnectionType.SERIAL, address="/dev/ttyFAKE"), timeout=5.0
+        )
+
+    assert transport.is_connected() is False
+
+
+def test_disconnect_is_an_explicit_successful_noop_and_clears_probe_state():
+    """Task 48 follow-up, explicit decision (not silent): this instance
+    never holds a persistent interface between calls, so disconnect()
+    has nothing to release - it must still return cleanly (no
+    exception) and mark the connection no longer proven, so a stale
+    CONNECTED doesn't linger after disconnect()."""
+    transport = _make_transport()
+
+    class _FakeInterface:
+        def close(self):
+            pass
+
+    transport._open_interface = lambda: _FakeInterface()
+    transport.connect(
+        ConnectionDescriptor(type=ConnectionType.SERIAL, address="/dev/ttyFAKE"), timeout=5.0
+    )
+    assert transport.is_connected() is True
+
+    transport.disconnect(timeout=5.0)  # must not raise
+
+    assert transport.is_connected() is False
+    assert transport.get_connection_info().state == ConnectionState.DISCONNECTED

--- a/tests/test_serial_transport_timeout.py
+++ b/tests/test_serial_transport_timeout.py
@@ -280,6 +280,50 @@ def test_connect_reports_state_connected_not_disconnected_after_a_real_probe():
     assert transport.is_connected() is True
 
 
+def test_abandoned_connect_thread_cannot_retroactively_overwrite_probe_state():
+    """Task 48 follow-up review requirement: _last_probe_ok must never be
+    written from inside the tier-1-abandoned background thread
+    (_call_with_timeout()'s documented tier-1/tier-2 gap - a timeout
+    releases the caller immediately but does not kill the thread still
+    running _do_connect()). Before this fix, a slow-but-eventually-
+    successful open() could finish AFTER the caller already received
+    TransportError(TIMEOUT) and silently flip _last_probe_ok back to
+    True behind the caller's back - a live-caught, real risk, not
+    hypothetical. Proven here: a fake interface whose open() sleeps
+    longer than the caller's declared timeout but then succeeds -
+    connect() must raise TIMEOUT on time, and is_connected() must still
+    read False even after waiting long enough for the abandoned thread
+    to have actually finished (it's a daemon thread, so the test doesn't
+    need to wait for it explicitly - just long enough that if it were
+    still writing shared state, this test would catch it)."""
+    transport = _make_transport()
+
+    class _SlowThenOkInterface:
+        def close(self):
+            pass
+
+    def _slow_open():
+        time.sleep(0.4)
+        return _SlowThenOkInterface()
+
+    transport._open_interface = _slow_open
+
+    with pytest.raises(TransportError) as excinfo:
+        transport.connect(
+            ConnectionDescriptor(type=ConnectionType.SERIAL, address="/dev/ttyFAKE"), timeout=0.1
+        )
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+
+    # Give the abandoned background thread time to actually finish its
+    # slow-but-successful open()+close() - if _last_probe_ok were still
+    # written from inside _do_connect(), this sleep is exactly the
+    # window in which it would flip back to True after the fact.
+    time.sleep(0.5)
+
+    assert transport.is_connected() is False
+    assert transport.get_connection_info().state == ConnectionState.DISCONNECTED
+
+
 def test_connect_reports_state_disconnected_when_the_probe_fails():
     """Mirror of the success case: a failing probe (device never
     responds - matches StreamInterface.__init__ raising when the real


### PR DESCRIPTION
## Summary
Three related but distinct bugs, all live-caught on TAP2 while re-verifying the previous serial-claim fix (PR #121).

**1. `TransportError` was `@dataclass(frozen=True)`.** A real `TransportError` raised from inside `claim_for_external_command()` (a generator-based `@contextmanager`) crashed with `dataclasses.FrozenInstanceError` instead of propagating cleanly - `contextlib`'s `_GeneratorContextManager.__exit__` does `exc.__traceback__ = traceback` when letting an exception through unchanged, which a frozen dataclass rejects. This masked the real underlying error (a genuine adapter timeout) behind an unrelated crash message. Pre-existing since Task 43.5 (`_claim_radio()` is already used internally by `send_packet()`/`get_local_node()`/etc.), just never triggered before a `TransportError` propagated through a generator-based context manager for the first time. Fixed by dropping `frozen=True` - confirmed nothing in the codebase relies on `TransportError` being hashable.

**2. `SerialTransport.connect()`'s adapter-side instance polled `is_connected()`, which checked `self._listen_process`** - state that only Core's own, separate `SerialTransport` instance ever populates (Stage A: `run_listener()` never runs on the adapter's instance). The poll loop could never succeed, so `connect()`/`reconnect()` always burned their full timeout and raised `TIMEOUT` - live-confirmed as an 87s failure on a 90s budget, not radio-side slowness. This is a direct, new consequence of the process split (Task 47's live verification predates it and tested the in-process model, where this confusion couldn't exist).

Fixed by having `connect()` actually prove connectivity: open a real `SerialInterface` and close it, matching `send_packet()`/`get_*()`'s already-established per-call open/use/close pattern. Verified against the real, installed `meshtastic` library source on TAP2 (not assumed) that `StreamInterface.__init__` already performs a full `connect()`+`waitForConfig()` handshake synchronously and raises on a non-responding device - so this is a real protocol-level proof of connectivity, not a bare OS-level port open.

Closes a second bug in the same method: even after the probe itself is fixed, the old `get_connection_info()` would still have reported `DISCONNECTED` after a proven-good `connect()` (same dead `is_connected()` check) - the same "state lies about a successful call" class of bug Task 47's fail-closed recovery work was built to prevent. Success/failure is now tracked in a new `self._last_probe_ok` field, which `is_connected()`/`get_connection_info()` read instead. `disconnect()` is now an explicit, documented no-op (nothing persistent to release, matching this instance's fully stateless-per-call role) rather than an accidental one via the same dead state.

`_SWITCH_CONNECT_TIMEOUT_S=90` needs no recalibration - it's an outer ceiling, not a target; real handshakes on this hardware already complete well under 15s via the same `_open_interface()` pattern used elsewhere.

**3. (Follow-up review finding) `_last_probe_ok` was being written from inside `_do_connect()`** - which runs on a tier-1-abandoned background thread (`_call_with_timeout()`'s own documented tier-1/tier-2 gap: a timeout releases the caller immediately but does not kill the thread still running the wrapped function). A slow-but-eventually-successful `open()` could finish *after* the caller already received `TransportError(TIMEOUT)` and silently flip `_last_probe_ok` back to `True` behind the caller's back - a live, real risk, not hypothetical (previously an abandoned thread only wasted resources, never mutated externally-visible state). Fixed: `_do_connect()` no longer touches `_last_probe_ok` at all; both writes now happen on the calling thread only - pessimistically `False` before attempting, `True` only after `_call_with_timeout()` actually returns (exclusively on genuine in-budget success).

## Test plan
- [x] `test_transport_error_raised_inside_claim_propagates_cleanly_not_frozeninstanceerror` - real-path regression (not just the isolated repro) proving a `TransportError` raised inside a real generator-based `claim_for_external_command()` propagates cleanly.
- [x] `test_connect_reports_state_connected_not_disconnected_after_a_real_probe` / `test_connect_reports_state_disconnected_when_the_probe_fails` - proves `connect()`'s returned state is correct in both directions, not just that it doesn't raise.
- [x] `test_disconnect_is_an_explicit_successful_noop_and_clears_probe_state` - proves the no-op decision explicitly, not by absence of a crash.
- [x] `test_abandoned_connect_thread_cannot_retroactively_overwrite_probe_state` - a slow-but-succeeding interface open, past the caller's timeout - proves `connect()` still raises `TIMEOUT` on time and `is_connected()` stays `False` even after the abandoned thread has had time to actually finish. Confirmed this test fails against the prior version (temporarily reverted, verified the failure, restored the fix) before landing.
- [x] Full suite - 314 passed, 24 skipped.
- [ ] Live re-verification on TAP2 (next step): the original step-3 scenario (time-sync after listener-reconnect overlapping a serial IPC call) re-run to a clean, unambiguous result - not just green unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)