### PR TITLE
fix: dedupe README's License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,11 +1818,7 @@ Providing detailed information helps identify and resolve problems more quickly.
 
 ## License
 
-This project is released under the MIT License.
-
-You are free to use, modify and distribute the software in accordance with the terms of the license.
-
-See the [LICENSE](LICENSE) file for details.
+See the [License](#license) section near the top of this document — MeshCenter's own code is MIT-licensed, with the GPLv3-licensed `meshtastic` dependency isolated in `adapters/meshtastic/` behind a process boundary.
 
 ---
 


### PR DESCRIPTION
## Summary
PR #124 added a full License section near the top of `README.md` but missed a second, older "## License" section near the bottom (next to Acknowledgements) - stale, incomplete (MIT-only, no mention of the GPLv3-isolated adapter), and a second independent source of truth for the same question in one file. Replaced with a short pointer back to the real section instead of duplicating or contradicting it.

## Test plan
- [x] Full suite - 318 passed, 24 skipped (docs-only change).
- [x] Confirmed both `## License` headers still resolve distinctly (`#license` / `#license-1` via GitHub's anchor algorithm) so the pointer link targets the correct, full section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)