### PR TITLE
Fix three install-hardening defects: libcamera-optional import, wrong installer IP, swap step numbering

### DIFF
--- a/camera/camera.py
+++ b/camera/camera.py
@@ -14,7 +14,23 @@ import threading
 import time
 from datetime import datetime
 from PIL import Image
-from libcamera import Transform, controls as libcamera_controls
+
+# libcamera is only present on real CSI-camera hardware (Picamera2's own
+# dependency) - devices running the USB driver instead (camera/usb_driver.py,
+# no libcamera dependency at all) or with no camera hardware at all must
+# still be able to import this module, since server.py imports it
+# unconditionally at startup (see camera/csi_driver.py's own import of this
+# module too). This is a different failure mode than "camera hardware not
+# detected" (already handled gracefully at runtime by init_camera()'s own
+# try/except around Picamera2() below) - an ImportError here happens before
+# init_camera() ever runs, so it needs its own guard.
+try:
+    from libcamera import Transform, controls as libcamera_controls
+    LIBCAMERA_AVAILABLE = True
+except ImportError:
+    Transform = None
+    libcamera_controls = None
+    LIBCAMERA_AVAILABLE = False
 
 try:
     from config import DATA_DIR
@@ -214,34 +230,41 @@ def save_camera_settings():
 # ============================================================
 # BASIC CAMERA CONTROL
 # ============================================================
-AWB_MODE_MAP = {
-    "auto": libcamera_controls.AwbModeEnum.Auto,
-    "daylight": libcamera_controls.AwbModeEnum.Daylight,
-    "cloudy": libcamera_controls.AwbModeEnum.Cloudy,
-    "indoor": libcamera_controls.AwbModeEnum.Indoor,
-    "tungsten": libcamera_controls.AwbModeEnum.Tungsten,
-    "fluorescent": libcamera_controls.AwbModeEnum.Fluorescent,
-    "incandescent": libcamera_controls.AwbModeEnum.Incandescent,
-}
+if LIBCAMERA_AVAILABLE:
+    AWB_MODE_MAP = {
+        "auto": libcamera_controls.AwbModeEnum.Auto,
+        "daylight": libcamera_controls.AwbModeEnum.Daylight,
+        "cloudy": libcamera_controls.AwbModeEnum.Cloudy,
+        "indoor": libcamera_controls.AwbModeEnum.Indoor,
+        "tungsten": libcamera_controls.AwbModeEnum.Tungsten,
+        "fluorescent": libcamera_controls.AwbModeEnum.Fluorescent,
+        "incandescent": libcamera_controls.AwbModeEnum.Incandescent,
+    }
 
-EXPOSURE_MODE_MAP = {
-    "normal": libcamera_controls.AeExposureModeEnum.Normal,
-    "short": libcamera_controls.AeExposureModeEnum.Short,
-    "long": libcamera_controls.AeExposureModeEnum.Long,
-}
+    EXPOSURE_MODE_MAP = {
+        "normal": libcamera_controls.AeExposureModeEnum.Normal,
+        "short": libcamera_controls.AeExposureModeEnum.Short,
+        "long": libcamera_controls.AeExposureModeEnum.Long,
+    }
 
-NOISE_REDUCTION_MAP = {
-    "off": libcamera_controls.draft.NoiseReductionModeEnum.Off,
-    "minimal": libcamera_controls.draft.NoiseReductionModeEnum.Minimal,
-    "fast": libcamera_controls.draft.NoiseReductionModeEnum.Fast,
-    "high_quality": libcamera_controls.draft.NoiseReductionModeEnum.HighQuality,
-    "zsl": libcamera_controls.draft.NoiseReductionModeEnum.ZSL,
-    "auto": libcamera_controls.draft.NoiseReductionModeEnum.Fast,
-}
+    NOISE_REDUCTION_MAP = {
+        "off": libcamera_controls.draft.NoiseReductionModeEnum.Off,
+        "minimal": libcamera_controls.draft.NoiseReductionModeEnum.Minimal,
+        "fast": libcamera_controls.draft.NoiseReductionModeEnum.Fast,
+        "high_quality": libcamera_controls.draft.NoiseReductionModeEnum.HighQuality,
+        "zsl": libcamera_controls.draft.NoiseReductionModeEnum.ZSL,
+        "auto": libcamera_controls.draft.NoiseReductionModeEnum.Fast,
+    }
+else:
+    AWB_MODE_MAP = {}
+    EXPOSURE_MODE_MAP = {}
+    NOISE_REDUCTION_MAP = {}
 
 
 def get_camera_transform():
     """Build orientation transform used by video and capture configurations."""
+    if not LIBCAMERA_AVAILABLE:
+        return None
     return Transform(
         hflip=bool(CAMERA_CONTROLS.get("hflip", False)),
         vflip=bool(CAMERA_CONTROLS.get("vflip", False)),
@@ -250,6 +273,8 @@ def get_camera_transform():
 
 def build_camera_controls():
     """Convert saved MeshCenter settings to Picamera2/libcamera controls."""
+    if not LIBCAMERA_AVAILABLE:
+        return {}
     awb_mode = str(CAMERA_CONTROLS.get("awb_mode", "auto")).lower()
     exposure_mode = str(
         CAMERA_CONTROLS.get("exposure_mode", "normal")

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,23 @@ log()      { echo -e "${GREEN}[MeshCenter]${NC} $*"; }
 warn()     { echo -e "${YELLOW}[WARNING]${NC} $*" >&2; }
 progress() { echo "$*" > "$PROGRESS_FILE"; log "$*"; }
 
+# Best-effort local IP for the "open in browser" messages. `hostname -I`
+# lists every interface's address in enumeration order, not the one
+# actually carrying outbound traffic - on a device with a dead/unused
+# interface (e.g. a phone's rndis0 USB-tethering link) that can print an
+# unreachable address instead of the real wlan0/eth0 one. `ip route get`
+# asks the kernel which source address it would actually use to reach the
+# internet (a routing-table lookup, no packet sent) - falls back to the
+# old hostname -I behavior if `ip` is missing or there's no default route.
+detect_local_ip() {
+    local ip=""
+    if command -v ip >/dev/null 2>&1; then
+        ip=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')
+    fi
+    [[ -z "$ip" ]] && ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    printf '%s' "$ip"
+}
+
 fail() {
     echo -e "\n${RED}[ERROR]${NC} $*" | tee -a "$LOG_FILE" >&2
     echo "" | tee -a "$LOG_FILE"
@@ -245,7 +262,7 @@ PYEOF
     # Check it actually started
     if kill -0 "$PROGRESS_PID" 2>/dev/null; then
         log "Progress server started on port $PROGRESS_PORT (PID $PROGRESS_PID)"
-        log "Watch progress at: http://$(hostname).local or http://$(hostname -I | awk '{print $1}')"
+        log "Watch progress at: http://$(hostname).local or http://$(detect_local_ip)"
     else
         PROGRESS_PID=""
         log "Progress server not started (port $PROGRESS_PORT busy or no permission — OK)"
@@ -301,7 +318,10 @@ step_system_packages() {
 
 # ─── Step 3: Swap (for Pi Zero 2W and devices with < 1GB RAM) ────────────────
 step_swap() {
-    [[ "$NEEDS_SWAP" == "true" ]] || return 0
+    if [[ "$NEEDS_SWAP" != "true" ]]; then
+        progress "3/9 Swap not needed for ${DEVICE_NAME} — skipping"
+        return 0
+    fi
 
     progress "3/9 Configuring swap for ${DEVICE_NAME}..."
 
@@ -650,7 +670,7 @@ step_cleanup() {
 }
 
 step_done() {
-    LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+    LOCAL_IP=$(detect_local_ip)
     VERSION=$(git -C "$INSTALL_DIR" describe --tags 2>/dev/null || echo "unknown")
 
     # Final message in progress file

--- a/tests/test_camera_libcamera_optional.py
+++ b/tests/test_camera_libcamera_optional.py
@@ -1,0 +1,71 @@
+"""Tests for camera/camera.py's libcamera import guard.
+
+server.py imports camera.camera unconditionally at startup (and
+camera/csi_driver.py imports it too, for the driver registry built by
+camera_manager.py) - on a device with no libcamera Python bindings at all
+(a USB-only setup, or non-Pi hardware like the Droidian node this was
+found on), the bare `from libcamera import Transform, controls` used to
+crash the whole process before init_camera()'s own, already-existing
+graceful "no camera" handling ever got a chance to run. This is a
+different failure mode from "camera hardware not detected" (already
+handled at runtime) - an ImportError here happens at *module* import
+time, before any runtime code executes.
+
+Forces the ImportError with sys.modules["libcamera"] = None (the
+standard way to make `import libcamera` raise ImportError regardless of
+whether it's actually installed on the machine running this test) -
+deliberately the OPPOSITE of conftest.py's _stub_libcamera(), which
+fakes libcamera as *present*. Restores sys.modules afterward so it
+doesn't leak into other tests.
+"""
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def libcamera_absent():
+    """Forces a fresh import of camera.camera to see libcamera as absent,
+    then restores prior sys.modules state (both for "libcamera" and
+    "camera.camera") so later tests get their normal, working imports."""
+    saved_libcamera = sys.modules.get("libcamera", "__unset__")
+    saved_camera_camera = sys.modules.pop("camera.camera", None)
+
+    sys.modules["libcamera"] = None
+    try:
+        import camera.camera as camera_module
+        yield camera_module
+    finally:
+        del sys.modules["camera.camera"]
+        if saved_libcamera == "__unset__":
+            sys.modules.pop("libcamera", None)
+        else:
+            sys.modules["libcamera"] = saved_libcamera
+        if saved_camera_camera is not None:
+            sys.modules["camera.camera"] = saved_camera_camera
+        else:
+            # Re-import normally (libcamera stubbed present again by
+            # conftest's own _stub_libcamera(), or genuinely absent if
+            # this suite never ran that fixture) so later tests see a
+            # working module either way.
+            import camera.camera  # noqa: F401
+
+
+def test_import_does_not_raise_when_libcamera_is_absent(libcamera_absent):
+    assert libcamera_absent.LIBCAMERA_AVAILABLE is False
+
+
+def test_transform_and_controls_maps_are_empty_when_libcamera_is_absent(libcamera_absent):
+    assert libcamera_absent.Transform is None
+    assert libcamera_absent.libcamera_controls is None
+    assert libcamera_absent.AWB_MODE_MAP == {}
+    assert libcamera_absent.EXPOSURE_MODE_MAP == {}
+    assert libcamera_absent.NOISE_REDUCTION_MAP == {}
+
+
+def test_get_camera_transform_returns_none_when_libcamera_is_absent(libcamera_absent):
+    assert libcamera_absent.get_camera_transform() is None
+
+
+def test_build_camera_controls_returns_empty_dict_when_libcamera_is_absent(libcamera_absent):
+    assert libcamera_absent.build_camera_controls() == {}


### PR DESCRIPTION
## Summary
Three small, independent install-hardening fixes, all confirmed directly in code before implementing:

1. **camera.py crashes without libcamera** - the unconditional `from libcamera import Transform, controls` at module load crashed the whole process on any non-Pi/USB-only device before `init_camera()`'s own already-existing graceful "no camera" handling ever ran. Found live on the Droidian node. Guarded behind `LIBCAMERA_AVAILABLE`; `get_camera_transform()`/`build_camera_controls()` and the three control maps degrade to `None`/`{}` instead of crashing. Confirmed this is a genuinely different failure mode than "camera hardware not detected" (already handled at runtime) - an import-time `ImportError` vs. `init_camera()`'s runtime `except Exception`, complementary once fixed.
2. **installer shows the wrong IP** - `hostname -I | awk '{print $1}'` (both the progress-server banner at line 248 and the final summary at line 653) takes the first address across all interfaces, not the one on the default route - showed a dead `rndis0` tethering address instead of the working `wlan0` address on Droidian. New `detect_local_ip()` helper uses `ip route get 1.1.1.1` to ask the kernel which interface it'd actually use, falling back to the old `hostname -I` behavior if `ip` is missing or there's no default route.
3. **installer step numbering skip** - `step_swap()` returned before ever calling `progress()` when swap wasn't needed, silently omitting "3/9" from the install trail (2/9 -> 4/9, a visible gap). Now always announces "3/9" first, then decides whether real work happens - matching `step_adapter_venv()`'s already-established convention elsewhere in the same script.

## Test plan
- [x] `pytest tests/test_camera_libcamera_optional.py` - 4 new tests forcing `ImportError` via `sys.modules["libcamera"] = None`
- [x] Full suite: `pytest` - 400 passed, 25 skipped (pre-existing platform skips)
- [x] `bash -n install.sh` clean, `python -m compileall camera/camera.py` clean
- [x] Confirmed live on Droidian: `libcamera` genuinely absent from its venv (`ModuleNotFoundError`) - the real target environment for fix #1
- [ ] Post-merge: sync + restart on dev/prod/camtest/Droidian, confirm the process starts cleanly on Droidian with the officially-merged fix (not the prior local workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)