### PR TITLE
Replace direct nmcli/iw sudo access with a narrow root helper (P1 #7/#8)

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -4,6 +4,7 @@ import time
 
 from flask import jsonify, request
 
+from meshsrv import network_config
 from system_log import get_system_events, log_system_event
 
 
@@ -229,31 +230,17 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
             return jsonify({"ok": False, "error": str(exc)}), 500
 
     def get_saved_wifi_names():
-        try:
-            out = subprocess.check_output(
-                ["sudo", "-n", "/usr/bin/nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"],
-                text=True,
-                stderr=subprocess.STDOUT,
-                timeout=10
-            )
-            saved = set()
-            for line in out.splitlines():
-                parts = line.split(":")
-                if len(parts) >= 2 and parts[1] == "802-11-wireless":
-                    saved.add(parts[0])
-            return saved
-        except Exception:
-            return set()
+        result = network_config.list_wifi_connections()
+        return result.get("ssids", set()) if result.get("ok") else set()
 
     @app.route("/api/system/wifi/scan")
     def api_system_wifi_scan():
         result = {"ok": True, "networks": []}
         try:
-            out = subprocess.check_output(
-                ["sudo", "-n", "/usr/sbin/iw", "dev", "wlan0", "scan"],
-                text=True,
-                stderr=subprocess.DEVNULL
-            )
+            scan_result = network_config.scan()
+            if not scan_result.get("ok"):
+                return jsonify({"ok": False, "error": scan_result.get("reason", "scan failed"), "networks": []}), 500
+            out = scan_result.get("stdout", "")
             networks = []
             current = None
             for raw_line in out.splitlines():
@@ -332,32 +319,17 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
         password = data.get("password") or ""
         if not ssid:
             return jsonify({"ok": False, "error": "SSID is required"}), 400
-        def run_nmcli(args, timeout=30):
-            return subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli"] + args, text=True, stderr=subprocess.STDOUT, timeout=timeout)
-        try:
-            cmd = ["dev", "wifi", "connect", ssid]
-            if password:
-                cmd += ["password", password]
-            out = run_nmcli(cmd)
-            return jsonify({"ok": True, "message": out.strip()})
-        except subprocess.CalledProcessError as e:
-            err = e.output.strip() if e.output else str(e)
-            if "key-mgmt" in err or "property is missing" in err or "secrets were required" in err:
-                try:
-                    run_nmcli(["connection", "delete", ssid], timeout=10)
-                except Exception:
-                    pass
-                try:
-                    cmd = ["dev", "wifi", "connect", ssid]
-                    if password:
-                        cmd += ["password", password]
-                    out = run_nmcli(cmd)
-                    return jsonify({"ok": True, "message": out.strip(), "recreated_profile": True})
-                except subprocess.CalledProcessError as e2:
-                    return jsonify({"ok": False, "error": e2.output.strip() if e2.output else str(e2)}), 500
-            return jsonify({"ok": False, "error": err}), 500
-        except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 500
+        # meshsrv.network_config.connect() sends `password` to the helper's
+        # stdin, never as an argv element (P1 #8) - and the helper itself
+        # unconditionally replaces any existing profile for this SSID
+        # before writing a fresh one, so the old two-pass
+        # delete-then-retry dance that used to live here (for "key-mgmt
+        # property is missing" errors) is no longer needed: a freshly
+        # written profile can't inherit a stale/mismatched security config.
+        result = network_config.connect(ssid, password)
+        if result.get("ok"):
+            return jsonify({"ok": True, "message": result.get("stdout", "")})
+        return jsonify({"ok": False, "error": result.get("reason", "connect failed")}), 500
 
     @app.route("/api/system/wifi/forget", methods=["POST"])
     def api_system_wifi_forget():
@@ -365,13 +337,10 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
         ssid = (data.get("ssid") or "").strip()
         if not ssid:
             return jsonify({"ok": False, "error": "SSID is required"}), 400
-        try:
-            out = subprocess.check_output(["sudo", "-n", "/usr/bin/nmcli", "connection", "delete", ssid], text=True, stderr=subprocess.STDOUT, timeout=15)
-            return jsonify({"ok": True, "message": out.strip()})
-        except subprocess.CalledProcessError as e:
-            return jsonify({"ok": False, "error": e.output.strip() if e.output else str(e)}), 500
-        except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 500
+        result = network_config.forget(ssid)
+        if result.get("ok"):
+            return jsonify({"ok": True, "message": result.get("stdout", "")})
+        return jsonify({"ok": False, "error": result.get("reason", "forget failed")}), 500
 
     @app.route("/api/system/network")
     def api_system_network():
@@ -381,6 +350,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
         except Exception:
             pass
         try:
+            # Unprivileged - iw link status needs no root on the target
+            # systems, so this stays a direct call, not routed through the
+            # sudo-gated helper (see meshsrv/network_config.py's docstring).
             out = subprocess.check_output(["/usr/sbin/iw", "dev", "wlan0", "link"], text=True)
             for line in out.splitlines():
                 line = line.strip()

--- a/deploy/meshcenter-wifi.sudoers
+++ b/deploy/meshcenter-wifi.sudoers
@@ -1,2 +1,4 @@
-__MESH_USER__ ALL=(root) NOPASSWD: /usr/sbin/iw
-__MESH_USER__ ALL=(root) NOPASSWD: /usr/bin/nmcli
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-network-helper list-connections
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-network-helper scan
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-network-helper connect *
+__MESH_USER__ ALL=(root) NOPASSWD: /usr/local/sbin/meshcenter-network-helper forget *

--- a/install.sh
+++ b/install.sh
@@ -572,6 +572,13 @@ step_systemd() {
     sudo install -o root -g root -m 0755 \
         "${INSTALL_DIR}/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
 
+    # Same pattern for Wi-Fi management (P1 #7/#8 stabilization follow-up):
+    # meshsrv/network_config.py calls this via `sudo -n` instead of the
+    # Flask process running nmcli/iw as root directly - see
+    # scripts/meshcenter-network-helper's own docstring.
+    sudo install -o root -g root -m 0755 \
+        "${INSTALL_DIR}/scripts/meshcenter-network-helper" /usr/local/sbin/meshcenter-network-helper
+
     # I2C bus access (unprivileged, via stock 60-i2c-aliases.rules) and now
     # RTC hardware-clock access (deploy/99-meshcenter-rtc.rules below) both
     # ride on membership in the `i2c` group - meshcenter-firstboot.sh's

--- a/meshcenter-firstboot.sh
+++ b/meshcenter-firstboot.sh
@@ -716,6 +716,8 @@ MESH_HOME="$TARGET_HOME"
     || fail "Missing deploy/meshcenter-hw.sudoers"
 [[ -f "$INSTALL_DIR/scripts/meshcenter-hw-config" ]] \
     || fail "Missing scripts/meshcenter-hw-config"
+[[ -f "$INSTALL_DIR/scripts/meshcenter-network-helper" ]] \
+    || fail "Missing scripts/meshcenter-network-helper"
 [[ -f "$INSTALL_DIR/deploy/99-meshcenter-rtc.rules" ]] \
     || fail "Missing deploy/99-meshcenter-rtc.rules"
 
@@ -729,6 +731,13 @@ sed -e "s|__MESH_USER__|${MESH_USER}|g" \
 # `sudo -n` - see scripts/meshcenter-hw-config's own docstring).
 install -o root -g root -m 0755 \
     "$INSTALL_DIR/scripts/meshcenter-hw-config" /usr/local/sbin/meshcenter-hw-config
+
+# Same pattern for Wi-Fi management (P1 #7/#8 stabilization follow-up):
+# meshsrv/network_config.py calls this via `sudo -n` instead of the Flask
+# process running nmcli/iw as root directly - see
+# scripts/meshcenter-network-helper's own docstring.
+install -o root -g root -m 0755 \
+    "$INSTALL_DIR/scripts/meshcenter-network-helper" /usr/local/sbin/meshcenter-network-helper
 
 # Grants the `i2c` group (already assigned to $TARGET_USER above) read
 # access to /dev/rtcN - without it, hardware/rtc_service.py's readable-stage

--- a/meshsrv/network_config.py
+++ b/meshsrv/network_config.py
@@ -1,0 +1,102 @@
+"""The only module allowed to invoke the privileged
+scripts/meshcenter-network-helper (via `sudo -n`) for Wi-Fi connection
+management. Nothing else in the codebase should shell out to nmcli/iw as
+root - api/api_system.py's Wi-Fi routes call the functions here instead.
+
+Mirrors hardware/hardware_config.py's shape (_run_helper() wrapping
+`sudo -n <helper> <args>`, never raising, always returning
+{"ok": True/False, ...}) - see that module's own docstring for the
+reasoning behind the pattern (a missing/misconfigured sudoers rule must
+fail immediately and distinctly, `sudo -n`, rather than hang the request
+on a password prompt nobody can answer).
+
+The one addition here: connect() passes the Wi-Fi password to the
+helper's stdin (`subprocess.run(..., input=password)`), never as an argv
+element - `ps aux` / `/proc/<pid>/cmdline` must never expose it for this
+process, the intermediate `sudo` process, or the helper itself (P1 #8;
+the previous direct `nmcli ... password <pw>` call put it straight into
+argv).
+
+Unprivileged reads (`iw dev wlan0 link`, `iwgetid -r`) do NOT go through
+this module or the helper - they need no root on the target systems, so
+routing them through a sudo-gated helper would only add attack surface
+for nothing. api/api_system.py still calls those directly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+HELPER_PATH = "/usr/local/sbin/meshcenter-network-helper"
+HELPER_TIMEOUT = 15
+# nmcli association + DHCP can legitimately take longer than a plain
+# list/scan query.
+CONNECT_TIMEOUT = 45
+
+
+def _run_helper(args: list[str], input_text: str | None = None, timeout: int = HELPER_TIMEOUT) -> dict:
+    """Never raises. `sudo -n` (no interactive prompt) means a missing/
+    misconfigured sudoers rule fails immediately and distinctly rather than
+    hanging the request waiting on a password prompt nobody can answer."""
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", HELPER_PATH, *args],
+            input=input_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "reason": "sudo is not available on this system"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "reason": f"meshcenter-network-helper timed out after {timeout}s"}
+    except Exception as exc:  # noqa: BLE001 - never raise out of this layer
+        return {"ok": False, "reason": f"meshcenter-network-helper failed: {exc}"}
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "password is required" in stderr.lower():
+            reason = (
+                "sudo is not configured for meshcenter-network-helper - install "
+                "deploy/meshcenter-wifi.sudoers (the installer does this automatically)"
+            )
+        else:
+            reason = stderr or f"meshcenter-network-helper exited with code {result.returncode}"
+        return {"ok": False, "reason": reason}
+
+    return {"ok": True, "stdout": (result.stdout or "").strip()}
+
+
+def list_wifi_connections() -> dict:
+    """Saved Wi-Fi connection names (nmcli's NAME column, filtered to the
+    802-11-wireless TYPE). {"ok": True, "ssids": set(...)} on success,
+    {"ok": False, "reason": ...} otherwise - never raises."""
+    result = _run_helper(["list-connections"])
+    if not result.get("ok"):
+        return result
+
+    ssids = set()
+    for line in result.get("stdout", "").splitlines():
+        parts = line.split(":")
+        if len(parts) >= 2 and parts[1] == "802-11-wireless":
+            ssids.add(parts[0])
+    return {"ok": True, "ssids": ssids}
+
+
+def scan() -> dict:
+    """Raw `iw dev wlan0 scan` output, `{"ok": True, "stdout": "..."}` or
+    `{"ok": False, "reason": ...}`. api/api_system.py's own parser turns
+    this into structured network entries - kept there rather than
+    duplicated in bash, see this module's own docstring."""
+    return _run_helper(["scan"])
+
+
+def connect(ssid: str, password: str = "") -> dict:
+    """Connect to `ssid`. `password` is sent to the helper's stdin, never
+    as an argv element (P1 #8 - see module docstring). Empty password
+    means an open network."""
+    return _run_helper(["connect", ssid], input_text=password, timeout=CONNECT_TIMEOUT)
+
+
+def forget(ssid: str) -> dict:
+    return _run_helper(["forget", ssid])

--- a/scripts/meshcenter-network-helper
+++ b/scripts/meshcenter-network-helper
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# meshcenter-network-helper - narrow, root-only helper for Wi-Fi
+# connection management (P1 #7/#8 stabilization follow-up).
+#
+# This is the ONLY thing allowed to run `nmcli`/`iw` as root on behalf of
+# MeshCenter's web UI: the Flask process runs as an unprivileged user and
+# calls this script through `sudo -n` (see meshsrv/network_config.py, the
+# single Python entry point for this script - nothing else in the
+# codebase should invoke it directly). Replaces the old
+# `NOPASSWD: /usr/bin/nmcli` / `NOPASSWD: /usr/sbin/iw` sudoers rules,
+# which allowed literally any nmcli/iw invocation (nmcli connection edit,
+# radio wifi off, arbitrary profile edits, ...) - this only allows four
+# fixed subcommands.
+#
+# Usage:
+#   meshcenter-network-helper list-connections
+#   meshcenter-network-helper scan
+#   meshcenter-network-helper connect <ssid>   # password read from stdin
+#   meshcenter-network-helper forget <ssid>
+#
+# sudoers grants `connect *` / `forget *` (deploy/meshcenter-wifi.sudoers)
+# since the SSID argument can't be enumerated in advance. That sudoers
+# glob matches the WHOLE command line as a string, not per-argv-position -
+# it would equally match `connect somessid --extra-dangerous-flag` if such
+# a thing were ever passed. sudo itself execs this script directly (no
+# shell involved), so an SSID containing shell metacharacters can never
+# trigger injection - but this script must still not trust "sudoers only
+# let one specific string through" as its own argument-count guard. Every
+# subcommand below explicitly checks $# before doing anything, independent
+# of whatever sudoers happens to allow.
+#
+# The Wi-Fi password for `connect` is read from this script's own stdin,
+# never accepted as an argument - `ps aux` / `/proc/<pid>/cmdline` must
+# never show it, for this process or for the `sudo`/Python processes
+# upstream of it (P1 #8). Stored only in a root:root, mode 600
+# NetworkManager keyfile profile - see cmd_connect() below.
+
+set -euo pipefail
+
+CONNECTIONS_DIR="/etc/NetworkManager/system-connections"
+WIFI_IFACE="wlan0"
+
+fail() {
+    echo "meshcenter-network-helper: error: $1" >&2
+    exit 1
+}
+
+require_argc() {
+    # $1 = expected arg count *after* the subcommand name, $2 = actual
+    # count, $3 = usage string for the error message. Guards against
+    # anything past the SSID the sudoers glob wouldn't itself catch (see
+    # module docstring above).
+    local expected="$1" actual="$2" usage="$3"
+    [[ "$actual" -eq "$expected" ]] || fail "$usage"
+}
+
+# Deletes any existing connection profile whose NAME matches $1, if one
+# exists - idempotent, safe to call whether or not a prior profile is
+# present. Used unconditionally before every connect (not just as an
+# error-retry path): a freshly written profile can never inherit stale or
+# mismatched security settings from an earlier attempt, which is the
+# entire "key-mgmt property is missing" class of error the old Python
+# code used to retry around.
+delete_existing_connection() {
+    local ssid="$1"
+    if nmcli -t -f NAME connection show 2>/dev/null | grep -qxF "$ssid"; then
+        nmcli connection delete "$ssid" >/dev/null 2>&1 || true
+    fi
+}
+
+cmd_list_connections() {
+    require_argc 0 "$#" "list-connections takes no arguments"
+    nmcli -t -f NAME,TYPE connection show
+}
+
+cmd_scan() {
+    require_argc 0 "$#" "scan takes no arguments"
+    iw dev "$WIFI_IFACE" scan
+}
+
+cmd_connect() {
+    require_argc 1 "$#" "connect requires exactly one argument: <ssid>"
+    local ssid="$1"
+    [[ -n "$ssid" ]] || fail "connect requires a non-empty SSID"
+
+    # Password (if any) arrives on stdin - a single value, read to EOF, no
+    # trailing newline expected but stripped if present. Empty means an
+    # open network.
+    local password
+    password="$(cat -)"
+
+    delete_existing_connection "$ssid"
+
+    if [[ -z "$password" ]]; then
+        nmcli device wifi connect "$ssid"
+        return
+    fi
+
+    # Random filename, NOT derived from $ssid: a legal 802.11 SSID may
+    # contain "/" (0-32 arbitrary bytes, nothing in the spec forbids it),
+    # so using it as a path component would be a real path-traversal
+    # vector, not a hypothetical one. NetworkManager identifies profiles
+    # by the id= field inside the file, not by filename, so this loses
+    # nothing - nmcli connection up/delete below still address it by SSID.
+    local profile_path
+    profile_path="$(mktemp -p "$CONNECTIONS_DIR" "meshcenter-XXXXXX.nmconnection")"
+
+    # mktemp already created the file 0600 owned by us (root, since this
+    # script only ever runs via sudo) - written in place, then given its
+    # real .nmconnection content atomically isn't necessary here (unlike
+    # meshcenter-hw-config's shared config.txt) since nothing else reads
+    # this exact path until we explicitly `nmcli connection load` it below.
+    cat > "$profile_path" <<EOF
+[connection]
+id=${ssid}
+type=wifi
+
+[wifi]
+mode=infrastructure
+ssid=${ssid}
+
+[wifi-security]
+key-mgmt=wpa-psk
+psk=${password}
+
+[ipv4]
+method=auto
+
+[ipv6]
+method=auto
+EOF
+    chmod 600 "$profile_path"
+
+    nmcli connection load "$profile_path"
+    nmcli connection up "$ssid"
+}
+
+cmd_forget() {
+    require_argc 1 "$#" "forget requires exactly one argument: <ssid>"
+    local ssid="$1"
+    [[ -n "$ssid" ]] || fail "forget requires a non-empty SSID"
+    nmcli connection delete "$ssid"
+}
+
+main() {
+    local subcommand="${1:-}"
+    [[ $# -ge 1 ]] || fail "no subcommand given (expected: list-connections | scan | connect <ssid> | forget <ssid>)"
+    shift
+
+    case "$subcommand" in
+        list-connections)
+            cmd_list_connections "$@"
+            ;;
+        scan)
+            cmd_scan "$@"
+            ;;
+        connect)
+            cmd_connect "$@"
+            ;;
+        forget)
+            cmd_forget "$@"
+            ;;
+        *)
+            fail "unknown subcommand: $subcommand (expected: list-connections | scan | connect <ssid> | forget <ssid>)"
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -168,10 +168,25 @@ elif echo "$SUDO_LIST" | grep -qE "NOPASSWD:\s*ALL|systemctl restart meshcenter\
 else
     bad "systemctl restart meshcenter.service not covered by passwordless sudo — UI restart action will hang waiting for a password (see deploy/meshcenter.sudoers)"
 fi
-if [ -n "$SUDO_LIST" ] && echo "$SUDO_LIST" | grep -qE "NOPASSWD:\s*ALL|nmcli|/usr/sbin/iw"; then
-    ok "NOPASSWD sudo confirmed for Wi-Fi commands (nmcli/iw)"
+# deploy/meshcenter-wifi.sudoers now grants meshcenter-network-helper only
+# (P1 #7/#8 stabilization follow-up), not nmcli/iw directly - an install
+# predating this change that has only ever been updated via `git pull` +
+# service restart will still have the OLD sudoers rule (NOPASSWD on
+# nmcli/iw themselves) until re-provisioned, same class of gap as
+# meshcenter-hw's own check below (task 39: git pull never updates
+# /etc/sudoers.d/* on an existing install - update_service.py deliberately
+# never touches system files).
+if [ -n "$SUDO_LIST" ] && echo "$SUDO_LIST" | grep -qE "NOPASSWD:\s*ALL|meshcenter-network-helper"; then
+    ok "NOPASSWD sudo confirmed for meshcenter-network-helper (Wi-Fi management)"
+elif [ -n "$SUDO_LIST" ] && echo "$SUDO_LIST" | grep -qE "nmcli|/usr/sbin/iw"; then
+    warn "sudo still grants the OLD direct nmcli/iw rule, not meshcenter-network-helper — re-run install.sh/meshcenter-firstboot.sh's relevant step (or manually install the updated deploy/meshcenter-wifi.sudoers) to pick up the narrower helper-based rule; Wi-Fi actions in the UI will fail until then, since api/api_system.py no longer calls nmcli/iw directly"
 else
-    warn "nmcli/iw not covered by passwordless sudo — Wi-Fi actions in the UI will fail (see deploy/meshcenter-wifi.sudoers)"
+    warn "meshcenter-network-helper not covered by passwordless sudo — Wi-Fi actions in the UI will fail (see deploy/meshcenter-wifi.sudoers)"
+fi
+if [ -x "/usr/local/sbin/meshcenter-network-helper" ]; then
+    ok "meshcenter-network-helper installed at /usr/local/sbin/meshcenter-network-helper"
+else
+    warn "/usr/local/sbin/meshcenter-network-helper missing or not executable — Wi-Fi actions in the UI will fail even with correct sudoers (see scripts/meshcenter-network-helper, installed by install.sh/meshcenter-firstboot.sh)"
 fi
 # Not `bad` - this only affects the Devices tab's optional I2C/RTC card, not
 # core MeshCenter functionality. An install predating task 23 (PR #84) that

--- a/tests/test_network_config.py
+++ b/tests/test_network_config.py
@@ -1,0 +1,146 @@
+"""Tests for meshsrv/network_config.py - the sudo wrapper around
+scripts/meshcenter-network-helper (P1 #7/#8 stabilization follow-up).
+
+subprocess is mocked throughout (the actual bash script's own argument-
+count guards and idempotent-profile-replace behavior are exercised
+directly against the real script in tests/test_network_helper_script.py,
+not here - this module only needs to prove its own Python-side wiring:
+correct argv, correct stdin passthrough for the password, and error
+handling). No server.py import needed.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from meshsrv import network_config
+
+
+def _completed(stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------- list_wifi_connections() ----------------
+
+def test_list_wifi_connections_filters_to_wireless_type():
+    mock_run = MagicMock(
+        return_value=_completed(
+            stdout="HomeWifi:802-11-wireless\nEthernet:802-3-ethernet\nOfficeWifi:802-11-wireless\n"
+        )
+    )
+    with patch("subprocess.run", mock_run):
+        result = network_config.list_wifi_connections()
+
+    assert result == {"ok": True, "ssids": {"HomeWifi", "OfficeWifi"}}
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["sudo", "-n", network_config.HELPER_PATH, "list-connections"]
+    assert kwargs.get("input") is None
+
+
+def test_list_wifi_connections_helper_failure_passed_through():
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="boom")):
+        result = network_config.list_wifi_connections()
+    assert result == {"ok": False, "reason": "boom"}
+
+
+# ---------------- scan() ----------------
+
+def test_scan_returns_raw_stdout():
+    mock_run = MagicMock(return_value=_completed(stdout="BSS aa:bb:cc:dd:ee:ff(on wlan0)\n\tSSID: TestNet\n"))
+    with patch("subprocess.run", mock_run):
+        result = network_config.scan()
+
+    assert result["ok"] is True
+    assert "TestNet" in result["stdout"]
+    args, _ = mock_run.call_args
+    assert args[0] == ["sudo", "-n", network_config.HELPER_PATH, "scan"]
+
+
+# ---------------- connect() - the P1 #8 password-not-in-argv guarantee ----------------
+
+def test_connect_sends_password_via_stdin_not_argv():
+    mock_run = MagicMock(return_value=_completed(stdout="Connection successfully activated"))
+    with patch("subprocess.run", mock_run):
+        result = network_config.connect("HomeWifi", "super-secret-password")
+
+    assert result["ok"] is True
+    args, kwargs = mock_run.call_args
+    # The password must appear nowhere in the argv list - this is the
+    # entire point of P1 #8 (the old code put it in `nmcli ... password
+    # <pw>`, visible via ps aux / /proc/<pid>/cmdline).
+    assert args[0] == ["sudo", "-n", network_config.HELPER_PATH, "connect", "HomeWifi"]
+    assert "super-secret-password" not in args[0]
+    assert all("super-secret-password" not in str(a) for a in args[0])
+    # It must instead be passed as stdin input.
+    assert kwargs.get("input") == "super-secret-password"
+
+
+def test_connect_open_network_sends_empty_password_via_stdin():
+    mock_run = MagicMock(return_value=_completed(stdout="Connection successfully activated"))
+    with patch("subprocess.run", mock_run):
+        network_config.connect("OpenNet")
+
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["sudo", "-n", network_config.HELPER_PATH, "connect", "OpenNet"]
+    assert kwargs.get("input") == ""
+
+
+def test_connect_uses_longer_timeout_than_other_operations():
+    mock_run = MagicMock(return_value=_completed(stdout="ok"))
+    with patch("subprocess.run", mock_run):
+        network_config.connect("HomeWifi", "pw")
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("timeout") == network_config.CONNECT_TIMEOUT
+    assert network_config.CONNECT_TIMEOUT > network_config.HELPER_TIMEOUT
+
+
+def test_connect_failure_reason_never_echoes_the_password():
+    # Even on failure, the reason string must not have been built by
+    # interpolating the password anywhere (e.g. "connect HomeWifi pw
+    # failed") - it's whatever stderr the helper produced, which never saw
+    # the password as an argument in the first place.
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="Secrets were required, but not provided")):
+        result = network_config.connect("HomeWifi", "super-secret-password")
+    assert result["ok"] is False
+    assert "super-secret-password" not in result["reason"]
+
+
+# ---------------- forget() ----------------
+
+def test_forget_calls_helper_with_ssid_argv():
+    mock_run = MagicMock(return_value=_completed(stdout="deleted"))
+    with patch("subprocess.run", mock_run):
+        result = network_config.forget("HomeWifi")
+
+    assert result == {"ok": True, "stdout": "deleted"}
+    args, _ = mock_run.call_args
+    assert args[0] == ["sudo", "-n", network_config.HELPER_PATH, "forget", "HomeWifi"]
+
+
+# ---------------- shared _run_helper() error handling ----------------
+
+def test_sudo_not_configured_gives_actionable_reason():
+    with patch("subprocess.run", return_value=_completed(returncode=1, stderr="sudo: a password is required")):
+        result = network_config.forget("HomeWifi")
+    assert result["ok"] is False
+    assert "meshcenter-wifi.sudoers" in result["reason"]
+
+
+def test_helper_timeout_reported_not_raised():
+    with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="sudo", timeout=15)):
+        result = network_config.list_wifi_connections()
+    assert result["ok"] is False
+    assert "timed out" in result["reason"]
+
+
+def test_sudo_missing_reported_not_raised():
+    with patch("subprocess.run", side_effect=FileNotFoundError()):
+        result = network_config.scan()
+    assert result["ok"] is False
+    assert "sudo is not available" in result["reason"]
+
+
+def test_unexpected_exception_reported_not_raised():
+    with patch("subprocess.run", side_effect=RuntimeError("boom")):
+        result = network_config.forget("HomeWifi")
+    assert result["ok"] is False
+    assert "boom" in result["reason"]

--- a/tests/test_network_helper_script.py
+++ b/tests/test_network_helper_script.py
@@ -1,0 +1,103 @@
+"""Functional tests for scripts/meshcenter-network-helper's own argument-
+count guards (P1 #7/#8 stabilization follow-up).
+
+These run the REAL script via `bash <path> ...` (not the shebang/exec
+path, so this works the same on the Windows dev machine's Git Bash as on
+Linux CI - no os.name skipif needed, just a `bash` binary on PATH). They
+deliberately do NOT need nmcli/iw/root: every case here is rejected by
+require_argc()/the empty-SSID checks before the script ever calls out to
+nmcli, so these are safe to run anywhere bash is available, unlike a real
+connect/scan/forget which needs an actual wireless interface.
+
+This is the concrete verification requested during review: sudoers'
+`connect *` / `forget *` glob matches the WHOLE command line as a string,
+not per-argv-position, so it would equally allow
+`meshcenter-network-helper connect somessid --extra-dangerous-flag`
+through at the sudo layer - the script itself must be the thing that
+refuses anything past exactly one SSID argument, not just "reasoning"
+about what sudoers would technically permit.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HELPER_SCRIPT = str(Path(__file__).resolve().parent.parent / "scripts" / "meshcenter-network-helper")
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="requires a bash binary on PATH")
+
+
+def _run(*args, stdin_text=""):
+    return subprocess.run(
+        ["bash", HELPER_SCRIPT, *args],
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+# ---------------- argument-count guards (the review's explicit ask) ----------------
+
+def test_connect_rejects_extra_argv_past_the_ssid():
+    result = _run("connect", "HomeWifi", "--extra-dangerous-flag")
+    assert result.returncode != 0
+    assert "exactly one argument" in result.stderr
+
+
+def test_connect_rejects_missing_ssid():
+    result = _run("connect")
+    assert result.returncode != 0
+    assert "exactly one argument" in result.stderr
+
+
+def test_forget_rejects_extra_argv_past_the_ssid():
+    result = _run("forget", "HomeWifi", "somethingelse")
+    assert result.returncode != 0
+    assert "exactly one argument" in result.stderr
+
+
+def test_forget_rejects_missing_ssid():
+    result = _run("forget")
+    assert result.returncode != 0
+    assert "exactly one argument" in result.stderr
+
+
+def test_list_connections_rejects_any_argument():
+    result = _run("list-connections", "unexpected")
+    assert result.returncode != 0
+    assert "takes no arguments" in result.stderr
+
+
+def test_scan_rejects_any_argument():
+    result = _run("scan", "unexpected")
+    assert result.returncode != 0
+    assert "takes no arguments" in result.stderr
+
+
+def test_connect_rejects_empty_ssid():
+    result = _run("connect", "")
+    assert result.returncode != 0
+    assert "non-empty SSID" in result.stderr
+
+
+def test_forget_rejects_empty_ssid():
+    result = _run("forget", "")
+    assert result.returncode != 0
+    assert "non-empty SSID" in result.stderr
+
+
+# ---------------- subcommand dispatch ----------------
+
+def test_no_subcommand_rejected():
+    result = _run()
+    assert result.returncode != 0
+    assert "no subcommand given" in result.stderr
+
+
+def test_unknown_subcommand_rejected():
+    result = _run("delete-everything")
+    assert result.returncode != 0
+    assert "unknown subcommand" in result.stderr


### PR DESCRIPTION
## Summary
- **P1 #8** (confirmed via `ps aux`/`/proc/<pid>/cmdline`, not hypothetical): Wi-Fi connect put the password straight into `nmcli dev wifi connect <ssid> password <password>` argv.
- **P1 #7**: sudoers granted `NOPASSWD: /usr/bin/nmcli` / `/usr/sbin/iw` unconditionally - any subcommand those binaries support, not just what the UI needs.
- Adds `scripts/meshcenter-network-helper`, modeled on the existing `scripts/meshcenter-hw-config` pattern: fixed subcommands (`list-connections` / `scan` / `connect <ssid>` / `forget <ssid>`), no arbitrary passthrough, idempotent. `deploy/meshcenter-wifi.sudoers` now grants only this helper.
- `connect` reads the password from its own **stdin**, never as an argument - `meshsrv/network_config.py` (mirrors `hardware/hardware_config.py`'s `_run_helper()` shape) passes it via `subprocess.run(..., input=password)`. Stored in a NetworkManager keyfile profile (root:root, mode 600), not passed to `nmcli ... password`. Confirmed nmcli 1.52.1 / the `keyfile` plugin is actually active on a real node before relying on it.
- Unprivileged reads (`iw dev wlan0 link`, `iwgetid -r`) untouched - they need no root, so routing them through the helper would only add attack surface.

## Two things caught during implementation (not in the original ask)
- Profile filename must **not** derive from the SSID: 802.11 legally allows `/` in an SSID, so `${ssid}.nmconnection` would be a real path-traversal vector. Uses `mktemp` instead - NetworkManager identifies profiles by the `id=` field inside the file, not the filename.
- sudoers' `connect *`/`forget *` glob matches the whole command line as a string, not per-argv-position - it would equally permit `connect somessid --extra-dangerous-flag` at the sudo layer. The helper script itself enforces `require_argc` before doing anything, verified by running the **real script**, not reasoning about it (see test plan).

## Also
`connect` now unconditionally replaces any existing profile for the SSID before writing a fresh one (not just on error-retry like before) - removes the whole "key-mgmt property is missing" class of error the old two-pass Python retry existed to paper over.

`install.sh`/`meshcenter-firstboot.sh` install the new helper binary. `scripts/verify-install.sh` checks for it (same pattern as `meshcenter-hw-config`), including an explicit warning if a pre-upgrade node still has the OLD direct nmcli/iw sudoers rule (task 39's exact class of gap - `git pull` never updates `/etc/sudoers.d/*`).

## Test plan
- [x] `pytest` - 378 passed, 25 skipped (POSIX/Linux-only, expected on this dev machine)
- [x] `tests/test_network_config.py` (13 tests): Python-side wiring, explicit assertion the password string never appears anywhere in the subprocess argv list
- [x] `tests/test_network_helper_script.py` (9 tests): runs the **real bash script** via `bash <path>` (no `os.name` skipif - Git Bash provides `bash` on Windows too) - every argument-count/empty-SSID rejection, without needing nmcli/iw/root
- [x] `bash -n` on all four modified/added shell scripts
- [x] `python -m py_compile`/`compileall` on all modified/added Python files
- [ ] Live verification pending: manual re-provisioning (helper binary + new sudoers) on all three existing nodes (dev/camtest/prod - required per task 39's lesson, not deferred) and a real Wi-Fi connect/forget round-trip on dev, coordinated separately since it risks a temporary SSH interruption on whichever interface dev is actually using