### PR TITLE
Fix timezone detection falling back to UTC when timedatectl is inaccessible

### DIFF
--- a/meshsrv/time_service.py
+++ b/meshsrv/time_service.py
@@ -3,8 +3,9 @@
 
 Single source of truth for system time state (NTP sync, RTC status,
 timezone) shared by the Time card, the e-paper System Screen and any future
-schedule engine. Probes ``timedatectl``/``/etc/timezone`` on a background
-thread and caches the result so request handlers never shell out directly.
+schedule engine. Probes ``timedatectl``/``/etc/timezone``/``/etc/localtime``
+on a background thread and caches the result so request handlers never
+shell out directly.
 
 RTC status (hardware/rtc_service.py's three independent stages - detected/
 configured/readable) is folded in here too, but on its own, much longer
@@ -18,6 +19,17 @@ each) on every 20s tick would be pure waste.
 is_trusted() deliberately still only looks at NTP synchronization, not RTC
 - RTC here is a boot/offline-recovery time source, not a "trusted time"
 signal for meshsrv/node_time_sync.py or meshsrv/schedule_engine.py.
+
+Timezone detection (detect_system_timezone()) is a separate fallback chain
+from NTP/Timesource probing (_probe_ntp_status()) - a system where
+``timedatectl`` is entirely inaccessible (observed on Droidian: the whole
+D-Bus query is denied, not one unsupported property) must not lose
+timezone detection just because NTP status can't be read, and vice versa.
+Each backend in the chain (timedatectl / /etc/timezone / /etc/localtime)
+has its own try/except and returns ``None`` on any failure rather than
+raising - see that function's own docstring for why. This module never
+calls ``timedatectl set-timezone`` or otherwise mutates system
+configuration - detection only.
 """
 
 from __future__ import annotations
@@ -27,6 +39,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from hardware import rtc_service
 
@@ -38,6 +51,189 @@ _CACHE_TTL = 20  # seconds
 _rtc_cache: dict[str, Any] = {}
 _rtc_cache_ts: float = 0.0
 _RTC_CACHE_TTL = 300  # seconds - see module docstring
+
+_ZONEINFO_ROOT = Path("/usr/share/zoneinfo")
+
+# Log-dedup for the timezone/NTP probing below (P1 timezone-detection fix):
+# maps a stable per-backend tag to the (exception type name, exception text)
+# last printed for it, so the same recurring failure (e.g. timedatectl
+# "Access denied" on every 20s tick) prints once, not on every _probe().
+# Manual dict + print(), not the logging module - see module docstring and
+# _log_once()'s own docstring for why comparing (type, text) is safe here.
+_tz_last_logged: dict[str, tuple[str, str]] = {}
+
+
+def _log_once(tag: str, error: Exception, message: str | None = None) -> None:
+    """Print an informational line for `error` at most once per distinct
+    (type, text) pair recorded under `tag` - avoids flooding the journal
+    with the same expected failure every _CACHE_TTL seconds, while still
+    logging again if the failure mode actually changes (a different error
+    appears, or a since-cleared one recurs differently).
+
+    Comparing (type(error).__name__, str(error)) rather than just str(error)
+    guards against two different exception types that happen to stringify
+    identically - cheap to be exact. Both halves are stable across repeated
+    calls for the same underlying failure: every subprocess call in this
+    module runs with stderr=DEVNULL, so no dynamic process output (which
+    could vary between calls - a PID, a timestamp) ever reaches str(error);
+    only the fixed argv/returncode/timeout values do (verified against
+    subprocess.CalledProcessError/FileNotFoundError/TimeoutExpired's actual
+    __str__ output - none include stderr content).
+    """
+    signature = (type(error).__name__, str(error))
+    if _tz_last_logged.get(tag) == signature:
+        return
+    _tz_last_logged[tag] = signature
+    print(message or f"[TIME] {tag} failed: {error}", flush=True)
+
+
+def _timezone_from_timedatectl() -> str | None:
+    """Query only the Timezone property, independent of NTP/Timesource -
+    a system where timedatectl is entirely inaccessible (Droidian: the
+    whole D-Bus query is denied) must not lose timezone detection just
+    because the same probe also asked for other properties. Own try/except:
+    never raises, returns None if the property can't be determined this way
+    so detect_system_timezone() falls through to the next backend."""
+    try:
+        out = subprocess.check_output(
+            ["timedatectl", "show", "-p", "Timezone"],
+            timeout=3, text=True, stderr=subprocess.DEVNULL,
+        )
+    except Exception as error:
+        _log_once(
+            "timedatectl_timezone", error,
+            "[TIME] timedatectl unavailable, using fallback timezone detection",
+        )
+        return None
+
+    for line in out.strip().splitlines():
+        if line.startswith("Timezone="):
+            value = line.split("=", 1)[1].strip()
+            return value or None
+    return None
+
+
+def _timezone_from_etc_timezone() -> str | None:
+    """Read /etc/timezone directly - present on Debian/Raspberry Pi OS/
+    Ubuntu, absent on Droidian. Own try/except: a missing file is the
+    expected, common case on systems that don't use it (no /etc/timezone
+    is not itself an error), anything else is logged once."""
+    try:
+        value = Path("/etc/timezone").read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except Exception as error:
+        _log_once("etc_timezone", error)
+        return None
+    return value or None
+
+
+def _timezone_from_localtime() -> str | None:
+    """Resolve /etc/localtime and, if it points inside the system zoneinfo
+    database, extract the IANA name from the relative path - e.g.
+    /usr/share/zoneinfo/Europe/Berlin -> "Europe/Berlin". This is the
+    fallback that actually fixes the reported Droidian bug: timedatectl is
+    denied and /etc/timezone doesn't exist there, but /etc/localtime is
+    still configured correctly.
+
+    Handles the /etc/localtime-is-a-regular-file-not-a-symlink case
+    (containers, some minimal images) without crashing: Path.resolve() on a
+    non-symlink just normalizes the same absolute path, so relative_to()
+    below raises ValueError (that path is not under _ZONEINFO_ROOT) and
+    this returns None like any other undetectable case - no special
+    handling needed, the existence check already covers it structurally.
+
+    Own try/except: never raises, returns None (not "UTC" itself - that's
+    detect_system_timezone()'s job) if this source is unusable.
+    """
+    try:
+        localtime = Path("/etc/localtime")
+        if not localtime.exists():
+            return None
+        resolved = localtime.resolve()
+        try:
+            relative = resolved.relative_to(_ZONEINFO_ROOT)
+        except ValueError:
+            return None
+        # .as_posix(), not str(): IANA timezone names are always
+        # forward-slash ("Europe/Berlin"), regardless of the host OS's own
+        # path separator - str() would use backslashes on Windows, which
+        # this code never actually runs on in production (Linux-only
+        # /etc/localtime), but the distinction matters for tests that
+        # exercise this function directly on a Windows dev machine.
+        name = relative.as_posix()
+        return name or None
+    except Exception as error:
+        _log_once("etc_localtime", error)
+        return None
+
+
+def _validate_timezone(name: str | None) -> str | None:
+    """Accept `name` only if zoneinfo actually recognizes it as an IANA
+    timezone - centralized here (not duplicated inside each
+    _timezone_from_*() backend) so "is this I/O usable" and "is this name
+    semantically valid" stay two separate concerns. An invalid name (typo,
+    truncated path, non-tzdata string) returns None so the caller falls
+    through to the next fallback instead of accepting garbage."""
+    if not name:
+        return None
+    try:
+        ZoneInfo(name)
+    except Exception:
+        return None
+    return name
+
+
+def detect_system_timezone() -> str:
+    """Return an IANA timezone name (e.g. "Europe/Berlin"), never a fixed
+    UTC offset - DST transitions must keep working automatically via
+    zoneinfo, not a hardcoded +2/+1. Tries timedatectl, then
+    /etc/timezone, then /etc/localtime, in that order; each candidate is
+    validated (see _validate_timezone()) before being accepted, and "UTC"
+    is only ever the last-resort return value, never assumed early.
+
+    This function itself never raises: each backend already guards its own
+    I/O, and the outer try/except here is a second net so a bug inside one
+    backend can never take down timezone detection for the whole probe.
+    """
+    for backend in (_timezone_from_timedatectl, _timezone_from_etc_timezone, _timezone_from_localtime):
+        try:
+            candidate = backend()
+        except Exception as error:
+            _log_once(f"{backend.__name__}_unexpected", error)
+            candidate = None
+
+        validated = _validate_timezone(candidate)
+        if validated:
+            return validated
+
+    return "UTC"
+
+
+def _probe_ntp_status() -> dict[str, Any]:
+    """Query NTPSynchronized/Timesource only - separate subprocess call from
+    timezone detection (see detect_system_timezone()) so a timezone-only
+    failure (or vice versa) never affects the other. Never raises."""
+    result: dict[str, Any] = {"synchronized": False, "source": "system"}
+    try:
+        out = subprocess.check_output(
+            ["timedatectl", "show", "-p", "NTPSynchronized", "-p", "Timesource"],
+            timeout=3, text=True, stderr=subprocess.DEVNULL,
+        )
+    except Exception as error:
+        _log_once("timedatectl_ntp", error)
+        return result
+
+    for line in out.strip().splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        value = value.strip()
+        if key == "NTPSynchronized":
+            result["synchronized"] = (value == "yes")
+        elif key == "Timesource" and value:
+            result["source"] = value
+    return result
 
 
 def _get_rtc_status() -> dict[str, Any]:
@@ -70,11 +266,13 @@ def _probe() -> dict[str, Any]:
     rtc_configured = bool(stages.get("configured", {}).get("ok"))
     rtc_readable = bool(stages.get("readable", {}).get("ok"))
 
+    ntp_status = _probe_ntp_status()
+
     result: dict[str, Any] = {
-        "synchronized": False,
-        "source": "system",
+        "synchronized": ntp_status["synchronized"],
+        "source": ntp_status["source"],
         "quality": "system",
-        "timezone": "UTC",
+        "timezone": detect_system_timezone(),
         # rtc_present kept for backward compatibility - same meaning as
         # rtc_configured ("the kernel has an RTC device configured"), not
         # the old raw Path("/sys/class/rtc/rtc0").exists() check.
@@ -83,43 +281,12 @@ def _probe() -> dict[str, Any]:
         "rtc_configured": rtc_configured,
         "rtc_readable": rtc_readable,
     }
-    try:
-        out = subprocess.check_output(
-            [
-                "timedatectl", "show",
-                "-p", "NTPSynchronized",
-                "-p", "Timesource",
-                "-p", "Timezone",
-            ],
-            timeout=3, text=True, stderr=subprocess.DEVNULL,
-        )
-        for line in out.strip().splitlines():
-            if "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            value = value.strip()
-            if key == "NTPSynchronized":
-                result["synchronized"] = (value == "yes")
-            elif key == "Timesource":
-                result["source"] = value
-            elif key == "Timezone":
-                result["timezone"] = value
-    except Exception as error:
-        print(f"[TIME] timedatectl probe failed: {error}", flush=True)
-
-    if result["timezone"] == "UTC":
-        try:
-            tz = Path("/etc/timezone").read_text().strip()
-            if tz:
-                result["timezone"] = tz
-        except Exception:
-            pass
 
     if result["synchronized"]:
         # NTP always wins, regardless of RTC state.
         result["quality"] = "synchronized"
         result["source"] = "ntp"
-    elif result["rtc_configured"] and result["rtc_readable"]:
+    elif rtc_configured and rtc_readable:
         # Configured-but-not-readable (e.g. permissions, or a different
         # device occupying /dev/rtc0 - see rtc_service.py's own docstring)
         # is deliberately NOT treated as quality "rtc" here anymore: the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,11 @@
 # CLAUDE.md: production installs `pip install -r requirements.txt` only).
 -r requirements.txt
 pytest>=7.4,<9
+# Pure-Python IANA tzdata for zoneinfo.ZoneInfo() - Linux hosts (CI,
+# production Pi) already get this from the OS, but a Windows dev machine
+# has no system tzdata at all, so DST-dependent tests in
+# tests/test_time_service.py would be blind without this. Unlike fcntl
+# (a platform-specific compiled module), this is portable data with no
+# platform restriction, so installing it is strictly better than skipping
+# those tests on non-Linux dev machines.
+tzdata

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -5,13 +5,27 @@ throughout; nothing here touches real hardware. No server.py import
 needed - this module only depends on hardware/rtc_service.py, which has
 no hardware dependency of its own at import time either.
 
-Module-level cache state (_cache/_cache_ts/_rtc_cache/_rtc_cache_ts) is
-reset around every test via an autouse fixture, same pattern
-tests/test_cpu_history.py already uses for its own module-level state.
+Module-level cache state (_cache/_cache_ts/_rtc_cache/_rtc_cache_ts,
+_tz_last_logged) is reset around every test via an autouse fixture, same
+pattern tests/test_cpu_history.py already uses for its own module-level
+state.
+
+Timezone-chain tests (P1 timezone-detection fix, MeshCenter_timezone_
+detection_TZ_2026-08-28.md) never rely on the real filesystem of whatever
+machine runs pytest - this bit the project once before (see the historical
+comment inside test_rtc_service_exception_does_not_crash_probe below,
+task 24: a test depended on the real /etc/timezone content of whichever
+machine happened to run it). _mock_etc_timezone()/_mock_etc_localtime()
+below always patch Path.read_text/.exists/.resolve explicitly, branching
+on str(self) so only the path each test cares about is faked - real
+Path instances for anything else keep working normally, and no test's
+result can depend on whether the test runner is Windows (no /etc/* paths
+at all) or Linux (real, possibly different, /etc/localtime).
 """
 
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
 
@@ -25,10 +39,49 @@ def _reset_time_service_state():
         time_service._cache_ts = 0.0
         time_service._rtc_cache = {}
         time_service._rtc_cache_ts = 0.0
+        time_service._tz_last_logged = {}
 
     _reset()
     yield
     _reset()
+
+
+def _mock_etc_timezone(monkeypatch, value: str | None) -> None:
+    """value=None simulates /etc/timezone not existing (the common,
+    non-error case on systems that don't use it, e.g. Droidian)."""
+    def _read_text(self, *args, **kwargs):
+        if self.as_posix() == "/etc/timezone" and value is not None:
+            return value
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(time_service.Path, "read_text", _read_text)
+
+
+def _mock_etc_localtime(monkeypatch, *, exists: bool, resolved_target: str | None = None) -> None:
+    """exists=False simulates no /etc/localtime at all. When exists=True,
+    resolved_target is what Path.resolve() should return for it -
+    resolved_target=None simulates /etc/localtime being a regular file
+    (not a symlink), where resolve() just normalizes to the same path
+    (doc section 18's container case)."""
+    def _exists(self, *args, **kwargs):
+        if self.as_posix() == "/etc/localtime":
+            return exists
+        return False
+
+    def _resolve(self, *args, **kwargs):
+        if self.as_posix() == "/etc/localtime":
+            return Path(resolved_target) if resolved_target is not None else self
+        return self
+
+    monkeypatch.setattr(time_service.Path, "exists", _exists)
+    monkeypatch.setattr(time_service.Path, "resolve", _resolve)
+
+
+def _mock_no_file_fallbacks(monkeypatch) -> None:
+    """Both /etc/timezone and /etc/localtime absent - isolates a test to
+    whatever subprocess.check_output mock it sets up itself."""
+    _mock_etc_timezone(monkeypatch, value=None)
+    _mock_etc_localtime(monkeypatch, exists=False)
 
 
 def _timedatectl_output(synchronized: bool, timesource: str | None = None, timezone: str = "UTC") -> str:
@@ -174,19 +227,19 @@ def test_rtc_service_exception_does_not_crash_probe(monkeypatch):
 
     monkeypatch.setattr(time_service.rtc_service, "get_status", _raise)
 
-    # _probe() falls back to reading the real /etc/timezone off disk
-    # whenever the parsed timedatectl timezone is "UTC" (see its own
-    # docstring-less fallback block) - left unmocked, this test's result
-    # silently depends on the host machine's actual /etc/timezone content
-    # (e.g. "Etc/UTC" rather than "UTC" on some systems), which is exactly
-    # what broke it during review. Force that read to fail the same way it
-    # does on a system with no /etc/timezone file at all, so the mocked
-    # "UTC" from _timedatectl_output() above is what actually survives.
-    def _raise_file_not_found(self):
-        raise FileNotFoundError()
-
-    monkeypatch.setattr(time_service.Path, "read_text", _raise_file_not_found)
-
+    # Historical note (task 24): this test used to depend on the real
+    # /etc/timezone content of whichever machine ran pytest, because the
+    # old _probe() only fell back to reading it when the parsed timedatectl
+    # timezone equaled "UTC" - which it did here, since _timedatectl_output()
+    # defaults to timezone="UTC". That's now structurally impossible to hit
+    # by accident: _timezone_from_timedatectl() finds "Timezone=UTC" in the
+    # mocked subprocess output above, "UTC" validates fine via zoneinfo, and
+    # detect_system_timezone() returns it immediately - /etc/timezone and
+    # /etc/localtime are never even reached in this scenario, mocked or not.
+    # The file-fallback chain itself (timedatectl failing, /etc/timezone
+    # missing, /etc/localtime resolved) has its own dedicated tests below
+    # (test_detect_system_timezone_*) that deliberately force each backend
+    # to be reached, with real filesystem calls always mocked there.
     result = time_service._probe()  # must not raise
 
     assert result["rtc_detected"] is False
@@ -207,6 +260,11 @@ def test_timedatectl_failure_does_not_crash_probe(monkeypatch):
         time_service.rtc_service, "get_status",
         lambda **kwargs: _rtc_status(detected=True, configured=True, readable=True),
     )
+    # timedatectl failing entirely means detect_system_timezone() falls
+    # through to /etc/timezone then /etc/localtime - both explicitly
+    # mocked absent here so the result ("UTC") never depends on the real
+    # filesystem of whatever machine runs this test.
+    _mock_no_file_fallbacks(monkeypatch)
 
     result = time_service._probe()  # must not raise
 
@@ -214,6 +272,7 @@ def test_timedatectl_failure_does_not_crash_probe(monkeypatch):
     # RTC side is unaffected by the timedatectl failure - still reports
     # quality "rtc" since NTP unsynced + RTC fully ready.
     assert result["quality"] == "rtc"
+    assert result["timezone"] == "UTC"
 
 
 # ---------------- RTC caching (_RTC_CACHE_TTL) ----------------
@@ -276,3 +335,222 @@ def test_is_trusted_only_looks_at_ntp_synchronized(monkeypatch):
     monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=True))
     time_service._refresh_cache()
     assert time_service.is_trusted() is True
+
+
+# ---------------- detect_system_timezone() fallback chain ----------------
+# Tests 1-5 below map directly to
+# MeshCenter_timezone_detection_TZ_2026-08-28.md sections 17-18.
+
+def test_detect_system_timezone_from_timedatectl(monkeypatch):
+    # Test 1: timedatectl works.
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: "Timezone=Europe/Berlin\n")
+    _mock_no_file_fallbacks(monkeypatch)
+
+    assert time_service.detect_system_timezone() == "Europe/Berlin"
+
+
+def test_detect_system_timezone_falls_back_to_etc_timezone(monkeypatch):
+    # Test 2: timedatectl inaccessible (Access denied, modeled as a non-zero
+    # exit - see the module's own _log_once() docstring for why stderr is
+    # never part of the exception text either way), /etc/timezone exists.
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    _mock_etc_timezone(monkeypatch, value="Europe/Berlin\n")
+    _mock_etc_localtime(monkeypatch, exists=False)
+
+    assert time_service.detect_system_timezone() == "Europe/Berlin"
+
+
+def test_detect_system_timezone_falls_back_to_etc_localtime(monkeypatch):
+    # Test 3 - THE regression test for the reported Droidian bug:
+    # timedatectl inaccessible, /etc/timezone absent, /etc/localtime
+    # resolves into the zoneinfo database.
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    _mock_etc_timezone(monkeypatch, value=None)
+    _mock_etc_localtime(monkeypatch, exists=True, resolved_target="/usr/share/zoneinfo/Europe/Berlin")
+
+    assert time_service.detect_system_timezone() == "Europe/Berlin"
+
+
+def test_detect_system_timezone_all_sources_absent_falls_back_to_utc(monkeypatch):
+    # Test 4: all sources absent.
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    _mock_no_file_fallbacks(monkeypatch)
+
+    assert time_service.detect_system_timezone() == "UTC"
+
+
+def test_detect_system_timezone_invalid_name_skips_to_next_fallback(monkeypatch):
+    # Test 5: timedatectl reports a name zoneinfo doesn't recognize - must
+    # not be accepted as-is (requirement 4: validate before accepting), and
+    # must not raise ZoneInfoNotFoundError outward. Falls through to
+    # /etc/timezone, which has a genuinely valid name, proving this is a
+    # real "skip to next fallback", not just "give up immediately".
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: "Timezone=Europe/InvalidCity\n")
+    _mock_etc_timezone(monkeypatch, value="Europe/Berlin\n")
+    _mock_etc_localtime(monkeypatch, exists=False)
+
+    assert time_service.detect_system_timezone() == "Europe/Berlin"
+
+
+def test_detect_system_timezone_invalid_name_everywhere_falls_back_to_utc(monkeypatch):
+    # Same as above, but no valid fallback exists anywhere in the chain -
+    # must land on "UTC", not raise and not return the invalid name.
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: "Timezone=Not/AZone\n")
+    _mock_etc_timezone(monkeypatch, value="Also/NotAZone\n")
+    _mock_etc_localtime(monkeypatch, exists=True, resolved_target="/usr/share/zoneinfo/Still/NotAZone")
+
+    assert time_service.detect_system_timezone() == "UTC"
+
+
+def test_detect_system_timezone_localtime_regular_file_not_symlink_does_not_crash(monkeypatch):
+    # Integration test (doc section 18, "Container"): /etc/localtime is a
+    # regular file, not a symlink into /usr/share/zoneinfo. Path.resolve()
+    # on a non-symlink just normalizes to the same path, so relative_to()
+    # raises ValueError inside _timezone_from_localtime() - must be caught
+    # there (it already is, by construction) and fall back to UTC, not
+    # crash detect_system_timezone().
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    _mock_etc_timezone(monkeypatch, value=None)
+    # resolved_target=None means resolve() returns the same /etc/localtime
+    # path unchanged - exactly what happens for a real, non-symlink file.
+    _mock_etc_localtime(monkeypatch, exists=True, resolved_target=None)
+
+    assert time_service.detect_system_timezone() == "UTC"
+
+
+def test_detect_system_timezone_never_raises_when_a_backend_misbehaves(monkeypatch):
+    # Belt-and-suspenders check for detect_system_timezone()'s own outer
+    # try/except: even if a backend somehow raised past its own internal
+    # try/except (a bug, not an expected path), the loop must still move
+    # on to the next backend instead of propagating.
+    def _timedatectl_raises_unexpectedly(*a, **k):
+        raise RuntimeError("boom - should never happen, but must not crash detection")
+
+    monkeypatch.setattr(time_service, "_timezone_from_timedatectl", _timedatectl_raises_unexpectedly)
+    _mock_etc_timezone(monkeypatch, value="Europe/Berlin\n")
+    _mock_etc_localtime(monkeypatch, exists=False)
+
+    assert time_service.detect_system_timezone() == "Europe/Berlin"
+
+
+# ---------------- DST (requires the `tzdata` package on non-Linux hosts -
+# see requirements-dev.txt) ----------------
+
+def test_dst_summer_offset_for_europe_berlin():
+    # Test 6: DST summer - MeshCenter_timezone_detection_TZ_2026-08-28.md's
+    # own example date/timezone.
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    dt = datetime(2026, 8, 28, 14, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    assert dt.utcoffset() == timedelta(hours=2)  # CEST
+
+
+def test_dst_winter_offset_for_europe_berlin():
+    # Test 7: DST winter.
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    dt = datetime(2026, 12, 15, 14, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    assert dt.utcoffset() == timedelta(hours=1)  # CET
+
+
+# ---------------- log-dedup (Вариант A: log once until state changes) ----
+
+def test_timedatectl_timezone_failure_logged_only_once(monkeypatch, capsys):
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+    _mock_no_file_fallbacks(monkeypatch)
+
+    time_service.detect_system_timezone()
+    time_service.detect_system_timezone()
+    time_service.detect_system_timezone()
+
+    out = capsys.readouterr().out
+    assert out.count("[TIME] timedatectl unavailable, using fallback timezone detection") == 1
+
+
+def test_timedatectl_timezone_failure_logs_again_when_the_error_changes(monkeypatch, capsys):
+    # Same tag, different underlying failure - must log again, not stay
+    # suppressed forever just because *some* error was already seen once.
+    def _raise_denied(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "Timezone"])
+
+    def _raise_missing_binary(*a, **k):
+        raise FileNotFoundError("[Errno 2] No such file or directory: 'timedatectl'")
+
+    _mock_no_file_fallbacks(monkeypatch)
+
+    monkeypatch.setattr(subprocess, "check_output", _raise_denied)
+    time_service.detect_system_timezone()
+
+    monkeypatch.setattr(subprocess, "check_output", _raise_missing_binary)
+    time_service.detect_system_timezone()
+
+    out = capsys.readouterr().out
+    assert out.count("[TIME] timedatectl unavailable, using fallback timezone detection") == 2
+
+
+def test_ntp_probe_failure_is_also_log_deduped(monkeypatch, capsys):
+    # The task explicitly called out extending dedup to the pre-existing
+    # NTP/Timesource probe (not just the new timezone code), so Droidian
+    # doesn't keep flooding the journal on that side either.
+    def _raise(*a, **k):
+        raise subprocess.CalledProcessError(1, ["timedatectl", "show", "-p", "NTPSynchronized", "-p", "Timesource"])
+
+    monkeypatch.setattr(subprocess, "check_output", _raise)
+
+    time_service._probe_ntp_status()
+    time_service._probe_ntp_status()
+
+    out = capsys.readouterr().out
+    assert out.count("timedatectl_ntp failed") == 1
+
+
+# ---------------- get_status()/quality integration with the new chain ----
+
+def test_probe_uses_detect_system_timezone_result(monkeypatch):
+    monkeypatch.setattr(subprocess, "check_output", lambda *a, **k: _timedatectl_output(synchronized=False, timezone="Europe/Berlin"))
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=False, configured=False, readable=False),
+    )
+
+    result = time_service._probe()
+
+    assert result["timezone"] == "Europe/Berlin"
+
+
+def test_probe_timezone_independent_of_ntp_probe_failure(monkeypatch):
+    # A Droidian-shaped system: the NTP/Timesource probe fails, but
+    # timezone detection (a separate subprocess call) still succeeds.
+    def _check_output(cmd, *a, **k):
+        if "-p" in cmd and "Timezone" in cmd and "NTPSynchronized" not in cmd:
+            return "Timezone=Europe/Berlin\n"
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "check_output", _check_output)
+    monkeypatch.setattr(
+        time_service.rtc_service, "get_status",
+        lambda **kwargs: _rtc_status(detected=False, configured=False, readable=False),
+    )
+
+    result = time_service._probe()
+
+    assert result["timezone"] == "Europe/Berlin"
+    assert result["synchronized"] is False
+    assert result["source"] == "system"


### PR DESCRIPTION
## Summary
Source: `MeshCenter_timezone_detection_TZ_2026-08-28.md`, reported on Pixel 3a XL / Droidian 101 - `timedatectl` entirely denied (`Failed to query server: Access denied`), `/etc/timezone` absent, `/etc/localtime` correctly configured but never consulted, so MeshCenter silently showed UTC (2h behind the real Europe/Berlin CEST time).

- Adds `detect_system_timezone()`: `timedatectl` → `/etc/timezone` → `/etc/localtime` symlink resolution → `"UTC"` only as a last resort. Each backend has its own try/except (one failing never takes another down) and every candidate is validated via `zoneinfo.ZoneInfo()` before acceptance (invalid name → next fallback, not trusted blindly).
- No fixed UTC offset anywhere - DST keeps working via `zoneinfo` for every consumer. Confirmed by inspection that `schedule_engine.py`, the e-Paper display, and the Web UI all already read `time_service.get_status()["timezone"]` as their single source of truth - no other file needed changes.
- Splits the NTP/Timesource probe into its own subprocess call, separate from timezone detection (previously one combined call whose failure took all three fields down together).
- Manual log-dedup (`print()`, not `logging` - matches this project's convention): a per-tag "last error signature" dict prints each distinct failure once, not every `_CACHE_TTL` (20s) tick - applied to both the new timezone path and the pre-existing NTP probe (which would otherwise keep flooding even after the timezone side was fixed).
- Never calls `timedatectl set-timezone` or touches system config - detection only.
- `tzdata` added to `requirements-dev.txt`: a Windows dev machine has no system IANA database, so `zoneinfo.ZoneInfo()` and the DST tests would be blind without it - chose "add the portable pure-Python data package" over `skipif`, unlike the genuinely-platform-specific `fcntl` skips elsewhere in this suite.

## Notable fix during implementation
`_timezone_from_localtime()` originally used `str(relative)` to build the IANA name from the resolved path - correct on Linux (where this code actually runs), but would emit backslashes on Windows. Switched to `.as_posix()` since IANA names are always forward-slash regardless of host OS; also fixed the same latent issue in the new tests' own path-comparison mocks (`str(self) == "/etc/timezone"` silently never matched on Windows since `str(Path(...))` there uses backslashes - switched to `.as_posix()` there too).

## Test plan
- [x] `pytest` - 356 passed, 25 skipped (POSIX/Linux-only, expected on this dev machine)
- [x] 27 tests in `tests/test_time_service.py`: all 5 doc-mandated fallback-chain cases + the Droidian regression test, invalid-timezone-name handling (both "skips to next fallback" and "everywhere invalid → UTC"), the `/etc/localtime`-is-a-regular-file container case (no crash), both DST directions for Europe/Berlin, log-dedup on both the timezone and NTP probe paths (including "logs again when the error actually changes"), and `_probe()` integration (timezone independent of NTP-probe failure)
- [x] Updated `test_rtc_service_exception_does_not_crash_probe` and `test_timedatectl_failure_does_not_crash_probe` so neither can silently depend on the real filesystem of whatever machine runs pytest (the exact class of bug task 24 hit in this same file previously)
- [x] `python -m py_compile meshsrv/time_service.py tests/test_time_service.py`
- [ ] Live verification on a real Linux node pending - Windows dev machine has no `/etc/localtime`/`timedatectl` to test the real fallback chain end-to-end; will confirm against dev (`!756f9960`, real Raspberry Pi OS with real `timedatectl`) before merge