### PR TITLE
🛡️ Sentinel: [HIGH] Validate Wi-Fi SSID input

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -325,13 +325,24 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
             return jsonify({"ok": False, "error": str(e), "networks": []}), 500
         return jsonify(result)
 
+    def validate_wifi_ssid(ssid):
+        """Validate SSID to prevent option injection and standard Wi-Fi violations."""
+        if not ssid or ssid.startswith("-"):
+            return "Invalid SSID format"
+        if len(ssid.encode("utf-8")) > 32:
+            return "SSID exceeds 32 octets limit"
+        if any(ord(c) < 32 or ord(c) == 127 for c in ssid):
+            return "SSID contains invalid control characters"
+        return None
+
     @app.route("/api/system/wifi/connect", methods=["POST"])
     def api_system_wifi_connect():
         data = request.get_json(force=True)
         ssid = (data.get("ssid") or "").strip()
         password = data.get("password") or ""
-        if not ssid:
-            return jsonify({"ok": False, "error": "SSID is required"}), 400
+        ssid_err = validate_wifi_ssid(ssid)
+        if ssid_err:
+            return jsonify({"ok": False, "error": ssid_err}), 400
         def run_nmcli(args, timeout=30):
             return subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli"] + args, text=True, stderr=subprocess.STDOUT, timeout=timeout)
         try:
@@ -363,8 +374,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
     def api_system_wifi_forget():
         data = request.get_json(force=True)
         ssid = (data.get("ssid") or "").strip()
-        if not ssid:
-            return jsonify({"ok": False, "error": "SSID is required"}), 400
+        ssid_err = validate_wifi_ssid(ssid)
+        if ssid_err:
+            return jsonify({"ok": False, "error": ssid_err}), 400
         try:
             out = subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli", "connection", "delete", ssid], text=True, stderr=subprocess.STDOUT, timeout=15)
             return jsonify({"ok": True, "message": out.strip()})

--- a/tests/test_api_system_wifi.py
+++ b/tests/test_api_system_wifi.py
@@ -1,0 +1,58 @@
+"""Tests for api/api_system.py's Wi-Fi SSID input validation logic."""
+
+from unittest.mock import patch
+from flask import Flask
+
+
+def test_api_system_wifi_connect_invalid_ssid(server_module):
+    from api.api_system import register_system_routes
+
+    app = Flask(__name__)
+    register_system_routes(app)
+    client = app.test_client()
+
+    # Empty SSID
+    resp = client.post("/api/system/wifi/connect", json={"ssid": ""})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid SSID format"
+
+    # Option-injection leading hyphen
+    resp = client.post("/api/system/wifi/connect", json={"ssid": "--create-profile"})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid SSID format"
+
+    # Exceeding 32 octets limit
+    resp = client.post("/api/system/wifi/connect", json={"ssid": "a" * 33})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "SSID exceeds 32 octets limit"
+
+    # Control characters
+    resp = client.post("/api/system/wifi/connect", json={"ssid": "MyWiFi\x00Name"})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "SSID contains invalid control characters"
+
+
+def test_api_system_wifi_forget_invalid_ssid(server_module):
+    from api.api_system import register_system_routes
+
+    app = Flask(__name__)
+    register_system_routes(app)
+    client = app.test_client()
+
+    # Option-injection leading hyphen
+    resp = client.post("/api/system/wifi/forget", json={"ssid": "-d"})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid SSID format"
+
+
+def test_api_system_wifi_connect_valid_ssid(server_module):
+    from api.api_system import register_system_routes
+
+    app = Flask(__name__)
+    register_system_routes(app)
+    client = app.test_client()
+
+    with patch("subprocess.check_output", return_value="Device 'wlan0' successfully activated"):
+        resp = client.post("/api/system/wifi/connect", json={"ssid": "HomeNetwork", "password": "secretpassword"})
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Validate Wi-Fi SSID input

- **🚨 Severity:** HIGH
- **💡 Vulnerability:** Unsanitized `ssid` input in Wi-Fi management endpoints (`/api/system/wifi/connect` and `/api/system/wifi/forget`).
- **🎯 Impact:** Potential option injection via leading hyphens passed into subprocess calls to `nmcli`, control character injection, or buffer/protocol issues from exceeding the standard 32-octet Wi-Fi SSID limit.
- **🔧 Fix:** Added `validate_wifi_ssid()` in `api/api_system.py` to enforce length checks (<= 32 octets), reject leading hyphens (`-`), and block unprintable control characters.
- **✅ Verification:** Added test coverage in `tests/test_api_system_wifi.py` validating both rejected invalid inputs and accepted valid inputs. All 358 tests in pytest suite pass.

---
*PR created automatically by Jules for task [1661977680407254309](https://jules.google.com/task/1661977680407254309) started by @FlintUA*