### PR TITLE
🛡️ Sentinel: Fix sensitive Wi-Fi password leakage in API error responses

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -332,6 +332,11 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
         password = data.get("password") or ""
         if not ssid:
             return jsonify({"ok": False, "error": "SSID is required"}), 400
+
+        def _sanitize_wifi_error(text):
+            val = str(text or "")
+            return val.replace(password, "******") if password and password in val else val
+
         def run_nmcli(args, timeout=30):
             return subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli"] + args, text=True, stderr=subprocess.STDOUT, timeout=timeout)
         try:
@@ -339,9 +344,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
             if password:
                 cmd += ["password", password]
             out = run_nmcli(cmd)
-            return jsonify({"ok": True, "message": out.strip()})
+            return jsonify({"ok": True, "message": _sanitize_wifi_error(out.strip())})
         except subprocess.CalledProcessError as e:
-            err = e.output.strip() if e.output else str(e)
+            err = _sanitize_wifi_error(e.output.strip() if e.output else str(e))
             if "key-mgmt" in err or "property is missing" in err or "secrets were required" in err:
                 try:
                     run_nmcli(["connection", "delete", ssid], timeout=10)
@@ -352,12 +357,13 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
                     if password:
                         cmd += ["password", password]
                     out = run_nmcli(cmd)
-                    return jsonify({"ok": True, "message": out.strip(), "recreated_profile": True})
+                    return jsonify({"ok": True, "message": _sanitize_wifi_error(out.strip()), "recreated_profile": True})
                 except subprocess.CalledProcessError as e2:
-                    return jsonify({"ok": False, "error": e2.output.strip() if e2.output else str(e2)}), 500
+                    err2 = _sanitize_wifi_error(e2.output.strip() if e2.output else str(e2))
+                    return jsonify({"ok": False, "error": err2}), 500
             return jsonify({"ok": False, "error": err}), 500
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 500
+            return jsonify({"ok": False, "error": _sanitize_wifi_error(str(e))}), 500
 
     @app.route("/api/system/wifi/forget", methods=["POST"])
     def api_system_wifi_forget():

--- a/tests/test_api_system_wifi.py
+++ b/tests/test_api_system_wifi.py
@@ -1,0 +1,63 @@
+"""Tests for api/api_system.py's Wi-Fi connection endpoint password redaction."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def api_client(server_module):
+    from api.api_system import register_system_routes
+
+    app = Flask(__name__)
+    register_system_routes(app)
+    return app.test_client()
+
+
+def test_wifi_connect_redacts_password_on_called_process_error(api_client):
+    cmd = ["sudo", "-n", "/usr/bin/nmcli", "dev", "wifi", "connect", "TestSSID", "password", "SuperSecretPass123!"]
+    err = subprocess.CalledProcessError(1, cmd, output=None)
+
+    with patch("subprocess.check_output", side_effect=err):
+        response = api_client.post(
+            "/api/system/wifi/connect",
+            json={"ssid": "TestSSID", "password": "SuperSecretPass123!"},
+        )
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["ok"] is False
+    assert "SuperSecretPass123!" not in body["error"]
+    assert "******" in body["error"]
+
+
+def test_wifi_connect_redacts_password_on_timeout_expired(api_client):
+    cmd = ["sudo", "-n", "/usr/bin/nmcli", "dev", "wifi", "connect", "TestSSID", "password", "SuperSecretPass123!"]
+    err = subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+    with patch("subprocess.check_output", side_effect=err):
+        response = api_client.post(
+            "/api/system/wifi/connect",
+            json={"ssid": "TestSSID", "password": "SuperSecretPass123!"},
+        )
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["ok"] is False
+    assert "SuperSecretPass123!" not in body["error"]
+    assert "******" in body["error"]
+
+
+def test_wifi_connect_success(api_client):
+    with patch("subprocess.check_output", return_value="Device 'wlan0' successfully activated with 'TestSSID'.\n"):
+        response = api_client.post(
+            "/api/system/wifi/connect",
+            json={"ssid": "TestSSID", "password": "SuperSecretPass123!"},
+        )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert "successfully activated" in body["message"]


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Redact Plaintext Wi-Fi Password in API Errors

- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Python's `subprocess.CalledProcessError` and `subprocess.TimeoutExpired` string representation includes the full subprocess command list (e.g. `['sudo', '-n', '/usr/bin/nmcli', 'dev', 'wifi', 'connect', 'SSID', 'password', 'SecretPass']`). Returning `str(e)` or raw process output on connection failures leaked plaintext Wi-Fi credentials in `/api/system/wifi/connect` HTTP error responses.
- 🎯 Impact: Plaintext Wi-Fi passwords could be exposed in network logs, browser devtools, or API responses when Wi-Fi connection attempts failed or timed out.
- 🔧 Fix: Added `_sanitize_wifi_error` helper in `api/api_system.py` to strip out plaintext passwords from error messages and output strings returned to the client.
- ✅ Verification: Added unit tests in `tests/test_api_system_wifi.py` confirming password redaction on connection failures and timeouts, and verified all 384 pytest tests pass.

---
*PR created automatically by Jules for task [14011502714215979290](https://jules.google.com/task/14011502714215979290) started by @FlintUA*