### PR TITLE
Raise MIN_PASSWORD_LENGTH to 12 and add login throttling (P1 #6)

### DIFF
--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -55,6 +55,17 @@ _LOGIN_THROTTLE_MAX_SECONDS = 300
 # rather than kept forever, so the dict doesn't grow unboundedly if probed
 # from many different source IPs.
 _LOGIN_THROTTLE_ENTRY_TTL_SECONDS = 86400
+# fail_count itself has no upper bound - an attacker (or just enough real
+# time) can push it arbitrarily high, since a sustained attempt every
+# ~_LOGIN_THROTTLE_MAX_SECONDS keeps refreshing last_seen forever, so the
+# TTL sweep above never reclaims that entry. The exponent handed to `**`
+# must therefore be capped independently of the final delay cap: 9 is the
+# smallest exponent where BASE * 2**9 (1024s) already exceeds
+# MAX_SECONDS (300s) for the current constants, so anything past it would
+# get clamped to the same 300s regardless - capping here avoids computing
+# an ever-larger bignum (2 ** over) for every failed attempt an
+# indefinitely-persistent attacker sends.
+_LOGIN_THROTTLE_MAX_EXPONENT = 9
 
 
 def _login_throttle_delay(fail_count):
@@ -72,11 +83,17 @@ def _login_throttle_delay(fail_count):
     see test_login_throttle_delay_boundary_between_5th_and_6th_failure and
     test_login_5th_wrong_attempt_still_plain_error_6th_is_throttled, which
     pin the exact attempt-6-not-attempt-7 behavior.
+
+    `fail_count` is unbounded input (see _LOGIN_THROTTLE_MAX_EXPONENT above)
+    - this function stays cheap and correct for any fail_count, not just
+    the small values exercised by the boundary tests; see
+    test_login_throttle_delay_stays_capped_for_very_large_fail_counts.
     """
     over = fail_count - _LOGIN_THROTTLE_FREE_ATTEMPTS + 1
     if over <= 0:
         return 0
-    return min(_LOGIN_THROTTLE_BASE_SECONDS * (2 ** (over - 1)), _LOGIN_THROTTLE_MAX_SECONDS)
+    exponent = min(over - 1, _LOGIN_THROTTLE_MAX_EXPONENT)
+    return min(_LOGIN_THROTTLE_BASE_SECONDS * (2 ** exponent), _LOGIN_THROTTLE_MAX_SECONDS)
 
 
 def _generate_initial_password():

--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -18,6 +18,7 @@ open-redirect vulnerability independently reproduced and fixed there.
 
 import os
 import secrets
+import time
 from urllib.parse import quote, urlsplit
 
 from flask import jsonify, redirect, request, render_template, session
@@ -25,12 +26,57 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 from storage.json_store import safe_read_json, safe_write_json
 
-MIN_PASSWORD_LENGTH = 4
+# P1 #6 stabilization follow-up: raised from 4 to the top of the 10-12
+# range the original audit recommended - this app has full access to
+# system restart/reboot/Wi-Fi/updates once logged in, so a short password
+# is a disproportionately large blast radius for a single shared secret.
+MIN_PASSWORD_LENGTH = 12
 
 # Paths that must stay reachable without a session so the login page itself
 # (and the assets it needs) can render.
 _EXEMPT_PATH_PREFIXES = ("/static/",)
 _EXEMPT_PATHS = ("/login",)
+
+# Login throttling (P1 #6): the first few wrong-password attempts from one
+# source are free (typos happen), then the lockout window doubles each
+# attempt up to a cap. Keyed by request.remote_addr, not by account - this
+# app has exactly one shared password, no per-user identity to throttle
+# against. In-memory only (no persistence across a process restart) is a
+# deliberate choice, not an oversight: this app already runs as a single
+# gunicorn worker with all runtime state in one process's memory (see
+# CLAUDE.md's "workers = 1" rationale), and restarting the service itself
+# requires access (sudoers-gated) far beyond what this throttle defends
+# against - persisting the counter to disk would add I/O on every login
+# attempt for no realistic security benefit here.
+_LOGIN_THROTTLE_FREE_ATTEMPTS = 5
+_LOGIN_THROTTLE_BASE_SECONDS = 2
+_LOGIN_THROTTLE_MAX_SECONDS = 300
+# Stale throttle entries (nothing failed recently) are swept out on access
+# rather than kept forever, so the dict doesn't grow unboundedly if probed
+# from many different source IPs.
+_LOGIN_THROTTLE_ENTRY_TTL_SECONDS = 86400
+
+
+def _login_throttle_delay(fail_count):
+    """Seconds to lock out the *next* attempt after `fail_count` consecutive
+    failures have just been recorded. The first _LOGIN_THROTTLE_FREE_ATTEMPTS
+    failures set no lockout at all (attempt number FREE_ATTEMPTS+1 still goes
+    through unthrottled); starting with the FREE_ATTEMPTS-th failure, a
+    lockout is set immediately so attempt FREE_ATTEMPTS+1 onward is blocked,
+    doubling each time past that and capped at _LOGIN_THROTTLE_MAX_SECONDS.
+
+    Concretely, with the default of 5 free attempts: failures 1-4 set no
+    lockout (so attempt 5 is never throttled), failure 5 sets a lockout that
+    blocks attempt 6, failure 6 (once attempt 6 is eventually retried and
+    fails) doubles it, and so on. Off-by-one here is easy to get backwards -
+    see test_login_throttle_delay_boundary_between_5th_and_6th_failure and
+    test_login_5th_wrong_attempt_still_plain_error_6th_is_throttled, which
+    pin the exact attempt-6-not-attempt-7 behavior.
+    """
+    over = fail_count - _LOGIN_THROTTLE_FREE_ATTEMPTS + 1
+    if over <= 0:
+        return 0
+    return min(_LOGIN_THROTTLE_BASE_SECONDS * (2 ** (over - 1)), _LOGIN_THROTTLE_MAX_SECONDS)
 
 
 def _generate_initial_password():
@@ -149,6 +195,11 @@ def is_protected(auth_state):
 
 
 def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, resolve_ui_language=None):
+    # Closure-local, not module-level: a fresh dict per register_auth_routes()
+    # call means each test (and each real app instance) starts with a clean
+    # slate, same lifetime as auth_state itself.
+    login_throttle = {}
+
     def _save():
         with state_lock:
             safe_write_json(auth_file, auth_state)
@@ -160,6 +211,17 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
             return resolve_ui_language()
         except Exception:
             return "en"
+
+    def _client_key():
+        return request.remote_addr or "unknown"
+
+    def _prune_login_throttle(now):
+        stale = [
+            key for key, entry in login_throttle.items()
+            if now - entry.get("last_seen", 0) > _LOGIN_THROTTLE_ENTRY_TTL_SECONDS
+        ]
+        for key in stale:
+            del login_throttle[key]
 
     @app.before_request
     def _enforce_auth():
@@ -196,18 +258,46 @@ def register_auth_routes(app, state_lock, auth_state, auth_file, handle_errors, 
             next_url = "/"
 
         error = None
+        retry_after = None
         if request.method == "POST":
+            client_key = _client_key()
+            now = time.monotonic()
+
+            with state_lock:
+                _prune_login_throttle(now)
+                entry = login_throttle.get(client_key)
+                locked_until = entry["locked_until"] if entry else 0
+
+            if now < locked_until:
+                retry_after = int(locked_until - now) + 1
+                return render_template(
+                    "login.html",
+                    error="login_throttled",
+                    retry_after=retry_after,
+                    next=next_url,
+                    ui_language=_ui_language(),
+                ), 429
+
             password = request.form.get("password", "")
             if password and check_password_hash(password_hash, password):
+                with state_lock:
+                    login_throttle.pop(client_key, None)
                 session.clear()
                 session.permanent = True
                 session["authenticated"] = True
                 return redirect(next_url)
+
+            with state_lock:
+                entry = login_throttle.setdefault(client_key, {"fail_count": 0, "locked_until": 0})
+                entry["fail_count"] += 1
+                entry["last_seen"] = now
+                entry["locked_until"] = now + _login_throttle_delay(entry["fail_count"])
             error = "login_error"
 
         return render_template(
             "login.html",
             error=error,
+            retry_after=retry_after,
             next=next_url,
             ui_language=_ui_language(),
         )

--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -59,12 +59,15 @@ _LOGIN_THROTTLE_ENTRY_TTL_SECONDS = 86400
 # time) can push it arbitrarily high, since a sustained attempt every
 # ~_LOGIN_THROTTLE_MAX_SECONDS keeps refreshing last_seen forever, so the
 # TTL sweep above never reclaims that entry. The exponent handed to `**`
-# must therefore be capped independently of the final delay cap: 9 is the
-# smallest exponent where BASE * 2**9 (1024s) already exceeds
+# must therefore be capped independently of the final delay cap: 8 is the
+# smallest exponent where BASE * 2**8 (512s) already exceeds
 # MAX_SECONDS (300s) for the current constants, so anything past it would
 # get clamped to the same 300s regardless - capping here avoids computing
 # an ever-larger bignum (2 ** over) for every failed attempt an
-# indefinitely-persistent attacker sends.
+# indefinitely-persistent attacker sends. Set to 9 (one extra step of
+# margin over the strict minimum) rather than the exact boundary value, so
+# a future off-by-one in this comment's own arithmetic can't silently
+# undercut the cap.
 _LOGIN_THROTTLE_MAX_EXPONENT = 9
 
 

--- a/static/chat-updates-security.js
+++ b/static/chat-updates-security.js
@@ -181,7 +181,7 @@ async function saveSecurityPassword() {
     const newPassword = newPasswordInput?.value || '';
     const confirmPassword = confirmInput?.value || '';
 
-    if (newPassword.length < 4) {
+    if (newPassword.length < 12) {
         renderSecurityResult(window.I18N.t('system.security_password_too_short'), true);
         return;
     }

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -554,7 +554,7 @@
     "security_password_not_set_note": "Noch kein Passwort gesetzt - lege eines fest, bevor du den Schutz aktivierst.",
     "security_saved": "Gespeichert.",
     "security_password_mismatch": "Die Passwörter stimmen nicht überein.",
-    "security_password_too_short": "Das Passwort muss mindestens 4 Zeichen lang sein.",
+    "security_password_too_short": "Das Passwort muss mindestens 12 Zeichen lang sein.",
     "security_enable_requires_password": "Lege ein Passwort fest, bevor du den Schutz aktivierst.",
     "security_save_failed": "Konnte nicht gespeichert werden: {reason}",
     "security_logout_btn": "Abmelden",
@@ -1135,6 +1135,7 @@
     "login_subtitle": "Dieses MeshCenter ist passwortgeschützt.",
     "password_label": "Passwort",
     "login_error": "Falsches Passwort.",
+    "login_throttled": "Zu viele Versuche. Versuche es in {seconds} Sekunden erneut.",
     "login_submit": "Anmelden"
   }
 }

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -554,7 +554,7 @@
     "security_password_not_set_note": "No password set yet - set one before enabling protection.",
     "security_saved": "Saved.",
     "security_password_mismatch": "Passwords do not match.",
-    "security_password_too_short": "Password must be at least 4 characters.",
+    "security_password_too_short": "Password must be at least 12 characters.",
     "security_enable_requires_password": "Set a password before enabling protection.",
     "security_save_failed": "Could not save: {reason}",
     "security_logout_btn": "Sign out",
@@ -1135,6 +1135,7 @@
     "login_subtitle": "This MeshCenter is password protected.",
     "password_label": "Password",
     "login_error": "Incorrect password.",
+    "login_throttled": "Too many attempts. Try again in {seconds} seconds.",
     "login_submit": "Sign in"
   }
 }

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -554,7 +554,7 @@
     "security_password_not_set_note": "Пароль ещё не задан - задайте его перед включением защиты.",
     "security_saved": "Сохранено.",
     "security_password_mismatch": "Пароли не совпадают.",
-    "security_password_too_short": "Пароль должен содержать не менее 4 символов.",
+    "security_password_too_short": "Пароль должен содержать не менее 12 символов.",
     "security_enable_requires_password": "Задайте пароль перед включением защиты.",
     "security_save_failed": "Не удалось сохранить: {reason}",
     "security_logout_btn": "Выйти",
@@ -1135,6 +1135,7 @@
     "login_subtitle": "Этот MeshCenter защищён паролем.",
     "password_label": "Пароль",
     "login_error": "Неверный пароль.",
+    "login_throttled": "Слишком много попыток. Повторите через {seconds} сек.",
     "login_submit": "Войти"
   }
 }

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -554,7 +554,7 @@
     "security_password_not_set_note": "Пароль ще не задано - задайте його перед увімкненням захисту.",
     "security_saved": "Збережено.",
     "security_password_mismatch": "Паролі не збігаються.",
-    "security_password_too_short": "Пароль має містити щонайменше 4 символи.",
+    "security_password_too_short": "Пароль має містити щонайменше 12 символів.",
     "security_enable_requires_password": "Задайте пароль перед увімкненням захисту.",
     "security_save_failed": "Не вдалося зберегти: {reason}",
     "security_logout_btn": "Вийти",
@@ -1135,6 +1135,7 @@
     "login_subtitle": "Цей MeshCenter захищено паролем.",
     "password_label": "Пароль",
     "login_error": "Невірний пароль.",
+    "login_throttled": "Забагато спроб. Спробуйте ще раз через {seconds} с.",
     "login_submit": "Увійти"
   }
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -105,7 +105,9 @@
                     <input type="password" id="loginPassword" name="password" autofocus autocomplete="current-password" required>
                 </div>
 
-                {% if error %}
+                {% if error == 'login_throttled' %}
+                <div class="login-error" id="loginError" data-i18n="auth.login_throttled" data-retry-after="{{ retry_after }}">Too many attempts. Try again in {{ retry_after }} seconds.</div>
+                {% elif error %}
                 <div class="login-error" data-i18n="auth.login_error">Incorrect password.</div>
                 {% endif %}
 
@@ -131,7 +133,13 @@
     </script>
     <script src="/static/i18n.js?v=20260806-6"></script>
     <script>
-        window.I18N.init("{{ ui_language }}").then(function () { window.I18N.applyStaticDom(); });
+        window.I18N.init("{{ ui_language }}").then(function () {
+            window.I18N.applyStaticDom();
+            var throttledError = document.getElementById('loginError');
+            if (throttledError && throttledError.dataset.retryAfter) {
+                throttledError.textContent = window.I18N.t('auth.login_throttled', { seconds: throttledError.dataset.retryAfter });
+            }
+        });
     </script>
 </body>
 </html>

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -314,6 +314,27 @@ def test_login_throttle_delay_caps_at_max_seconds():
     assert _login_throttle_delay(100) == api_auth._LOGIN_THROTTLE_MAX_SECONDS
 
 
+def test_login_throttle_delay_stays_capped_for_very_large_fail_counts():
+    # fail_count has no upper bound (a sustained attacker keeps refreshing
+    # last_seen, so the TTL sweep never reclaims the entry) - correctness
+    # must hold far past anything the boundary tests exercise.
+    for fail_count in (1_000, 1_000_000, 10 ** 9):
+        assert _login_throttle_delay(fail_count) == api_auth._LOGIN_THROTTLE_MAX_SECONDS
+
+
+def test_login_throttle_max_exponent_constant_is_actually_sufficient():
+    # The invariant _LOGIN_THROTTLE_MAX_EXPONENT relies on: that exponent
+    # alone must already reach _LOGIN_THROTTLE_MAX_SECONDS, so the function
+    # never needs (and the code never computes) a larger one - this is what
+    # makes capping the exponent safe rather than just "usually right". If
+    # someone tightens MAX_SECONDS or loosens BASE_SECONDS without touching
+    # this constant, this test catches the cap becoming insufficient.
+    assert (
+        api_auth._LOGIN_THROTTLE_BASE_SECONDS * (2 ** api_auth._LOGIN_THROTTLE_MAX_EXPONENT)
+        >= api_auth._LOGIN_THROTTLE_MAX_SECONDS
+    )
+
+
 def test_login_5th_wrong_attempt_still_plain_error_6th_is_throttled(tmp_path, monkeypatch):
     fake_now = [1000.0]
     monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -13,6 +13,7 @@ has no hardware/CLI dependencies of its own.
 """
 
 import json
+import os
 import stat
 import sys
 import threading
@@ -23,7 +24,26 @@ from flask import Flask
 from werkzeug.security import check_password_hash, generate_password_hash
 
 import api.api_auth as api_auth
-from api.api_auth import _is_safe_redirect_target, is_protected, load_auth_state, register_auth_routes
+from api.api_auth import (
+    _is_safe_redirect_target,
+    _login_throttle_delay,
+    is_protected,
+    load_auth_state,
+    register_auth_routes,
+)
+
+
+_TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "templates")
+
+
+def _make_app(tmp_path, password="realpassword123", enabled=True):
+    auth_file = tmp_path / "auth.json"
+    app = Flask(__name__, template_folder=_TEMPLATE_DIR)
+    app.secret_key = "test-secret-key"
+    state_lock = threading.RLock()
+    auth_state = {"enabled": enabled, "password_hash": generate_password_hash(password)}
+    register_auth_routes(app, state_lock, auth_state, str(auth_file), lambda f: f)
+    return app, auth_state
 
 
 def test_load_auth_state_first_run_defaults_to_disabled(tmp_path):
@@ -240,3 +260,172 @@ def test_login_redirect_still_honors_a_legitimate_next_url(tmp_path):
     resp = client.post("/login?next=/map", data={"password": "realpassword123"})
     assert resp.status_code == 302
     assert resp.headers.get("Location") == "/map"
+
+
+# --- P1 #6: MIN_PASSWORD_LENGTH ---------------------------------------------
+
+def test_min_password_length_is_12_not_the_old_4():
+    # Pins the actual constant, not just behavior derived from it - a
+    # regression here (e.g. someone "simplifying" back to 4) must fail
+    # loudly on this line alone.
+    assert api_auth.MIN_PASSWORD_LENGTH == 12
+
+
+def test_generated_initial_password_passes_the_real_min_length_validation(tmp_path):
+    # P1 #6 explicitly asked not to assume the 16-hex-char generated
+    # password (P1 #5) clears the raised MIN_PASSWORD_LENGTH - prove it by
+    # running the actual generator output through the actual validation
+    # route (api_update_security), not a hand-copied len() check.
+    app, _ = _make_app(tmp_path)
+    client = app.test_client()
+
+    generated = api_auth._generate_initial_password()
+    assert len(generated) >= api_auth.MIN_PASSWORD_LENGTH, (
+        f"generated password is {len(generated)} chars, below MIN_PASSWORD_LENGTH="
+        f"{api_auth.MIN_PASSWORD_LENGTH}"
+    )
+
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True  # /api/security itself needs a session
+
+    resp = client.post("/api/security", json={"password": generated})
+    data = resp.get_json()
+    assert data["ok"] is True, data
+    assert data.get("error_code") != "password_too_short"
+
+
+# --- P1 #6: login throttling -------------------------------------------------
+
+def test_login_throttle_delay_boundary_between_5th_and_6th_failure():
+    # The exact off-by-one the task called out: with 5 free attempts, the
+    # 5th failed *attempt* must still render as a plain error (not 429) -
+    # which requires the lockout to already be armed by the time the 5th
+    # failure is *recorded*, so it blocks attempt #6. delay(fail_count) is
+    # "the delay this many recorded failures impose on the NEXT attempt",
+    # not on the attempt that just happened.
+    assert _login_throttle_delay(1) == 0
+    assert _login_throttle_delay(4) == 0  # attempt 5 still goes through unthrottled
+    assert _login_throttle_delay(5) == 2  # ...but now attempt 6 is blocked
+    assert _login_throttle_delay(6) == 4
+    assert _login_throttle_delay(7) == 8
+
+
+def test_login_throttle_delay_caps_at_max_seconds():
+    assert _login_throttle_delay(100) == api_auth._LOGIN_THROTTLE_MAX_SECONDS
+
+
+def test_login_5th_wrong_attempt_still_plain_error_6th_is_throttled(tmp_path, monkeypatch):
+    fake_now = [1000.0]
+    monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])
+
+    app, _ = _make_app(tmp_path)
+    client = app.test_client()
+    overrides = {"REMOTE_ADDR": "10.0.0.5"}
+
+    for attempt in range(1, 6):  # attempts 1..5 - all free
+        resp = client.post(
+            "/login", data={"password": "wrong"}, environ_overrides=overrides
+        )
+        assert resp.status_code == 200, f"attempt {attempt} should render the plain login form, got {resp.status_code}"
+        assert b"auth.login_error" in resp.data or b"Incorrect password" in resp.data
+        assert resp.status_code != 429
+
+    # 6th failure - now throttled.
+    resp = client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+    assert resp.status_code == 429
+    assert b'id="loginError"' in resp.data  # throttled branch, not the plain login_error one
+
+    # Correct password no longer helps while still locked out - proves the
+    # lockout check runs before the password is even checked.
+    resp = client.post("/login", data={"password": "realpassword123"}, environ_overrides=overrides)
+    assert resp.status_code == 429
+
+
+def test_login_throttle_lifts_once_the_backoff_window_elapses(tmp_path, monkeypatch):
+    fake_now = [1000.0]
+    monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])
+
+    app, _ = _make_app(tmp_path)
+    client = app.test_client()
+    overrides = {"REMOTE_ADDR": "10.0.0.6"}
+
+    for _ in range(6):  # trip the throttle (6th failure -> 2s lockout)
+        client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+
+    resp = client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+    assert resp.status_code == 429
+
+    fake_now[0] += 3  # past the 2s lockout window
+    resp = client.post("/login", data={"password": "realpassword123"}, environ_overrides=overrides)
+    assert resp.status_code == 302
+    assert resp.headers.get("Location") == "/"
+
+
+def test_login_throttle_is_scoped_per_source_ip(tmp_path, monkeypatch):
+    fake_now = [1000.0]
+    monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])
+
+    app, _ = _make_app(tmp_path)
+    client = app.test_client()
+
+    for _ in range(6):
+        client.post("/login", data={"password": "wrong"}, environ_overrides={"REMOTE_ADDR": "10.0.0.7"})
+    blocked = client.post("/login", data={"password": "wrong"}, environ_overrides={"REMOTE_ADDR": "10.0.0.7"})
+    assert blocked.status_code == 429
+
+    # A different source IP is unaffected by the first one's failures.
+    resp = client.post(
+        "/login", data={"password": "realpassword123"}, environ_overrides={"REMOTE_ADDR": "10.0.0.8"}
+    )
+    assert resp.status_code == 302
+
+
+def test_login_success_resets_the_failure_counter(tmp_path, monkeypatch):
+    fake_now = [1000.0]
+    monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])
+
+    app, _ = _make_app(tmp_path)
+    client = app.test_client()
+    overrides = {"REMOTE_ADDR": "10.0.0.9"}
+
+    for _ in range(4):  # under the free-attempt threshold
+        client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+
+    resp = client.post("/login", data={"password": "realpassword123"}, environ_overrides=overrides)
+    assert resp.status_code == 302  # logged in - counter should now be cleared
+
+    # A fresh session for the same IP fails again - if the counter had NOT
+    # been reset, this would already be past the free-attempt threshold.
+    client2 = app.test_client()
+    resp = client2.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+    assert resp.status_code == 200
+    assert b'id="loginError"' not in resp.data
+
+
+def test_login_throttle_never_engages_while_auth_is_disabled(tmp_path, monkeypatch):
+    # Explicit check requested for the interaction with `if not protected`:
+    # while auth is disabled, login() returns its early redirect before the
+    # throttle code ever runs (see api_auth.py's login(), the `if not
+    # protected: return redirect("/")` line precedes the `if request.method
+    # == "POST":` throttle block) - so failed attempts against a disabled
+    # instance must never pre-warm a lockout for when protection is later
+    # turned on from the UI.
+    fake_now = [1000.0]
+    monkeypatch.setattr(api_auth.time, "monotonic", lambda: fake_now[0])
+
+    app, auth_state = _make_app(tmp_path, enabled=False)
+    client = app.test_client()
+    overrides = {"REMOTE_ADDR": "10.0.0.10"}
+
+    for _ in range(10):  # far past the free-attempt threshold, if it counted at all
+        resp = client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+        assert resp.status_code == 302
+        assert resp.headers.get("Location") == "/"
+
+    # Now flip protection on, exactly as api_update_security() would via
+    # the Settings UI, and confirm the very first attempt against this same
+    # IP is treated as attempt #1, not #11.
+    auth_state["enabled"] = True
+    resp = client.post("/login", data={"password": "wrong"}, environ_overrides=overrides)
+    assert resp.status_code == 200, "must render the ordinary error form, not be pre-throttled"
+    assert b'id="loginError"' not in resp.data


### PR DESCRIPTION
## Summary
- `MIN_PASSWORD_LENGTH`: 4 → 12 (`api/api_auth.py`) — top of the original audit's 10-12 range, given this app has full system restart/reboot/Wi-Fi/update access once logged in.
- Synced the same limit into `static/chat-updates-security.js`'s independent client-side check and the `security_password_too_short` i18n string in all 4 catalogs (`en`/`de`/`ru`/`uk`) — both previously hardcoded `4` on their own.
- Verified (test) that the P1 #5 generated initial password (16 hex chars) still clears the raised threshold via the real `/api/security` validation route, not an assumption.
- Added login throttling to `/login` (previously none at all): per-source-IP (`request.remote_addr` — one shared password app-wide, no per-account identity), 5 free failed attempts, then exponential backoff (2s → 4s → 8s → … capped at 300s) *before* the password is even checked. In-memory, closure-local to `register_auth_routes()` — deliberately not persisted across a restart (single-gunicorn-worker app, restarting the service already requires sudoers-gated access beyond what this defends against).
- `429` responses render a new `auth.login_throttled` i18n key (all 4 catalogs), `{seconds}` interpolated client-side.

## Notable fix during implementation
Caught and fixed a real off-by-one in the backoff formula: the initial version armed the lockout one attempt too late (blocking attempt #7 instead of #6). Reworked `_login_throttle_delay()` so the 5th recorded failure arms the lockout for attempt #6, and pinned the exact boundary with `test_login_throttle_delay_boundary_between_5th_and_6th_failure` / `test_login_5th_wrong_attempt_still_plain_error_6th_is_throttled`.

Also explicitly tested the `if not protected` interaction: `login()`'s early `return redirect("/")` for a disabled instance runs before any throttle code, so failed attempts against a disabled instance never pre-warm a lockout for when protection is turned on later — see `test_login_throttle_never_engages_while_auth_is_disabled`.

## Test plan
- [x] `pytest` — 339 passed, 25 skipped (POSIX/Linux-only, expected on this dev machine)
- [x] 10 new tests in `tests/test_api_auth.py`: MIN_PASSWORD_LENGTH pin, generated-password validation, throttle boundary (5th vs 6th), backoff-window expiry, per-IP scoping, counter reset on success, disabled-auth interaction
- [x] `python -m py_compile api/api_auth.py tests/test_api_auth.py`
- [x] `node --check static/chat-updates-security.js`
- [x] i18n catalog JSON validity + exact key-parity across en/de/ru/uk (flattened key-set diff empty)
- [ ] Live-test on dev (`!756f9960`) pending — will follow the same pattern as PR #134 (temporarily engage the real login flow, confirm throttling/lockout behavior against the actual running service, restore state) before merge