### PR TITLE
🛡️ Sentinel: Fix path traversal in node icon routes

### DIFF
--- a/api/api_node_icons.py
+++ b/api/api_node_icons.py
@@ -6,10 +6,17 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
     icons_dir = Path(data_dir) / "node_icons"
     icons_dir.mkdir(parents=True, exist_ok=True)
+    base_dir = icons_dir.resolve()
 
     def icon_path(node_id):
         safe_name = node_id.lstrip("!").lower()
-        return icons_dir / f"{safe_name}.png"
+        # Defensive path traversal check: ensure target stays strictly within icons_dir
+        target = (icons_dir / f"{safe_name}.png").resolve()
+        try:
+            target.relative_to(base_dir)
+        except ValueError:
+            return None
+        return target
 
     @app.route("/api/nodes/<node_id>/icon", methods=["GET"])
     def get_node_icon(node_id):
@@ -18,6 +25,8 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
         path = icon_path(normalized_id)
+        if path is None:
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
         if not path.exists():
             return jsonify({"ok": False, "error": "Node icon not found"}), 404
 
@@ -29,6 +38,10 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
     def upload_node_icon(node_id):
         normalized_id = node_id if node_id.startswith("!") else f"!{node_id}"
         if not node_id_validator(normalized_id):
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
+
+        destination = icon_path(normalized_id)
+        if destination is None:
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
         uploaded = request.files.get("icon")
@@ -49,7 +62,6 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
                 x = (256 - source.width) // 2
                 y = (256 - source.height) // 2
                 canvas.alpha_composite(source, (x, y))
-                destination = icon_path(normalized_id)
                 temporary = destination.with_suffix(".tmp")
                 canvas.save(temporary, format="PNG", optimize=True)
                 temporary.replace(destination)
@@ -69,6 +81,8 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
         path = icon_path(normalized_id)
+        if path is None:
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
         if path.exists():
             path.unlink()
         return jsonify({"ok": True, "node_id": normalized_id})

--- a/tests/test_node_id_validation.py
+++ b/tests/test_node_id_validation.py
@@ -60,3 +60,25 @@ def test_normalize_node_id_passes_through_well_formed_id(server_module):
 def test_normalize_node_id_returns_none_for_empty_input(server_module):
     assert server_module.normalize_node_id("") is None
     assert server_module.normalize_node_id(None) is None
+
+
+def test_node_icon_path_traversal_prevention(tmp_path):
+    from pathlib import Path
+    from flask import Flask
+    import api.api_node_icons as api_node_icons
+
+    app = Flask(__name__)
+    api_node_icons.register_node_icon_routes(app, str(tmp_path), "!12345678", lambda n: True)
+
+    # Invoke view function directly with test_request_context to test icon_path traversal check
+    get_view = app.view_functions["get_node_icon"]
+    delete_view = app.view_functions["delete_node_icon"]
+
+    with app.test_request_context():
+        resp_get, status_get = get_view("!../../etc/passwd")
+        assert status_get == 400
+        assert resp_get.get_json()["error"] == "Invalid node_id"
+
+        resp_del, status_del = delete_view("!../../etc/passwd")
+        assert status_del == 400
+        assert resp_del.get_json()["error"] == "Invalid node_id"


### PR DESCRIPTION
Prevent path traversal in `api/api_node_icons.py` by verifying that resolved icon file paths stay strictly within `icons_dir`. Add tests in `tests/test_node_id_validation.py`.

---
*PR created automatically by Jules for task [17884539518716545456](https://jules.google.com/task/17884539518716545456) started by @FlintUA*