### PR TITLE
Doc/CI stabilization: P1 #10-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,38 @@ jobs:
       - name: Byte-compile all Python sources
         run: python -m compileall -q .
 
+      - name: GPLv3 license-boundary check (meshtastic import stays inside adapters/meshtastic/)
+        run: |
+          set -e
+          # git ls-files, not a filesystem walk: scopes this to tracked
+          # sources only, so it can never be polluted by an untracked
+          # local scratch/worktree directory (verified: this repo's own
+          # .claude/worktrees/ holds pre-Task-48 code with real, now-
+          # historical `from meshtastic... import SerialInterface` lines -
+          # gitignored, so git ls-files never sees them, but a raw
+          # `grep -r .` would have and failed this check on files that
+          # were never part of the repo).
+          #
+          # Anchored to actual import statements (optional leading
+          # whitespace, \b word boundary after "meshtastic") - an
+          # unanchored substring grep for "import meshtastic"/"from
+          # meshtastic" also matches "import meshtastic_transport" (a
+          # first-party module name that happens to start with
+          # "meshtastic", see meshsrv/meshtastic_transport.py) and dozens
+          # of comments/docstrings/test mock class names across this
+          # codebase that mention SerialInterface/BLEInterface in prose -
+          # verified against the current tree before writing this step:
+          # an unanchored version produced ~45 false-positive hits here,
+          # none of them a real violation.
+          HITS=$(git ls-files -- '*.py' | grep -v "^adapters/meshtastic/" \
+              | xargs grep -nE "^\s*(import meshtastic\b|from meshtastic\b)" || true)
+          if [ -n "$HITS" ]; then
+            echo "GPLv3 boundary violation: meshtastic imported outside adapters/meshtastic/:"
+            echo "$HITS"
+            exit 1
+          fi
+          echo "OK - no meshtastic import found outside adapters/meshtastic/"
+
       - name: Shell script syntax check (bash -n)
         run: |
           set -e

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,14 +33,14 @@ your situation, they are not interchangeable steps of the same process:
 - Internet connection during installation
 
 **Minimum (Manual install):**
-- Any Linux system with Python 3.9+
-- Debian 11 (Bullseye) or newer / Ubuntu 22.04 LTS or newer
+- Any Linux system with Python 3.11+
+- Debian 12 (Bookworm) or newer / Ubuntu 23.04 or newer
 - 500MB free disk space · 512MB RAM · systemd
 
 **Not supported:**
 - Windows / macOS
 - Raspberry Pi OS 32-bit (lgpio compatibility issues)
-- Debian 10 (Buster) or older (Python 3.7 — too old)
+- Debian 11 (Bullseye) or older (Python 3.9/3.10 — below the 3.11 minimum) / Ubuntu 22.04 LTS or older (same reason)
 - Alpine Linux (musl libc — pip build failures)
 
 ---

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,22 @@ To keep GPLv3 code from linking into MeshCenter's own MIT-licensed process, `mes
 
 `meshtastic`'s own dependencies (installed alongside it in `adapters/meshtastic/venv`, pinned in `adapters/meshtastic/requirements.txt`) are all permissively licensed: `bleak` (Bluetooth LE support, MIT — along with its own dependency `dbus-fast`, also MIT), `protobuf` (BSD-3-Clause), `pyserial` (BSD), `pyyaml` (MIT), `requests` (Apache-2.0), `tabulate` (MIT), `pypubsub` (BSD-2-Clause), `packaging` (Apache-2.0 or BSD-2-Clause).
 
+## Chart.js (bundled, MIT)
+
+[Chart.js](https://www.chartjs.org/) v4.4.0 is vendored as `static/chart.umd.min.js` (fetched pre-minified from jsDelivr, per the file's own header comment) and used for telemetry charts (`static/chat-telemetry.js`) and the CPU history chart (`static/chat.js`). MIT-licensed — permissive, no attribution requirement beyond retaining the license notice already present in the bundled file's own header.
+
+## Leaflet (CDN, BSD-2-Clause)
+
+[Leaflet](https://leafletjs.com/) v1.9.4 is loaded from the `unpkg.com` CDN (`templates/index.html`), not bundled — no local copy to track a license file for. BSD-2-Clause. Leaflet itself doesn't require on-map attribution for its own code, but see the OpenStreetMap entry below for the tile data it renders, which does.
+
+## OpenStreetMap tiles (external service, attribution required)
+
+The Map workspace (`static/chat-map.js`) renders tiles from `tile.openstreetmap.org` via a Leaflet `L.tileLayer`, with the required `&copy; OpenStreetMap contributors` attribution already wired into that same `L.tileLayer(...)` call — the [OSM tile usage policy](https://operations.osmfoundation.org/policies/tiles/) requires this attribution to remain visible on the map, not just exist in this file. Map data © OpenStreetMap contributors, [ODbL-licensed](https://www.openstreetmap.org/copyright); MeshCenter doesn't bundle or redistribute the tile data itself, only fetches it live from the map workspace UI. `settings.maps.provider` also offers a `google` option — that's an outbound "open in Google Maps" link, not an embedded/bundled dependency, so it doesn't need an entry here.
+
+## Waveshare e-Paper driver (vendored, MIT-style per-file notice)
+
+`modules/display/drivers/vendor/waveshare_epd/` vendors Waveshare's official demo driver for the 2.13" 4-color e-Paper HAT (G) — see [`LICENSE_NOTICE.md`](modules/display/drivers/vendor/waveshare_epd/LICENSE_NOTICE.md) in that directory for the full provenance (exact source URL, retrieval date, the GitHub-`master`-vs-official-ZIP divergence that matters for anyone re-vendoring this later) and the per-file MIT-style permission notice each vendored file carries in its own header.
+
 ## Everything else
 
 Core's own dependencies (`requirements.txt`) — Flask, Pillow, requests, psutil, v4l2py, gunicorn — are all permissively licensed (MIT/BSD/Apache-family). See each package's own PyPI page for its specific license.

--- a/adapters/meshtastic/ipc_server.py
+++ b/adapters/meshtastic/ipc_server.py
@@ -29,11 +29,12 @@ completely stateless about "which one is active", so Core and the
 adapter can never disagree about it after a partial failure the way two
 independently-tracked "active" flags could.
 
-Not started from server.py yet - server.py still constructs
-SerialTransport/BLETransport in-process (unchanged). This is a
-free-standing module Core's supervisor spawns; it works today against a
-real venv with meshtastic/bleak installed, wiring it into server.py is
-the next increment.
+Wired into server.py: `AdapterSupervisor` spawns this module as
+`<adapter venv>/bin/python -m adapters.meshtastic.ipc_server`, and
+`AdapterIPCTransport` (both in `meshsrv/adapter_ipc_client.py`) is the
+concrete `RadioTransport` implementation `server.py` actually constructs
+and routes through `TransportRouter` - not an in-process
+SerialTransport/BLETransport construction any more.
 """
 from __future__ import annotations
 

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -1,12 +1,15 @@
 # Backend Protocol v1
 
-Status: **draft, interface-only** (Task 43.5). No implementation exists yet.
-`SerialTransport` (Task 44) and `BLETransport` (Task 45) will implement this
-contract; the Python interface lives in
-[`meshsrv/radio_transport.py`](../meshsrv/radio_transport.py) as an
-`abc.ABC` — this document also defines the JSON wire shape the same contract
-maps onto once the adapter is moved behind a subprocess boundary (Task 48).
-Until then, Core calls the Python interface directly, in-process.
+Status: **implemented and live** — `SerialTransport` (Task 44) and
+`BLETransport` (Task 45) implement this contract; the Python interface lives
+in [`meshsrv/radio_transport.py`](../meshsrv/radio_transport.py) as an
+`abc.ABC`. Task 48's process-isolation boundary has also landed: Core
+(`server.py`) constructs `AdapterIPCTransport`/`AdapterSupervisor`
+(`meshsrv/adapter_ipc_client.py`) and wires them into `TransportRouter` —
+the concrete transports run in a separate OS process (the "adapter"
+subprocess), not in-process inside Core, and this document's "JSON wire
+shape" section below is the real, in-use serialization for that boundary
+(implemented in `meshsrv/ipc_protocol.py`), not a forward-looking sketch.
 
 `protocol_version` (currently `1`) is present on every JSON message so the
 IPC boundary introduced in Task 48 can detect a Core/adapter version
@@ -15,11 +18,15 @@ mismatch instead of failing opaquely.
 ## Where this comes from
 
 Five call sites in Core (`server.py`, `api/api_chat.py` ×2,
-`meshsrv/schedule_actions.py`, `storage/waypoint_sender.py`) import
-`meshtastic` (GPLv3) directly today — a real copyleft violation, not a
-formality. This protocol is the boundary that isolates all Meshtastic
-specifics (Serial today, BLE from Task 45) behind neutral models, so Core
-(MIT) never imports `meshtastic` once Task 48 lands.
+`meshsrv/schedule_actions.py`, `storage/waypoint_sender.py`) used to import
+`meshtastic` (GPLv3) directly — a real copyleft violation, not a formality.
+This protocol is the boundary that isolates all Meshtastic specifics
+(Serial, BLE) behind neutral models, and Task 48 landing closed that
+violation for real: `import meshtastic`/`from meshtastic ...` no longer
+appears anywhere in Core (verified by grep, not assumed — CI now enforces
+this on every PR/push, see `.github/workflows/ci.yml`'s "GPLv3
+license-boundary check" step). The five call sites above now go through
+`TransportRouter`/`RadioTransport` instead.
 
 ## Operations
 
@@ -44,11 +51,11 @@ specifics (Serial today, BLE from Task 45) behind neutral models, so Core
 `get_channels` was not in the original Task 43.5 operation list handed
 down from the plan document, even though `channel` was already listed
 among the neutral models below. `api/api_chat.py`'s
-`discover_radio_channels()` reads exactly this today — without a
-corresponding method, that functionality has nowhere to go in Task 44. This
-mirrors the gap the plan already caught and fixed once, for `send_waypoint`
-and `set_device_time`. **Flagged for confirmation before Task 44**, not
-assumed.
+`discover_radio_channels()` reads exactly this today. This mirrored the gap
+the plan already caught and fixed once, for `send_waypoint` and
+`set_device_time` — **resolved**: `get_channels` is implemented in both
+`SerialTransport` and `BLETransport` (`adapters/meshtastic/`), not just
+declared on the interface.
 
 ## Timeouts
 
@@ -81,11 +88,22 @@ Only an OS process can be `SIGKILL`ed.
    session from a previous attempt blocking the next `connect()` until an
    out-of-band `bluetoothctl disconnect`.
 
-**Which one is implemented at this stage: tier 1 only.** An implementation
-that wants real resource release before Task 48 has to arrange it itself —
-e.g. run the risky library call in its own short-lived subprocess (which
-*can* be `SIGKILL`ed) rather than a thread. That is an implementation
-decision for Task 44/45, not something this interface guarantees for them.
+**Both tiers are implemented now that Task 48 has landed.** Tier 1
+(non-blocking return) has held since Task 44/45; tier 2 (resource release)
+is real as of Task 48's process boundary — `AdapterSupervisor.call()`
+(`meshsrv/adapter_ipc_client.py`) waits up to the caller's declared budget
+for a response and `SIGKILL`s the adapter subprocess on expiry, so a
+wedged call's orphaned resources (event loop, live bleak/GATT session) go
+away with the process, not just get abandoned in a still-running thread.
+BLE cleanup on a kill is handled explicitly too: a `SIGKILL`'d adapter's
+serial file descriptors are reclaimed by the kernel automatically, but a
+BLE GATT session (brokered through BlueZ over D-Bus) can outlive the
+process that opened it, so Core runs `bluetoothctl disconnect <address>`
+itself when a kill happens mid-BLE-operation (see
+`meshsrv/adapter_ipc_client.py`'s module docstring for the full detail,
+including the two independent layers — `KillMode=control-group` and
+`PR_SET_PDEATHSIG` — that separately cover Core itself dying with the
+adapter still alive).
 
 ## Reconnect / teardown
 
@@ -153,23 +171,42 @@ use today. A normalized event stream (`message_received`, `node_updated`,
 `telemetry`, `connection_state`) is explicitly deferred to Stage B (Task
 49+, "Stage B listener").
 
-## JSON wire shape (for Task 48's subprocess IPC boundary)
+## JSON wire shape (Task 48's subprocess IPC boundary — implemented, in use)
 
-Not used yet — Core calls the Python interface in-process through Task 47.
-Documented now so Task 48 has no interface redesign to do, only a
-serialization layer.
+Implemented in `meshsrv/ipc_protocol.py` (Core side) and
+`adapters/meshtastic/ipc_server.py` (adapter side); this is the real,
+current serialization for every call between Core and the adapter
+subprocess, not a forward-looking sketch.
+
+One deliberate addition beyond what was originally sketched here: every
+request also carries a `transport_type` field (`"serial"` or
+`"bluetooth"`), telling the adapter subprocess which of its two live
+transport instances (`SerialTransport`/`BLETransport`) to route this call
+to. This keeps the adapter subprocess stateless about "which transport is
+active" — `TransportRouter` on Core's side already tracks that, and
+forwarding it on every request means Core and the adapter can never
+disagree about it after a partial failure the way two independently
+tracked "active" flags could (see `adapters/meshtastic/ipc_server.py`'s
+module docstring, "STATELESS ROUTING"). Shown below on the `connect()`
+example.
 
 ```jsonc
-// Request
+// Request - params.message is a full OutgoingMessage dict, nested under
+// a "message" key (matching AdapterIPCTransport.send_text()'s actual
+// {"message": outgoing_message_to_dict(message)} call, not a flat dict
+// of the message's own fields)
 {
   "protocol_version": 1,
   "operation": "send_text",
+  "transport_type": "serial",
   "params": {
-    "text": "hello mesh",
-    "destination_id": "^all",
-    "channel_index": 0,
-    "want_ack": false,
-    "reply_id": null
+    "message": {
+      "text": "hello mesh",
+      "destination_id": "^all",
+      "channel_index": 0,
+      "want_ack": false,
+      "reply_id": null
+    }
   },
   "timeout": 15.0
 }
@@ -201,24 +238,36 @@ serialization layer.
 ```
 
 ```jsonc
-// connect()
+// connect() - transport_type is the stateless-routing addition, see above.
+// `timeout` is top-level only, not duplicated inside `params` - `params`
+// here is exactly {descriptor, force}, matching AdapterIPCTransport.
+// connect()'s actual call site (meshsrv/adapter_ipc_client.py).
 {
   "protocol_version": 1,
   "operation": "connect",
+  "transport_type": "bluetooth",
   "params": {
     "descriptor": {
       "type": "bluetooth",
       "address": "3C:DC:75:6F:99:61",
       "label": "FLT2_9960"
     },
-    "force": true,
-    "timeout": 30.0
-  }
+    "force": true
+  },
+  "timeout": 30.0
 }
 ```
 
 ```jsonc
-// get_connection_info() response
+// connect()'s response - this ConnectionInfo shape is what populates
+// AdapterIPCTransport's local cache, which get_connection_info() then
+// serves from directly (Task 48 design decision: get_connection_info()
+// itself is non-blocking/cache-only and never crosses the IPC boundary at
+// all - see AdapterIPCTransport.get_connection_info() in
+// meshsrv/adapter_ipc_client.py, "never cross the IPC boundary, per the
+// approved investigation report"). Shown here as a response because this
+// exact shape is real wire traffic on every connect()/reconnect() call,
+// just not one this specific method name triggers itself.
 {
   "protocol_version": 1,
   "ok": true,

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ PROGRESS_PORT=80
 LOG_FILE="/tmp/meshcenter-install.log"
 PROGRESS_FILE="/tmp/meshcenter-progress.txt"
 MIN_PYTHON_MAJOR=3
-MIN_PYTHON_MINOR=9
+MIN_PYTHON_MINOR=11
 MIN_FREE_MB=500
 MIN_RAM_MB=512
 
@@ -118,9 +118,9 @@ step_preflight() {
         *) warn "Unknown architecture: $ARCH. Proceeding anyway." ;;
     esac
 
-    # Python >= 3.9
+    # Python >= 3.11
     command -v python3 &>/dev/null || \
-        fail "python3 not found. Install Python 3.9+ first."
+        fail "python3 not found. Install Python 3.11+ first."
 
     PY_MAJOR=$(python3 -c "import sys; print(sys.version_info.major)")
     PY_MINOR=$(python3 -c "import sys; print(sys.version_info.minor)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,17 @@
-Flask>=3.0.0
-Pillow>=10.0.0
-requests>=2.31.0
-psutil>=5.9.0
+# P1 #14 stabilization follow-up: range-pinned (lower bound = what's
+# actually been live-verified, upper bound = the next untested major),
+# same reasoning as gunicorn's own pin below - not exact `==` pins
+# (this is a small Flask monolith installed directly via
+# `pip install -r requirements.txt` on real Pi nodes with no lock-file
+# build step, not a project with a large transitive dependency graph or
+# multiple deployment targets that would justify a pip-compile-generated
+# lock file), but not left fully unbounded either. Live-verified versions
+# on dev (!756f9960) at the time of this pin: Flask 3.1.3, Pillow 11.1.0,
+# requests 2.32.3, psutil 7.2.2.
+Flask>=3.0.0,<4.0.0
+Pillow>=10.0.0,<12.0.0
+requests>=2.31.0,<3.0.0
+psutil>=5.9.0,<8.0.0
 # Task 48: the meshtastic package (GPLv3) no longer lives in Core's own
 # venv - Core never imports it directly (adapters/meshtastic/*.py are the
 # only modules that do, and they run in a separate process/venv, see
@@ -11,7 +21,7 @@ psutil>=5.9.0
 # --info calls (arm's-length subprocess invocation, not an import) -
 # meshsrv/runtime_identity.py's resolve_meshtastic_cli() finds that
 # binary in the adapter venv created by install.sh's step_adapter_venv().
-v4l2py>=3.0.0
+v4l2py>=3.0.0,<4.0.0
 # Production WSGI server (see gunicorn.conf.py / deploy/meshcenter.service).
 # Pinned to the 23.x line - gunicorn's own worker/arbiter internals (the
 # gthread worker class specifically, which /video_feed's long-lived MJPEG


### PR DESCRIPTION
## Summary

- **#10** `docs/BACKEND_API.md` — rewrote the Status section (falsely claimed "draft, interface-only... No implementation exists yet" and in-process calls; Task 48's process isolation has been live for a while — verified against `server.py` directly). Also fixed several parts of the doc that had quietly drifted from the real implementation while being verified section-by-section, not deleted wholesale: the closed meshtastic-import violation, tier-2 timeout guarantee now real, `get_channels` resolved (not still "flagged"), and the JSON wire shape section/examples — which turned out to have real shape divergences (`transport_type` field missing from every example despite being sent on every real request, `send_text`'s actual `{"message": {...}}` params shape, `connect()` not actually duplicating `timeout` inside `params`, and `get_connection_info()` never actually crossing the IPC boundary). One-line fix in `adapters/meshtastic/ipc_server.py`'s own docstring, which still said "wiring it into server.py is the next increment" — directly contradicted by `server.py` already doing exactly that.
- **#11** `THIRD_PARTY_NOTICES.md` — added the four missing sections: Chart.js (bundled, MIT), Leaflet (CDN, BSD-2-Clause), OpenStreetMap tiles (external service, attribution already wired into the UI), Waveshare e-Paper driver (vendored, pointer to its existing `LICENSE_NOTICE.md`). Existing meshtastic section untouched.
- **#12** Python 3.11+ — policy-only, zero code impact (verified: no match/case/except*/tomllib syntax anywhere, the one walrus-operator use is 3.8+, no dependency requires 3.11). Updated `INSTALL.md` and `install.sh` (both the enforced `MIN_PYTHON_MINOR` check and the message), plus the OS-version minimum line for internal consistency (Debian 11/Ubuntu 22.04 no longer clear a 3.11 floor).
- **#13** CI — added a "GPLv3 license-boundary check" step to the existing `checks` job. The plan document's suggested grep pattern produces ~45 false positives against the current tree (verified before writing the step) — the actual step anchors to real import statements and scopes to `git ls-files` (not a filesystem walk) so it can't be polluted by an untracked local scratch/worktree directory.
- **#14** Dependency lock — range-pinned directly in `requirements.txt` (lower bound = live-verified on dev, upper bound = next untested major), matching the existing `gunicorn` pin's precedent, per the design decision confirmed before implementing (not a pip-compile lock file).

## Test plan
- [x] `pytest` — 378 passed, 25 skipped (POSIX/Linux-only, expected on this dev machine)
- [x] `python -m compileall -q .`
- [x] `bash -n install.sh meshcenter-firstboot.sh deploy.sh`
- [x] `pip install --dry-run -r requirements.txt` — new version ranges resolve cleanly
- [x] The new CI GPLv3-boundary step run manually against the current tree: clean pass; separately verified it actually catches a real violation before adding it
- [x] YAML-validated the modified `.github/workflows/ci.yml`