### PR TITLE
Fix open redirect in /login's next parameter

### DIFF
--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -9,7 +9,7 @@ POST /api/settings merge-and-replace in api_settings.py, and the hash is
 never included in a settings.json snapshot handed back to the browser.
 """
 
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from flask import jsonify, redirect, request, render_template, session
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -39,6 +39,38 @@ def load_auth_state(auth_file, bootstrap_enabled=False, bootstrap_password_hash=
         "enabled": bool(bootstrap_enabled) and bool(bootstrap_password_hash.strip()),
         "password_hash": bootstrap_password_hash,
     }
+
+
+def _is_safe_redirect_target(target):
+    """True only for a same-origin relative path/query/fragment - the
+    login route's `next` param must never send a browser off-origin.
+
+    Not just a startswith("/")/startswith("//") check (what this
+    replaced): independently reproduced a live open redirect against
+    that exact old check via `next=/%09/evil.example` - real browser
+    navigation confirmed, not just a suspicious-looking string. Werkzeug
+    silently strips the tab character while building the Location header,
+    turning `/\t/evil.example` into `//evil.example` (a protocol-relative
+    absolute URL) *after* the old prefix check already passed it.
+    urlsplit() resolves scheme/netloc correctly for this case (and
+    similar ones) because it does real URL parsing, not a guess at one
+    specific bypass character.
+
+    Backslash (`/\\evil.example`) is rejected explicitly too, even though
+    it was independently verified NOT to be exploitable against the
+    Werkzeug version this project currently runs (it percent-encodes `\\`
+    to `%5C` before the Location header is ever sent, so a browser never
+    sees a raw backslash to normalize) - relying on that as the only
+    defense would silently break if Werkzeug's encoding behavior ever
+    changes, and urlsplit() alone does not catch it (Python's URL parser
+    doesn't treat backslash as a separator the way browsers do).
+    """
+    if not target or not isinstance(target, str):
+        return False
+    if not target.startswith("/") or target.startswith("//") or "\\" in target:
+        return False
+    parsed = urlsplit(target)
+    return not parsed.scheme and not parsed.netloc
 
 
 def is_protected(auth_state):
@@ -91,7 +123,7 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
             return redirect("/")
 
         next_url = request.values.get("next") or "/"
-        if not next_url.startswith("/") or next_url.startswith("//"):
+        if not _is_safe_redirect_target(next_url):
             next_url = "/"
 
         error = None

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,14 +1,19 @@
 """Tests for api/api_auth.py's load_auth_state()/is_protected() - the
 bootstrap and lockout-avoidance logic behind the optional password
-protection feature added in PR #63. No server.py import needed; this module
-has no hardware/CLI dependencies of its own.
+protection feature added in PR #63 - plus _is_safe_redirect_target()/the
+login route's `next` handling (open-redirect fix, see that function's own
+docstring for the live-reproduced vulnerability this replaced). No
+server.py import needed; this module has no hardware/CLI dependencies of
+its own.
 """
 
 import json
+import threading
 
+from flask import Flask
 from werkzeug.security import generate_password_hash
 
-from api.api_auth import is_protected, load_auth_state
+from api.api_auth import _is_safe_redirect_target, is_protected, load_auth_state, register_auth_routes
 
 
 def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
@@ -66,3 +71,76 @@ def test_is_protected_tolerates_missing_keys():
     assert is_protected({}) is False
     assert is_protected({"enabled": True}) is False
     assert is_protected({"password_hash": "somehash"}) is False
+
+
+def test_is_safe_redirect_target_accepts_ordinary_same_origin_paths():
+    assert _is_safe_redirect_target("/") is True
+    assert _is_safe_redirect_target("/map") is True
+    assert _is_safe_redirect_target("/settings?tab=general") is True
+    assert _is_safe_redirect_target("/chat#bottom") is True
+
+
+def test_is_safe_redirect_target_rejects_open_redirects():
+    # Already blocked by the old startswith("/")/startswith("//") check.
+    assert _is_safe_redirect_target("//evil.example") is False
+    assert _is_safe_redirect_target("http://evil.example") is False
+    assert _is_safe_redirect_target("https://evil.example") is False
+    assert _is_safe_redirect_target("javascript:alert(1)") is False
+    assert _is_safe_redirect_target("") is False
+    assert _is_safe_redirect_target(None) is False
+
+    # Backslash - independently verified NOT exploitable against this
+    # project's Werkzeug version (percent-encoded to %5C before the
+    # Location header is sent - see the function's own docstring), but
+    # rejected explicitly anyway since urlsplit() alone does not catch it
+    # and relying solely on Werkzeug's current encoding behavior would be
+    # fragile.
+    assert _is_safe_redirect_target("/\\evil.example") is False
+    assert _is_safe_redirect_target("/\\/evil.example") is False
+
+    # The actual live vulnerability, independently reproduced via a real
+    # Flask test client + real browser navigation against the OLD check
+    # (see this module's git history / the investigation report): a tab
+    # character is silently stripped while Werkzeug builds the Location
+    # header, turning "/\t/evil.example" into "//evil.example" - a
+    # protocol-relative absolute URL - *after* a naive prefix check
+    # already let it through. Both the raw tab and its percent-encoded
+    # form (as it would actually arrive in a query string) must be
+    # rejected.
+    assert _is_safe_redirect_target("/\t/evil.example") is False
+
+
+def test_login_redirect_rejects_the_live_reproduced_open_redirect(tmp_path):
+    # End-to-end regression test through the real route (not just the
+    # helper function in isolation): a real login POST with the tab-
+    # stripping payload URL-encoded in the query string exactly as an
+    # attacker-supplied link would deliver it, against the actual
+    # register_auth_routes() code, not a hand-copied replica.
+    auth_file = tmp_path / "auth.json"
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    state_lock = threading.RLock()
+    auth_state = {"enabled": True, "password_hash": generate_password_hash("realpassword123")}
+    register_auth_routes(app, state_lock, auth_state, str(auth_file), lambda f: f)
+
+    client = app.test_client()
+    resp = client.post(
+        "/login?next=/%09/evil.example/marker",
+        data={"password": "realpassword123"},
+    )
+    assert resp.status_code == 302
+    assert resp.headers.get("Location") == "/"
+
+
+def test_login_redirect_still_honors_a_legitimate_next_url(tmp_path):
+    auth_file = tmp_path / "auth.json"
+    app = Flask(__name__)
+    app.secret_key = "test-secret-key"
+    state_lock = threading.RLock()
+    auth_state = {"enabled": True, "password_hash": generate_password_hash("realpassword123")}
+    register_auth_routes(app, state_lock, auth_state, str(auth_file), lambda f: f)
+
+    client = app.test_client()
+    resp = client.post("/login?next=/map", data={"password": "realpassword123"})
+    assert resp.status_code == 302
+    assert resp.headers.get("Location") == "/map"


### PR DESCRIPTION
## Summary
- Two Jules-authored branches (`fix-open-redirect-auth-...`, `fix/auth-open-redirect-prevention-...`) flagged `/login`'s `next` parameter validation, targeting a backslash bypass (`/\evil.com` -> browser-normalized to `//evil.com`). Neither branch merged — both diverged thousands of lines from main. Their idea was taken as reference and reimplemented from scratch against current `api/api_auth.py`.
- Independently verified with a real Flask test client, a real login POST against the actual `register_auth_routes()` code, and real browser navigation across two local origins (no external domain touched):
  - The **backslash class both branches targeted is not exploitable** against this project's Werkzeug (3.1.8) — it percent-encodes `\` to `%5C` before the `Location` header is ever sent. Confirmed three ways: via `redirect()`, via a manually-set raw header, and via actual browser navigation (stayed same-origin).
  - A **real, live bypass exists via a different vector neither branch tested**: `next=/%09/evil.example`. Werkzeug silently *strips* the tab character while building the `Location` header, turning `/\t/evil.example` into `//evil.example`. Confirmed via a real browser tab actually navigating cross-origin to a local "attacker" server.
- `_is_safe_redirect_target()` uses both branches' general approach (`urlsplit()`-based `netloc`/`scheme` check, which happens to catch the tab-stripping case too, since Python's URL parser strips `\t\r\n` before parsing) plus an explicit backslash rejection kept as defense-in-depth — not because it's currently reachable, but relying solely on Werkzeug's current encoding behavior would be fragile across versions.

## Test plan
- [x] Unit coverage for `_is_safe_redirect_target()` — legitimate paths + every payload checked (protocol-relative, backslash variants, the real tab-stripping payload, `javascript:`, empty/None).
- [x] Two end-to-end tests through the real `register_auth_routes()` login route: one posts the exact tab-stripping payload and asserts `Location: '/'`; one confirms a legitimate `next=/map` still redirects correctly.
- [x] Full suite: `pytest` — 327 passed, 24 skipped (pre-existing), 0 failed.
- [x] `python -m compileall .`

Both Jules branches will be closed/deleted after this merges, with a comment explaining the finding was independently reviewed and reimplemented against current code, not merged as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)