### PR TITLE
P0: fix adapter stdout/IPC protocol corruption (Droidian-caught cascade)

### DIFF
--- a/adapters/meshtastic/ipc_server.py
+++ b/adapters/meshtastic/ipc_server.py
@@ -38,6 +38,7 @@ SerialTransport/BLETransport construction any more.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 import threading
@@ -203,6 +204,81 @@ class _AdapterDispatcher:
         raise TransportError(TransportErrorCode.UNSUPPORTED, f"unknown operation: {operation!r}")
 
 
+def serve_forever(dispatcher: _AdapterDispatcher, *, stdin=None, stdout=None) -> None:
+    """The read-dispatch-write loop. `stdin`/`stdout` are DI seams for
+    tests (defaulting to the real sys.stdin/sys.stdout in production) -
+    matching this project's convention elsewhere for exercising real
+    logic against fakes instead of mocking the loop away.
+
+    STDOUT PROTOCOL ISOLATION (P0 stabilization follow-up - Droidian-
+    caught: a stray print() from meshsrv/serial_port_supervisor.py's
+    wait_serial_release(), triggered by an `lsof` subprocess timeout,
+    corrupted this exact JSON stream, cascading into a killed adapter and
+    a serial-contention "Radio Busy" loop). `protocol_stdout` is captured
+    ONCE, before any request handling, and is the ONLY thing a JSON
+    response is ever written through below. Every `dispatcher.handle(...)`
+    call runs inside `contextlib.redirect_stdout(sys.stderr)`, so ANY
+    stray print() during it - first-party (serial_port_supervisor.py,
+    now fixed at the source too, see that module's own print() call
+    sites - this redirect is belt-and-suspenders, not a replacement for
+    that fix, see the gap explained next) or third-party (the meshtastic
+    library itself, never audited for its own prints) - lands on stderr,
+    never on the real protocol channel.
+
+    THIS REDIRECT ALONE IS NOT SUFFICIENT (investigation finding, not
+    assumed): adapters/meshtastic/_timeout_support.py's
+    _call_with_timeout() runs the actual work on a background daemon
+    thread. If that call hits its OWN internal timeout, the caller gets
+    TransportError(TIMEOUT) back and the `with redirect_stdout(...)`
+    block below exits - but the background thread itself is not killed
+    (the documented tier-1/tier-2 gap, docs/BACKEND_API.md "Timeouts")
+    and may still be running unsupervised, e.g. inside
+    wait_serial_release()'s own retry loop. If THAT orphaned thread calls
+    print() after this block has already exited and restored the real
+    stdout - most likely while this loop is blocked on `for line in
+    stdin:` waiting for Core's next request, i.e. exactly when the
+    protocol channel is live and unguarded again - an unfixed print()
+    call site would still corrupt it, redirect_stdout notwithstanding.
+    Fixing every print() call site in meshsrv/serial_port_supervisor.py
+    directly (file=sys.stderr, unconditional, independent of whatever
+    sys.stdout happens to be at the time) is what actually closes this
+    gap; the redirect here only covers the common/expected case and
+    anything not yet audited for its own stray prints (meshtastic
+    itself). Neither one is optional-if-the-other-exists.
+
+    SINGLE-THREADED LOOP, SAFE TO MUTATE sys.stdout GLOBALLY: this
+    function's own `for line in stdin:` loop is strictly synchronous -
+    one request is read, dispatched, and answered before the next line
+    is ever read (Core's TransportRouter already serializes callers to
+    at most one in-flight IPC call - see this module's own docstring,
+    "STATELESS ROUTING"). redirect_stdout() mutates the process-global
+    sys.stdout for the duration of its `with` block, which would be
+    unsafe if two of THIS loop's own iterations could overlap - they
+    structurally cannot. The background daemon thread described above is
+    a different, already-covered case (the print()-call-site fix), not a
+    second concurrent iteration of this loop.
+    """
+    stdin = stdin if stdin is not None else sys.stdin
+    protocol_stdout = stdout if stdout is not None else sys.stdout
+
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as error:
+            response = ipc_protocol.make_error_response(
+                TransportError(TransportErrorCode.UNKNOWN, f"malformed request JSON: {error}")
+            )
+        else:
+            with contextlib.redirect_stdout(sys.stderr):
+                response = dispatcher.handle(request)
+
+        protocol_stdout.write(json.dumps(response) + "\n")
+        protocol_stdout.flush()
+
+
 def main() -> None:
     import argparse
 
@@ -221,21 +297,7 @@ def main() -> None:
         ble_transport=BLETransport(address=""),
     )
 
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            request = json.loads(line)
-        except json.JSONDecodeError as error:
-            response = ipc_protocol.make_error_response(
-                TransportError(TransportErrorCode.UNKNOWN, f"malformed request JSON: {error}")
-            )
-        else:
-            response = dispatcher.handle(request)
-
-        sys.stdout.write(json.dumps(response) + "\n")
-        sys.stdout.flush()
+    serve_forever(dispatcher)
 
 
 if __name__ == "__main__":

--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -182,6 +182,25 @@ _KILL_WAIT_TIMEOUT_S = 5.0
 
 _BLUETOOTHCTL_DISCONNECT_TIMEOUT_S = 10.0
 
+# P0 stabilization follow-up (Droidian-caught stdout-corruption cascade):
+# before this, ANY non-JSON line on the adapter's stdout - even one
+# stray print() from a source not yet audited - killed the adapter
+# outright on the very first bad line, no tolerance at all. These bound
+# how many/how much malformed content this reader will skip past before
+# giving up (still within the caller's own overall `timeout` budget -
+# this never extends it). Kept deliberately small (5 lines / 4KB, not
+# tens): tolerating a couple of stray lines absorbs the "one print() slipped
+# through despite ipc_server.py's redirect_stdout + the serial_port_
+# supervisor.py source fix" case this whole effort exists to paper over
+# as a last resort - but a stream producing MORE than a handful of bad
+# lines in a row is not a one-off print(), it's a sign the adapter's
+# stdout protocol is genuinely broken (wrong Python launched, a crash mid-
+# write, something writing a real log stream to stdout) and should fail
+# fast and diagnosably (ADAPTER_PROTOCOL_ERROR) rather than mask a bigger
+# problem behind a long tolerant wait.
+MAX_NON_JSON_LINES = 5
+MAX_NON_JSON_BYTES = 4096
+
 # Task 48 review, unaddressed gap in the original design: KillMode=
 # control-group in deploy/meshcenter.service (confirmed live on TAP2 via
 # `systemctl show -p KillMode` - not assumed from documentation) means a
@@ -337,14 +356,55 @@ class AdapterSupervisor:
             bufsize=1,
             preexec_fn=_set_pdeathsig_to_sigkill if sys.platform == "linux" else None,
         )
+        # P0 stabilization follow-up: stderr=PIPE above gives the adapter
+        # subprocess a real OS pipe with a finite kernel buffer (typically
+        # 64KB on Linux) - before this drain thread, nothing ever read it.
+        # A writer blocks once that buffer fills, so an adapter that logs
+        # enough to stderr (more likely now that ipc_server.py's
+        # redirect_stdout sends stray prints there too - see that
+        # module's serve_forever()) could wedge itself indefinitely on a
+        # stderr write nobody was ever going to drain. One daemon thread
+        # per spawned process (not shared across respawns - proc.stderr
+        # is a fresh pipe each time), forwarding each line to on_log()
+        # rather than discarding it, since it's real diagnostic
+        # information (exactly the print()s this whole effort relocated
+        # there), not noise to throw away.
+        proc = self._proc
+        threading.Thread(
+            target=self._drain_stderr, args=(proc,), daemon=True, name="adapter-stderr-drain"
+        ).start()
+
+    def _drain_stderr(self, proc: subprocess.Popen) -> None:
+        try:
+            for line in proc.stderr:
+                line = line.rstrip("\n")
+                if line:
+                    self._on_log(f"[adapter stderr] {line}", "WARNING")
+        except Exception:
+            # The pipe closing (process exited/killed) or any other read
+            # error ends the drain silently - this thread's only job is
+            # to keep the pipe from filling, not to report its own
+            # lifecycle; a killed/respawned adapter gets a fresh drain
+            # thread from the next _spawn_locked() call regardless.
+            pass
 
     def call(self, request: dict, *, timeout: float, ble_address_for_cleanup: Optional[str]) -> dict:
-        """Send one request, wait up to `timeout` for one response line.
-        On any failure to complete within that window - no response, a
-        write error, a dead process - kills the adapter (+ BLE cleanup
-        if `ble_address_for_cleanup` is set) and raises TransportError,
-        so the caller's thread is always released by `timeout`, never
-        left waiting on the subprocess itself."""
+        """Send one request, wait up to `timeout` for one valid JSON
+        response line - tolerating up to MAX_NON_JSON_LINES/
+        MAX_NON_JSON_BYTES of stray non-JSON output first (P0
+        stabilization follow-up: the adapter's stdout is also its IPC
+        channel, so one stray print() used to be fatal - see
+        adapters/meshtastic/ipc_server.py's serve_forever() and
+        meshsrv/serial_port_supervisor.py for where that could come from
+        and how it's now guarded at the source too). On any failure to
+        complete within the overall `timeout` window - no response, a
+        write error, a dead process, or malformed output past the
+        tolerance bounds (TransportErrorCode.ADAPTER_PROTOCOL_ERROR,
+        distinct from ADAPTER_UNAVAILABLE/UNKNOWN so this failure mode is
+        diagnosable on its own) - kills the adapter (+ BLE cleanup if
+        `ble_address_for_cleanup` is set) and raises TransportError, so
+        the caller's thread is always released by `timeout`, never left
+        waiting on the subprocess itself."""
         with self._proc_lock:
             if self._proc is None or self._proc.poll() is not None:
                 try:
@@ -374,8 +434,47 @@ class AdapterSupervisor:
             result_box: "queue.Queue[tuple[str, object]]" = queue.Queue(maxsize=1)
 
             def _read() -> None:
+                # P0 stabilization follow-up: parsing now happens IN this
+                # thread, not back in call() - lets it tolerate a bounded
+                # number of non-JSON lines (MAX_NON_JSON_LINES/
+                # MAX_NON_JSON_BYTES, see those constants' own comment for
+                # why) before giving up, instead of the previous behavior
+                # of killing the adapter on the very first malformed line
+                # - the actual mechanism of the observed Droidian
+                # corruption cascade (a single stray print() from
+                # wait_serial_release() was enough to kill a healthy
+                # adapter and cascade into serial contention). Still
+                # bounded by call()'s own `result_box.get(timeout=timeout)`
+                # below either way - tolerating bad lines never extends
+                # the caller's overall deadline, it only avoids treating
+                # ONE stray line as fatal within it.
+                bad_lines = 0
+                bad_bytes = 0
                 try:
-                    result_box.put(("ok", proc.stdout.readline()))
+                    while True:
+                        raw = proc.stdout.readline()
+                        if not raw:
+                            result_box.put(("closed", None))
+                            return
+                        stripped = raw.strip()
+                        if not stripped:
+                            continue
+                        try:
+                            parsed = json.loads(stripped)
+                        except json.JSONDecodeError:
+                            bad_lines += 1
+                            bad_bytes += len(raw)
+                            if bad_lines > MAX_NON_JSON_LINES or bad_bytes > MAX_NON_JSON_BYTES:
+                                result_box.put((
+                                    "protocol_error",
+                                    f"{bad_lines} malformed line(s) totaling {bad_bytes} bytes "
+                                    f"before giving up (limits: {MAX_NON_JSON_LINES} lines / "
+                                    f"{MAX_NON_JSON_BYTES} bytes)",
+                                ))
+                                return
+                            continue
+                        result_box.put(("ok", parsed))
+                        return
                 except Exception as exc:  # noqa: BLE001
                     result_box.put(("error", exc))
 
@@ -397,21 +496,18 @@ class AdapterSupervisor:
                     TransportErrorCode.ADAPTER_UNAVAILABLE, f"failed to read from adapter subprocess: {payload}"
                 )
 
-            line = str(payload).strip()
-            if not line:
+            if status == "closed":
                 self._kill_locked(ble_address_for_cleanup)
                 raise TransportError(
                     TransportErrorCode.ADAPTER_UNAVAILABLE,
                     "adapter subprocess closed its output unexpectedly (crashed or exited)",
                 )
 
-            try:
-                return json.loads(line)
-            except json.JSONDecodeError as error:
+            if status == "protocol_error":
                 self._kill_locked(ble_address_for_cleanup)
-                raise TransportError(
-                    TransportErrorCode.UNKNOWN, f"malformed response from adapter subprocess: {error}"
-                ) from error
+                raise TransportError(TransportErrorCode.ADAPTER_PROTOCOL_ERROR, str(payload))
+
+            return payload
 
     def _kill_locked(self, ble_address_for_cleanup: Optional[str]) -> None:
         """Caller must already hold self._proc_lock."""

--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -585,7 +585,14 @@ class AdapterIPCTransport(RadioTransport):
                 # since freeing the port is a fixed-magnitude operation.
                 # What it actually took IS subtracted from the caller's
                 # budget below - dynamic, not a fixed proportion (see
-                # module docstring).
+                # module docstring). KNOWN TRADE-OFF: the more thorough
+                # (and more correct) the port-busy check inside this
+                # claim is, the slower a worst-case claim can be on slow
+                # hardware, and the less of `remaining` is left for the
+                # actual call() below - see
+                # SerialPortSupervisor.check_port_release_once()'s own
+                # docstring for the specific trade-off this was measured
+                # against (P0 stabilization follow-up).
                 with self._core_serial_transport.claim_exclusive_access():
                     elapsed = time.monotonic() - start
                     remaining = max(1.0, timeout - elapsed)

--- a/meshsrv/radio_transport.py
+++ b/meshsrv/radio_transport.py
@@ -56,6 +56,17 @@ class TransportErrorCode(str, Enum):
     # "radio not connected" apart from "the whole adapter is missing" at a
     # glance, not by string-matching last_error.message.
     ADAPTER_UNAVAILABLE = "adapter_unavailable"
+    # P0 stabilization follow-up (Droidian-caught stdout-corruption
+    # cascade): distinct from ADAPTER_UNAVAILABLE (adapter never reached/
+    # crashed/closed its pipe) and UNKNOWN (a genuinely nondescript
+    # failure) - this means the adapter WAS reached and responded, but
+    # what came back on stdout wasn't valid JSON after tolerating a
+    # bounded number of stray lines (AdapterSupervisor.call()'s reader -
+    # see MAX_NON_JSON_LINES/MAX_NON_JSON_BYTES there). A caller/UI can
+    # tell "the wire protocol itself broke" apart from "a radio-level
+    # thing failed" or "the adapter is missing entirely" at a glance, not
+    # by string-matching last_error.message.
+    ADAPTER_PROTOCOL_ERROR = "adapter_protocol_error"
 
 
 # ---------------------------------------------------------------------------

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -41,13 +41,38 @@ from SerialTransport's own internal send/get methods too, not just
 """
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 import threading
 import time
 from contextlib import contextmanager
+from enum import Enum
+from pathlib import Path
 from typing import Callable, Optional
 
 from meshsrv.radio_transport import TransportError, TransportErrorCode
+
+
+class PortReleaseOutcome(str, Enum):
+    """P0 stabilization follow-up (Droidian-caught): wait_serial_release()
+    used to collapse every non-PORT_FREE case - a real busy port, an
+    `lsof` timeout, `lsof` erroring, `lsof` missing entirely - into the
+    same boolean False, indistinguishable from each other in both the
+    return value and the log line. Root cause of the observed corruption
+    cascade: on Droidian, `lsof` itself apparently hits its own 2s
+    subprocess timeout unreliably (slower/different I/O than the
+    Raspberry Pi hardware this was developed and live-verified against),
+    which every prior version of this code treated as "port busy" -
+    which then unnecessarily lengthened the exclusive-access claim,
+    increasing the odds a stray print() (see this module's print() call
+    sites, all now file=sys.stderr) would land on the adapter's stdout
+    protocol channel mid-claim."""
+    PORT_FREE = "port_free"
+    PORT_BUSY = "port_busy"
+    CHECK_TIMEOUT = "check_timeout"
+    CHECK_FAILED = "check_failed"
+    UTILITY_MISSING = "utility_missing"
 
 
 class SerialPortSupervisor:
@@ -134,7 +159,7 @@ class SerialPortSupervisor:
                     try:
                         self._on_raw_line(line)
                     except Exception as e:
-                        print(f"[SerialPortSupervisor] on_raw_line error: {e}", flush=True)
+                        print(f"[SerialPortSupervisor] on_raw_line error: {e}", file=sys.stderr, flush=True)
 
                 with self._radio_lock:
                     current = self._listen_process
@@ -157,7 +182,10 @@ class SerialPortSupervisor:
                     continue
 
                 if return_code is not None and return_code != 0:
-                    print(f"[SerialPortSupervisor] Listener process ended with code: {return_code}", flush=True)
+                    print(
+                        f"[SerialPortSupervisor] Listener process ended with code: {return_code}",
+                        file=sys.stderr, flush=True,
+                    )
                     consecutive_errors += 1
                 else:
                     consecutive_errors = 0
@@ -168,7 +196,10 @@ class SerialPortSupervisor:
 
             except Exception as e:
                 consecutive_errors += 1
-                print(f"[SerialPortSupervisor] run_listener (attempt {consecutive_errors}): {e}", flush=True)
+                print(
+                    f"[SerialPortSupervisor] run_listener (attempt {consecutive_errors}): {e}",
+                    file=sys.stderr, flush=True,
+                )
                 delay = min(consecutive_errors * 2, 30)
                 time.sleep(delay)
 
@@ -239,33 +270,156 @@ class SerialPortSupervisor:
                     proc.wait(timeout=5)
             return True
         except Exception as e:
-            print(f"[SerialPortSupervisor] Error stopping listener: {e}", flush=True)
+            print(f"[SerialPortSupervisor] Error stopping listener: {e}", file=sys.stderr, flush=True)
             return False
         finally:
             with self._radio_lock:
                 self._listen_process = None
             time.sleep(1.0)
 
+    # ------------------------------------------------------------------
+    # Port-release check (P0 stabilization follow-up) - layered, cheapest
+    # and most reliable check first, `lsof` (an external process, subject
+    # to its own timeout/missing-binary/hang risk - the actual root cause
+    # of the Droidian corruption cascade) only as a last resort. Each
+    # layer returns a PortReleaseOutcome or None ("inconclusive, ask the
+    # next layer") rather than collapsing straight to a bool.
+    # ------------------------------------------------------------------
+    def _check_known_pid(self) -> Optional[PortReleaseOutcome]:
+        """Cheapest, most limited check: is OUR OWN listener process still
+        holding the port? This answers "does our own listener still grip
+        me back", NOT "is the port free in general" - an orphaned process
+        left over from a previous adapter crash, or an entirely unrelated
+        process on the device, is invisible to this check by design. It
+        exists to short-circuit the common case (we know for a fact our
+        own listener is still up) cheaply; the layers below exist
+        precisely to catch what this one structurally cannot. Never treat
+        this returning None as "port confirmed free" - it only means "not
+        held by the process we already know about".
+        """
+        with self._radio_lock:
+            proc = self._listen_process
+        if proc is not None and proc.poll() is None:
+            return PortReleaseOutcome.PORT_BUSY
+        return None
+
+    def _check_proc_fd_scan(self) -> Optional[PortReleaseOutcome]:
+        """Scan /proc/*/fd for an open file descriptor resolving to this
+        port - pure in-process file I/O, no subprocess spawn, so unlike
+        `lsof` it cannot itself hit an external-command timeout. Linux-
+        only; returns None (inconclusive, fall through to the next layer)
+        wherever /proc isn't usable rather than guessing."""
+        proc_root = Path("/proc")
+        if not proc_root.is_dir():
+            return None
+        try:
+            target = os.path.realpath(self._port)
+        except OSError:
+            return None
+
+        try:
+            pid_dirs = [entry for entry in proc_root.iterdir() if entry.name.isdigit()]
+        except OSError:
+            return PortReleaseOutcome.CHECK_FAILED
+
+        for pid_dir in pid_dirs:
+            try:
+                fd_entries = list((pid_dir / "fd").iterdir())
+            except (OSError, PermissionError):
+                # Not our process, or it exited mid-scan - not a scan
+                # failure, just an entry we can't see into.
+                continue
+            for fd_entry in fd_entries:
+                try:
+                    if os.path.realpath(fd_entry) == target:
+                        return PortReleaseOutcome.PORT_BUSY
+                except OSError:
+                    continue
+        return PortReleaseOutcome.PORT_FREE
+
+    def _check_external_tool(self, tool: str, args: list[str], *, busy_timeout: float = 2.0) -> PortReleaseOutcome:
+        """Shared shape for the two external-process fallbacks (`fuser`,
+        `lsof`) - both can hang/time out/be missing, which is the actual
+        root cause this whole layered rework exists to stop conflating
+        with a genuinely busy port."""
+        try:
+            result = subprocess.run([tool, *args], capture_output=True, text=True, timeout=busy_timeout)
+        except FileNotFoundError:
+            return PortReleaseOutcome.UTILITY_MISSING
+        except subprocess.TimeoutExpired:
+            return PortReleaseOutcome.CHECK_TIMEOUT
+        except Exception:
+            return PortReleaseOutcome.CHECK_FAILED
+
+        if result.stdout.strip():
+            return PortReleaseOutcome.PORT_BUSY
+        return PortReleaseOutcome.PORT_FREE
+
+    def _check_fuser(self) -> PortReleaseOutcome:
+        # fuser prints the PIDs holding the file to stdout (nothing if
+        # free) - same "non-empty stdout means busy" shape as the lsof
+        # check below, just a lighter external tool tried first.
+        return self._check_external_tool("fuser", [self._port])
+
+    def _check_lsof(self) -> PortReleaseOutcome:
+        return self._check_external_tool("lsof", ["-t", self._port])
+
+    def check_port_release_once(self) -> PortReleaseOutcome:
+        """One pass through the full layered strategy: known PID -> /proc
+        fd scan -> fuser -> lsof. Returns as soon as a layer gives a
+        definitive PORT_FREE/PORT_BUSY answer; an inconclusive layer
+        (None, or CHECK_FAILED/CHECK_TIMEOUT/UTILITY_MISSING from an
+        external tool) falls through to the next one. The final layer's
+        own outcome (including an inconclusive one) is returned as-is if
+        every layer was inconclusive - the caller (wait_serial_release())
+        decides how to treat that, this method never silently upgrades
+        "couldn't tell" into "busy"."""
+        outcome = self._check_known_pid()
+        if outcome is not None:
+            return outcome
+
+        outcome = self._check_proc_fd_scan()
+        if outcome is not None and outcome != PortReleaseOutcome.CHECK_FAILED:
+            return outcome
+
+        outcome = self._check_fuser()
+        if outcome not in (
+            PortReleaseOutcome.CHECK_FAILED,
+            PortReleaseOutcome.CHECK_TIMEOUT,
+            PortReleaseOutcome.UTILITY_MISSING,
+        ):
+            return outcome
+
+        return self._check_lsof()
+
     def wait_serial_release(self, timeout: float = 8) -> bool:
+        """Public bool contract unchanged (existing callers - server.py's
+        thin wrapper, SerialTransport's connect(force=True) branch,
+        claim_exclusive_access() below - all just need "did it free up in
+        time"). What changed: every retry now goes through the layered
+        check_port_release_once() instead of an unconditional `lsof`
+        call, so a busy port, an inconclusive/timed-out/missing-tool
+        check, and a genuinely free port are distinguished internally
+        (see PortReleaseOutcome) even though only the final True/False
+        crosses this method's own boundary - callers that need the
+        distinction can call check_port_release_once() directly."""
         if not self._port:
             return True
 
         start = time.time()
+        last_outcome: Optional[PortReleaseOutcome] = None
         while time.time() - start < timeout:
-            try:
-                result = subprocess.run(
-                    ["lsof", "-t", self._port],
-                    capture_output=True,
-                    text=True,
-                    timeout=2,
-                )
-                if not result.stdout.strip():
-                    return True
-            except Exception as e:
-                print(f"[SerialPortSupervisor] wait_serial_release error: {e}", flush=True)
+            last_outcome = self.check_port_release_once()
+            if last_outcome == PortReleaseOutcome.PORT_FREE:
+                return True
             time.sleep(0.2)
 
-        print(f"[SerialPortSupervisor] Serial port still busy after {timeout}s: {self._port}", flush=True)
+        detail = last_outcome.value if last_outcome is not None else "no check completed"
+        print(
+            f"[SerialPortSupervisor] Serial port not confirmed free after {timeout}s "
+            f"(last outcome: {detail}): {self._port}",
+            file=sys.stderr, flush=True,
+        )
         return False
 
     def _prepare_command(self, timeout: float = 8) -> bool:

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -417,6 +417,32 @@ class SerialPortSupervisor:
         "confirmed not-X" - that exact collapse (an lsof timeout treated
         as a busy port) was the root cause of the corruption cascade this
         module was rewritten to fix.
+
+        KNOWN TRADE-OFF, explicitly accepted (review follow-up, not a
+        free improvement): falling through past every inconclusive layer
+        means a genuinely stuck check can now try known-PID, /proc scan,
+        `fuser`, AND `lsof` in sequence before giving up, instead of just
+        `lsof` alone - on hardware where BOTH external tools are slow
+        (not just `lsof`, the one originally caught live on Droidian),
+        one call to this method can now take longer in the worst case
+        than the old lsof-only version did. That eats into
+        AdapterIPCTransport._call()'s own
+        `remaining = max(1.0, timeout - elapsed)` budget split
+        (meshsrv/adapter_ipc_client.py) for the actual IPC round-trip
+        that follows the claim - a slower claim phase here can mean less
+        of the caller's declared timeout is left for the adapter call
+        itself, which can surface as more frequent "adapter subprocess
+        did not respond within {remaining}s" kills on such hardware.
+        Live-measured on the Droidian node this was written for: the
+        combined effect (this correctness fix plus the stdout-corruption
+        fix it shipped alongside) still reduced that kill frequency
+        roughly 3.7x (~1/11s before both fixes -> ~1/41s after), so this
+        is a real trade-off being made deliberately, not a regression
+        being introduced - but if a future device turns up where `fuser`
+        is ALSO systematically slow (not just `lsof`), a higher kill
+        frequency for short-timeout callers is the expected, already-
+        accepted consequence of this design choice, not a new bug to
+        rediscover from scratch.
         """
         known_pid = self._check_known_pid()
         if known_pid == PortReleaseOutcome.PORT_BUSY:

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -308,7 +308,25 @@ class SerialPortSupervisor:
         port - pure in-process file I/O, no subprocess spawn, so unlike
         `lsof` it cannot itself hit an external-command timeout. Linux-
         only; returns None (inconclusive, fall through to the next layer)
-        wherever /proc isn't usable rather than guessing."""
+        wherever /proc isn't usable rather than guessing.
+
+        ASYMMETRIC RELIABILITY (review finding, not hypothetical): a
+        PORT_BUSY answer from this scan is trustworthy unconditionally -
+        finding even one fd resolving to the port is proof, regardless of
+        whose process it belongs to. A PORT_FREE answer is NOT
+        equivalent-strength: `except (OSError, PermissionError): continue`
+        below means a PID directory this process lacks permission to read
+        into is silently skipped, not reported as inconclusive - so a
+        holder running as a different user (e.g. someone's root-owned
+        `screen /dev/ttyACM0` debugging session) is invisible to this
+        scan and would make it report PORT_FREE while the port is
+        genuinely busy. This is exactly the class of mistake the whole
+        layered rework exists to stop making (collapsing "couldn't find
+        evidence" into "confirmed absent") - so check_port_release_once()
+        below deliberately does NOT treat this method's PORT_FREE as
+        final; only its PORT_BUSY short-circuits the chain. See that
+        method's own docstring.
+        """
         proc_root = Path("/proc")
         if not proc_root.is_dir():
             return None
@@ -326,8 +344,12 @@ class SerialPortSupervisor:
             try:
                 fd_entries = list((pid_dir / "fd").iterdir())
             except (OSError, PermissionError):
-                # Not our process, or it exited mid-scan - not a scan
-                # failure, just an entry we can't see into.
+                # Not our process, or it exited mid-scan, OR (see the
+                # ASYMMETRIC RELIABILITY note above) a different user's
+                # process we simply can't see into - these three cases
+                # are indistinguishable from here, which is exactly why a
+                # clean scan below only ever produces a provisional
+                # PORT_FREE, never a final one.
                 continue
             for fd_entry in fd_entries:
                 try:
@@ -366,29 +388,47 @@ class SerialPortSupervisor:
 
     def check_port_release_once(self) -> PortReleaseOutcome:
         """One pass through the full layered strategy: known PID -> /proc
-        fd scan -> fuser -> lsof. Returns as soon as a layer gives a
-        definitive PORT_FREE/PORT_BUSY answer; an inconclusive layer
-        (None, or CHECK_FAILED/CHECK_TIMEOUT/UTILITY_MISSING from an
-        external tool) falls through to the next one. The final layer's
-        own outcome (including an inconclusive one) is returned as-is if
-        every layer was inconclusive - the caller (wait_serial_release())
-        decides how to treat that, this method never silently upgrades
-        "couldn't tell" into "busy"."""
-        outcome = self._check_known_pid()
-        if outcome is not None:
-            return outcome
+        fd scan -> fuser -> lsof.
 
-        outcome = self._check_proc_fd_scan()
-        if outcome is not None and outcome != PortReleaseOutcome.CHECK_FAILED:
-            return outcome
+        DELIBERATELY ASYMMETRIC (review finding): PORT_BUSY from ANY
+        layer short-circuits immediately and is trusted unconditionally -
+        a positive finding (something IS holding the port) doesn't
+        depend on having looked everywhere, so it can never be a false
+        positive this way, no matter which layer produced it.
 
-        outcome = self._check_fuser()
-        if outcome not in (
-            PortReleaseOutcome.CHECK_FAILED,
-            PortReleaseOutcome.CHECK_TIMEOUT,
-            PortReleaseOutcome.UTILITY_MISSING,
-        ):
-            return outcome
+        PORT_FREE is different, and is NOT treated the same way. Every
+        layer before the last one can only fail to find evidence of a
+        holder, not prove none exists - _check_known_pid() only ever
+        knows about OUR OWN listener process by design, and
+        _check_proc_fd_scan()/_check_fuser() can each silently miss a
+        holder running as a different user they lack permission to
+        inspect (see _check_proc_fd_scan()'s own ASYMMETRIC RELIABILITY
+        note for the concrete scenario this isn't hypothetical for - a
+        root-owned debugging session on the port, invisible to a
+        non-root scan). So PORT_FREE/None/any inconclusive outcome from
+        every layer up to (not including) the final one falls through to
+        the next layer instead of terminating - only the LAST layer's
+        answer (lsof, the existing, previously-sole check this whole
+        rework is layered in front of) is trusted as a final PORT_FREE.
+
+        This is the exact principle the whole rework exists to enforce,
+        applied to the layers among themselves too, not just to
+        `lsof` alone: never collapse "couldn't find evidence of X" into
+        "confirmed not-X" - that exact collapse (an lsof timeout treated
+        as a busy port) was the root cause of the corruption cascade this
+        module was rewritten to fix.
+        """
+        known_pid = self._check_known_pid()
+        if known_pid == PortReleaseOutcome.PORT_BUSY:
+            return known_pid
+
+        fd_scan = self._check_proc_fd_scan()
+        if fd_scan == PortReleaseOutcome.PORT_BUSY:
+            return fd_scan
+
+        fuser = self._check_fuser()
+        if fuser == PortReleaseOutcome.PORT_BUSY:
+            return fuser
 
         return self._check_lsof()
 

--- a/tests/fixtures/fake_adapter.py
+++ b/tests/fixtures/fake_adapter.py
@@ -15,6 +15,20 @@ adapter protocol never uses:
   "sleep:<seconds>" - sleeps that long, then responds ok=true - for
     proving a response that lands just inside vs. just outside the
     caller's deadline.
+  "noisy:<n>" - writes `n` non-JSON garbage lines to stdout BEFORE the
+    real JSON response (P0 stabilization follow-up: simulates a stray
+    print() slipping onto the protocol channel despite
+    ipc_server.py's redirect_stdout - proves AdapterSupervisor.call()'s
+    reader tolerates up to MAX_NON_JSON_LINES/MAX_NON_JSON_BYTES of this
+    before giving up, rather than killing the adapter on the very first
+    bad line like the pre-fix code did).
+  "stderr_flood:<bytes>" - writes at least `bytes` bytes to stderr
+    (chunked, flushed) before responding normally on stdout - simulates
+    enough adapter-side log volume to fill an undrained OS pipe buffer
+    (typically 64KB on Linux); if AdapterSupervisor has no stderr-drain
+    thread, the write blocks once the buffer fills and the whole call
+    wedges until the caller's own timeout fires instead of completing
+    normally.
 
 Writes its own PID to stdout on the FIRST request's response
 (`_pid` key) so a test can confirm a kill+respawn actually launched a
@@ -47,6 +61,21 @@ def main() -> None:
 
         if behavior.startswith("sleep:"):
             time.sleep(float(behavior.split(":", 1)[1]))
+
+        if behavior.startswith("noisy:"):
+            count = int(behavior.split(":", 1)[1])
+            for i in range(count):
+                sys.stdout.write(f"not json at all, garbage line {i}\n")
+                sys.stdout.flush()
+
+        if behavior.startswith("stderr_flood:"):
+            target_bytes = int(behavior.split(":", 1)[1])
+            written = 0
+            chunk = ("x" * 4096) + "\n"
+            while written < target_bytes:
+                sys.stderr.write(chunk)
+                sys.stderr.flush()
+                written += len(chunk)
 
         response = {
             "protocol_version": 1,

--- a/tests/test_adapter_ipc_client.py
+++ b/tests/test_adapter_ipc_client.py
@@ -447,3 +447,187 @@ def test_transport_error_raised_inside_claim_propagates_cleanly_not_frozeninstan
     assert excinfo.value.code == TransportErrorCode.TIMEOUT
     assert "did not respond within" in excinfo.value.message
     assert core_serial.claim_calls == 1
+
+
+# --- P0 stabilization follow-up (Droidian-caught stdout-corruption cascade) ---
+# All against the REAL fake_adapter.py subprocess (not mocked-out proc/pipe
+# behavior), matching this file's own established approach.
+
+def test_a_few_stray_non_json_lines_are_tolerated_then_the_real_response_wins():
+    """The actual fix for the corruption mechanism: a handful of stray
+    non-JSON lines (well under MAX_NON_JSON_LINES) on the adapter's
+    stdout - simulating a print() slipping through despite ipc_server.py's
+    own redirect_stdout - must NOT kill the adapter or fail the call, as
+    long as the real JSON response still follows within the same overall
+    timeout. Pre-fix behavior: the very first bad line killed the adapter
+    outright."""
+    supervisor = _make_supervisor()
+
+    response = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {"_test_behavior": "noisy:3"}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+
+    assert response["ok"] is True
+    # See test_tolerated_noisy_lines_do_not_trigger_a_respawn() below for
+    # the stronger process-identity check (this one just confirms the
+    # call itself succeeds).
+
+
+def test_tolerated_noisy_lines_do_not_trigger_a_respawn():
+    """Same scenario as above, checked more directly: the PID echoed back
+    on the (still-first) successful response must be the SAME process
+    that was already spawned, not a new one - proving the noisy lines
+    were tolerated in-place, not papered over by a kill+respawn cycle
+    that would coincidentally still succeed."""
+    supervisor = _make_supervisor()
+
+    first = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    first_pid = first["result"]["_pid"]
+    assert first_pid is not None
+
+    second = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {"_test_behavior": "noisy:3"}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    # fake_adapter.py only echoes _pid on its own first request - a
+    # respawn would reset that script-level "first" flag on a new
+    # process, so a non-None _pid here would itself prove a respawn
+    # happened; None confirms this is still the same process's second
+    # request being answered, tolerated line and all.
+    assert second["result"]["_pid"] is None
+
+
+def test_more_non_json_lines_than_the_tolerance_gives_a_distinct_protocol_error():
+    """Exceeding MAX_NON_JSON_LINES must fail fast with a distinct,
+    diagnosable error code (ADAPTER_PROTOCOL_ERROR) - not silently
+    tolerated forever, and not conflated with ADAPTER_UNAVAILABLE/UNKNOWN,
+    the same principle P0.3 applies to the port-release check: don't
+    collapse genuinely different failure modes into one signal."""
+    supervisor = _make_supervisor()
+
+    with pytest.raises(TransportError) as excinfo:
+        supervisor.call(
+            {
+                "operation": "get_metadata",
+                "transport_type": "serial",
+                "params": {"_test_behavior": f"noisy:{adapter_ipc_client.MAX_NON_JSON_LINES + 5}"},
+                "timeout": 5.0,
+            },
+            timeout=5.0,
+            ble_address_for_cleanup=None,
+        )
+
+    assert excinfo.value.code == TransportErrorCode.ADAPTER_PROTOCOL_ERROR
+    assert "malformed line" in excinfo.value.message
+
+
+def test_protocol_error_kills_the_adapter_same_as_any_other_fatal_failure():
+    """A protocol-error response must still trigger the same kill+respawn
+    discipline as every other fatal outcome (timeout, crash, closed pipe)
+    - an adapter whose stdout protocol broke once should not be trusted
+    to keep answering on the same process."""
+    supervisor = _make_supervisor()
+
+    first = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    first_pid = first["result"]["_pid"]
+    assert first_pid is not None
+
+    with pytest.raises(TransportError):
+        supervisor.call(
+            {
+                "operation": "get_metadata",
+                "transport_type": "serial",
+                "params": {"_test_behavior": f"noisy:{adapter_ipc_client.MAX_NON_JSON_LINES + 5}"},
+                "timeout": 5.0,
+            },
+            timeout=5.0,
+            ble_address_for_cleanup=None,
+        )
+
+    third = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    # A genuinely new process answers this one - fake_adapter.py echoes a
+    # non-None _pid only on ITS OWN first request.
+    assert third["result"]["_pid"] is not None
+    assert third["result"]["_pid"] != first_pid
+
+
+def test_stderr_flood_does_not_wedge_the_adapter():
+    """P0.2: without a drain thread reading the adapter's stderr pipe,
+    enough stderr volume fills the OS pipe buffer (typically 64KB on
+    Linux) and the writing process blocks - which, without a drain
+    thread, would silently wedge the whole call until the caller's own
+    timeout fires, indistinguishable from a genuinely hung adapter. This
+    sends comfortably more than a typical pipe buffer's worth (256KB) to
+    stderr before responding on stdout, and expects the call to complete
+    well within its budget - proving the stderr side is actively drained,
+    not just occasionally read."""
+    import time
+
+    supervisor = _make_supervisor()
+
+    start = time.monotonic()
+    response = supervisor.call(
+        {
+            "operation": "get_metadata",
+            "transport_type": "serial",
+            "params": {"_test_behavior": "stderr_flood:262144"},
+            "timeout": 10.0,
+        },
+        timeout=10.0,
+        ble_address_for_cleanup=None,
+    )
+    elapsed = time.monotonic() - start
+
+    assert response["ok"] is True
+    assert elapsed < 8.0, (
+        f"took {elapsed:.2f}s for a 256KB stderr flood - should complete quickly if stderr is "
+        f"actively drained, not stall until close to the full 10s budget (a wedge, not a fast response)"
+    )
+
+
+def test_stderr_drain_forwards_lines_to_on_log():
+    """The drained stderr content must actually reach on_log() (used to
+    surface it in Core's own system log), not just be discarded to
+    prevent the pipe from filling - discarding real diagnostic output
+    (the exact print()s this whole effort relocated to stderr) would
+    trade one failure mode for a quieter one."""
+    import time
+
+    logged = []
+    supervisor = _make_supervisor(on_log=lambda msg, level="INFO": logged.append((msg, level)))
+
+    supervisor.call(
+        {
+            "operation": "get_metadata",
+            "transport_type": "serial",
+            "params": {"_test_behavior": "stderr_flood:4096"},
+            "timeout": 5.0,
+        },
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+
+    # The drain thread is async relative to call() returning (it keeps
+    # reading until the pipe closes) - give it a moment to have forwarded
+    # at least the lines written before the response was sent.
+    deadline = time.monotonic() + 2.0
+    while not logged and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+    assert logged, "stderr content was drained but never reached on_log()"
+    assert any("adapter stderr" in msg for msg, _level in logged)

--- a/tests/test_ipc_server.py
+++ b/tests/test_ipc_server.py
@@ -11,9 +11,12 @@ the real transport classes' own behavior. This file is specifically
 about whether _AdapterDispatcher routes and (de)serializes correctly,
 independent of either.
 """
+import io
+import json
+
 import pytest
 
-from adapters.meshtastic.ipc_server import _AdapterDispatcher, _adapter_side_timeout
+from adapters.meshtastic.ipc_server import _AdapterDispatcher, _adapter_side_timeout, serve_forever
 from meshsrv.radio_transport import (
     ChannelInfo,
     ConnectionDescriptor,
@@ -237,3 +240,83 @@ def test_adapter_side_timeout_never_goes_below_the_one_second_floor():
     assert _adapter_side_timeout(1.0) == 1.0
     assert _adapter_side_timeout(0.1) == 1.0
     assert _adapter_side_timeout(None) == 13.0  # default 15.0 - margin 2.0
+
+
+# --- P0 stabilization follow-up: serve_forever()'s stdout protocol isolation ---
+# (Droidian-caught corruption cascade - a stray print() during request
+# handling landed on stdout, which IS the JSON-RPC channel back to Core in
+# this subprocess. serve_forever() wraps dispatcher.handle() in
+# contextlib.redirect_stdout(sys.stderr) so any such stray output - here
+# simulated from inside a fake dispatcher, standing in for either a not-yet-
+# fixed first-party call site or an unaudited third-party one (the
+# meshtastic library itself) - never reaches the real protocol channel.)
+
+class _NoisyDispatcher:
+    """Stands in for a dispatcher whose handle() does something noisy
+    internally (a stray print()) before returning a normal response -
+    simulating the exact mechanism of the Droidian-caught bug without
+    depending on the real SerialPortSupervisor/lsof machinery this
+    module's own regression test (tests/test_serial_port_supervisor.py)
+    already covers directly."""
+
+    def __init__(self, noisy_on_request_numbers=frozenset({1})):
+        self._noisy_on = noisy_on_request_numbers
+        self.n = 0
+
+    def handle(self, request):
+        self.n += 1
+        if self.n in self._noisy_on:
+            print(f"stray third-party output during request {self.n}")
+        return {"protocol_version": 1, "ok": True, "result": {"n": self.n}}
+
+
+def test_serve_forever_stray_print_never_reaches_protocol_stdout(capsys):
+    stdin = io.StringIO('{"operation": "noop"}\n')
+    protocol_out = io.StringIO()
+
+    serve_forever(_NoisyDispatcher(), stdin=stdin, stdout=protocol_out)
+
+    captured = capsys.readouterr()
+    assert captured.out == "", f"a stray print() during handle() must never reach real stdout, got: {captured.out!r}"
+    assert "stray third-party output" in captured.err
+
+    # The actual protocol response still went through cleanly on the
+    # separately-tracked protocol_stdout, unaffected by the redirect.
+    response = json.loads(protocol_out.getvalue().strip())
+    assert response["ok"] is True
+
+
+def test_adapter_stdout_contains_only_json_across_multiple_requests(capsys):
+    """Broader smoke test: several requests, one of them noisy partway
+    through - every line written to the protocol channel must be valid,
+    parseable JSON, none of them containing the stray output."""
+    stdin = io.StringIO("{}\n{}\n{}\n")
+    protocol_out = io.StringIO()
+
+    serve_forever(_NoisyDispatcher(noisy_on_request_numbers={2}), stdin=stdin, stdout=protocol_out)
+
+    lines = protocol_out.getvalue().splitlines()
+    assert len(lines) == 3
+    for line in lines:
+        parsed = json.loads(line)  # raises if anything but clean JSON slipped in
+        assert parsed["ok"] is True
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "stray third-party output during request 2" in captured.err
+
+
+def test_serve_forever_still_reports_malformed_request_json_normally():
+    """Sanity check the redirect doesn't interfere with the pre-existing
+    malformed-REQUEST handling (a bad line from Core, not a stray print
+    from the adapter side) - that path never calls dispatcher.handle()
+    at all, so it's outside the redirect_stdout block entirely."""
+    stdin = io.StringIO("not valid json at all\n")
+    protocol_out = io.StringIO()
+
+    serve_forever(_NoisyDispatcher(), stdin=stdin, stdout=protocol_out)
+
+    response = json.loads(protocol_out.getvalue().strip())
+    assert response["ok"] is False
+    assert response["error"]["code"] == "unknown"
+    assert "malformed request JSON" in response["error"]["message"]

--- a/tests/test_serial_port_supervisor.py
+++ b/tests/test_serial_port_supervisor.py
@@ -194,3 +194,50 @@ def test_known_pid_free_is_not_treated_as_port_confirmed_free():
 class _AlwaysRunningProcess:
     def poll(self):
         return None  # None = still running, matching subprocess.Popen.poll()'s own contract
+
+
+# --- Review follow-up: asymmetric BUSY/FREE trust between layers -------------
+# A PORT_FREE from an intermediate layer (proc_fd_scan, fuser) is NOT the
+# same strength of evidence as its own PORT_BUSY - a cross-user process
+# holding the port (e.g. a root-owned debugging `screen /dev/ttyACM0`
+# session) is invisible to a scan/tool this process lacks permission to
+# see into, so it would silently report PORT_FREE while the port is
+# genuinely busy. Only PORT_BUSY short-circuits early; PORT_FREE from
+# anything but the LAST layer (lsof) must fall through for confirmation.
+
+def test_intermediate_layer_port_free_is_not_trusted_falls_through_to_next_layer():
+    """proc_fd_scan saying PORT_FREE must not end the check - fuser is
+    still consulted, and its PORT_BUSY answer wins over the earlier
+    PORT_FREE."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_BUSY
+
+    def _fail_if_called():
+        raise AssertionError("lsof should never be reached - fuser already answered BUSY")
+
+    supervisor._check_lsof = _fail_if_called
+
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_BUSY
+
+
+def test_only_the_final_layer_lsof_can_confirm_port_free():
+    """Every intermediate PORT_FREE must fall through all the way to
+    lsof - the last layer in the chain - before the result is trusted as
+    a genuine "confirmed free". If lsof itself can't confirm either
+    (timeout/failed/missing), that inconclusive outcome is the final
+    answer - it must never be silently upgraded to PORT_FREE just
+    because earlier layers guessed free."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+
+    supervisor._check_lsof = lambda: PortReleaseOutcome.PORT_FREE
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_FREE
+
+    supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.CHECK_TIMEOUT

--- a/tests/test_serial_port_supervisor.py
+++ b/tests/test_serial_port_supervisor.py
@@ -10,10 +10,11 @@ why this is a shared primitive, not Core-exclusive logic.
 No server.py import needed - SerialPortSupervisor takes radio_lock/
 pause_listen by DI and never imports server.py or meshtastic itself.
 """
+import subprocess
 import threading
 import time
 
-from meshsrv.serial_port_supervisor import SerialPortSupervisor
+from meshsrv.serial_port_supervisor import PortReleaseOutcome, SerialPortSupervisor
 
 
 def _make_supervisor():
@@ -87,3 +88,109 @@ def test_claim_exclusive_access_raises_busy_when_the_port_never_frees():
         assert error.code == TransportErrorCode.BUSY
     else:
         raise AssertionError("claim_exclusive_access() did not raise on a busy port")
+
+
+# --- P0 stabilization follow-up (Droidian-caught stdout-corruption cascade) ---
+# adapters/meshtastic/ipc_server.py's main() runs a SerialTransport that
+# composes ITS OWN SerialPortSupervisor instance (not Core's separate one) -
+# on that instance, this module's stdout IS the JSON-RPC protocol channel
+# back to Core. wait_serial_release() hitting an `lsof` subprocess timeout
+# used to `print(..., flush=True)` with no `file=` argument, defaulting to
+# stdout - corrupting the response Core was about to parse. This is
+# platform-independent (nothing here depends on real `lsof`/OS timing,
+# unlike the live Droidian report that first caught it) and does not touch
+# any live node.
+
+def test_lsof_timeout_never_reaches_stdout_only_stderr(monkeypatch, capsys):
+    """THE regression test for the reported corruption mechanism: force
+    subprocess.run (used by both the fuser and lsof fallback layers) to
+    raise TimeoutExpired - exactly what was observed, unreliably, on
+    Droidian - and confirm nothing lands on stdout, only stderr. The
+    known-PID and /proc/*/fd layers are forced inconclusive (return None)
+    so this test deterministically reaches the external-tool fallback
+    layers regardless of the platform running it (a real /proc scan on
+    Linux CI could otherwise short-circuit to PORT_FREE before ever
+    calling subprocess.run, silently skipping the actual case under
+    test)."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    monkeypatch.setattr(supervisor, "_check_known_pid", lambda: None)
+    monkeypatch.setattr(supervisor, "_check_proc_fd_scan", lambda: None)
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0][0] if args else "lsof", timeout=2)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+
+    result = supervisor.wait_serial_release(timeout=0.5)
+
+    assert result is False
+    captured = capsys.readouterr()
+    assert captured.out == "", f"a subprocess timeout must never print to stdout, got: {captured.out!r}"
+    assert "Serial port not confirmed free" in captured.err
+    assert "check_timeout" in captured.err
+
+
+def test_check_port_release_once_distinguishes_timeout_from_busy_from_missing():
+    """P0.3: an lsof/fuser timeout, a genuinely busy port, and a missing
+    utility must be distinguishable outcomes, not all collapsed into the
+    same "busy" signal - the actual root cause of the observed corruption
+    (a timeout was silently treated as proof of a busy port, prolonging
+    the exclusive-access claim window unnecessarily)."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: None
+
+    supervisor._check_fuser = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+    supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.CHECK_TIMEOUT
+
+    supervisor._check_fuser = lambda: PortReleaseOutcome.UTILITY_MISSING
+    supervisor._check_lsof = lambda: PortReleaseOutcome.UTILITY_MISSING
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.UTILITY_MISSING
+
+    supervisor._check_fuser = lambda: PortReleaseOutcome.CHECK_FAILED
+    supervisor._check_lsof = lambda: PortReleaseOutcome.PORT_BUSY
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_BUSY
+
+
+def test_known_pid_busy_short_circuits_before_any_external_tool():
+    """The known-PID layer answering PORT_BUSY must skip every layer
+    below it entirely (cheapest check first) - proven by making every
+    other layer raise if reached, not just by checking the return value."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    with supervisor._radio_lock:
+        supervisor._listen_process = _AlwaysRunningProcess()
+
+    def _fail_if_called(*a, **k):
+        raise AssertionError("should never be reached - known-PID layer already answered BUSY")
+
+    supervisor._check_proc_fd_scan = _fail_if_called
+    supervisor._check_fuser = _fail_if_called
+    supervisor._check_lsof = _fail_if_called
+
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_BUSY
+
+
+def test_known_pid_free_is_not_treated_as_port_confirmed_free():
+    """Explicit test for the review's own caveat: "our listener isn't
+    holding it" must NOT short-circuit straight to PORT_FREE - only to
+    "inconclusive, ask the next layer" (None). An orphaned process from a
+    previous crash, or an unrelated process on the device, would be
+    invisible to the known-PID check alone."""
+    supervisor = _make_supervisor()
+    # No listener process at all - the known-PID layer's "not held by
+    # OUR process" case.
+    assert supervisor._check_known_pid() is None
+
+    # Confirm check_port_release_once() actually consults the next layer
+    # in this case, rather than treating None as a final PORT_FREE answer.
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_BUSY
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_BUSY
+
+
+class _AlwaysRunningProcess:
+    def poll(self):
+        return None  # None = still running, matching subprocess.Popen.poll()'s own contract


### PR DESCRIPTION
## Summary

Root cause (verified directly in current code, not assumed): `adapters/meshtastic/ipc_server.py`'s `main()` answers every JSON-RPC request on the adapter subprocess's own stdout - the SAME stdout `SerialPortSupervisor`'s six bare `print()` call sites (no `file=sys.stderr` anywhere) also targeted. `wait_serial_release()`'s `lsof`-timeout path was the trigger observed live on Droidian: a `subprocess.TimeoutExpired` was silently treated as "port busy" (no distinct outcome), retried, then printed straight to stdout - corrupting the JSON stream Core was parsing, killing the adapter on the first bad line, cascading into serial contention and a "Radio Busy" loop. This code path predates Task 48 (harmless pre-IPC), and survived multiple later rounds of review (including this session's own P0 #1 extraction) uncaught.

- **P0.1** - `serve_forever()` (testable, DI'd version of `main()`'s loop) wraps `dispatcher.handle()` in `contextlib.redirect_stdout(sys.stderr)`.
- **P0.1b (not optional - see finding below)** - all six `print()` sites in `serial_port_supervisor.py` fixed at the source, `file=sys.stderr` unconditionally.
- **Investigation finding**: P0.1 alone is insufficient. `_call_with_timeout()` runs work on a background daemon thread; if it hits its own internal timeout, `redirect_stdout`'s block exits while the orphaned thread (the documented tier-1/tier-2 gap) may still be running and could `print()` after real stdout is restored - most likely while `serve_forever` is blocked waiting for Core's next request. P0.1b closes this unconditionally; neither fix substitutes for the other.
- **P0.2** - `AdapterSupervisor` now drains the adapter's stderr pipe on a daemon thread from spawn time (previously `stderr=PIPE` was set but never read - an undrained ~64KB pipe can wedge the writer once full).
- **P0.3** - new `PortReleaseOutcome` enum + layered `check_port_release_once()`: known-PID (cheap, in-process, explicitly documented as answering "does OUR listener hold it", not "is the port free in general") → `/proc/*/fd` scan → `fuser` → `lsof` (external tools, last resort). `wait_serial_release()`'s public bool contract unchanged.
- **P0.4** - `AdapterSupervisor.call()`'s reader tolerates up to `MAX_NON_JSON_LINES=5` / `MAX_NON_JSON_BYTES=4096` of stray non-JSON output (within the same overall timeout) before giving up, instead of killing on the first bad line. New `TransportErrorCode.ADAPTER_PROTOCOL_ERROR`, distinct from `ADAPTER_UNAVAILABLE`/`UNKNOWN`.

Deferred to P1 (per the source document's own priority): channel refresh backoff, operation priority queue, time-sync radio-starvation avoidance, listener lifecycle semantic differentiation.

## Test plan
- [x] `pytest` - 391 passed, 25 skipped (POSIX/Linux-only, expected on this dev machine)
- [x] `tests/test_serial_port_supervisor.py`: the requested regression test (mocked `subprocess.TimeoutExpired`, **confirmed to fail on the pre-fix code via a temporary local revert before being restored** - not just asserted to pass), outcome-distinguishing tests, known-PID short-circuit/non-exhaustive tests
- [x] `tests/test_ipc_server.py`: `serve_forever()` stdout-isolation (single stray print, multi-request with one noisy call, malformed-request handling unaffected)
- [x] `tests/test_adapter_ipc_client.py`: against a real `fake_adapter.py` subprocess (not mocked-out proc/pipe behavior) - tolerated-vs-exceeded non-JSON lines (including confirming tolerance does NOT trigger a respawn), stderr-flood-does-not-wedge, stderr reaches `on_log()`
- [x] `python -m compileall -q .`
- [ ] **Live verification on the Droidian node that first caught this - required before merge**, coordinating separately. A passing test suite proves the mechanism is real and fixed in the abstract, not that the observed "Radio Busy" cascade is actually gone on that specific device.