### PR TITLE
Distinguish real serial-port BUSY from an inconclusive port-release check

### DIFF
--- a/meshsrv/radio_transport.py
+++ b/meshsrv/radio_transport.py
@@ -67,6 +67,15 @@ class TransportErrorCode(str, Enum):
     # thing failed" or "the adapter is missing entirely" at a glance, not
     # by string-matching last_error.message.
     ADAPTER_PROTOCOL_ERROR = "adapter_protocol_error"
+    # Droidian-caught follow-up to the P0.3 asymmetric-trust work: a
+    # port-release check that couldn't reach a definitive answer (an
+    # external tool like `lsof` timed out/errored/is missing) is NOT the
+    # same thing as a confirmed busy port - claim_exclusive_access() used
+    # to raise BUSY for both, a false "Serial port busy" the user could
+    # not distinguish from a genuinely occupied port. Distinct from BUSY
+    # (a real owner was found) so a caller/UI can tell "we don't know"
+    # apart from "something is actually holding it".
+    PORT_CHECK_INCONCLUSIVE = "port_check_inconclusive"
 
 
 # ---------------------------------------------------------------------------

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -409,7 +409,14 @@ class SerialPortSupervisor:
         every layer up to (not including) the final one falls through to
         the next layer instead of terminating - only the LAST layer's
         answer (lsof, the existing, previously-sole check this whole
-        rework is layered in front of) is trusted as a final PORT_FREE.
+        rework is layered in front of) is trusted as a final PORT_FREE on
+        its own. Droidian follow-up: if lsof itself can't answer in time
+        (its own timing is unreliable on some hardware - see the
+        CHECK_TIMEOUT/CHECK_FAILED/UTILITY_MISSING fallback below this
+        docstring), a PORT_FREE from BOTH fd_scan AND fuser together is
+        also trusted as final - two independent affirmative confirmations
+        outweighing one slow/flaky last-resort tool failing to finish,
+        without touching busy-detection on any layer.
 
         This is the exact principle the whole rework exists to enforce,
         applied to the layers among themselves too, not just to
@@ -456,28 +463,62 @@ class SerialPortSupervisor:
         if fuser == PortReleaseOutcome.PORT_BUSY:
             return fuser
 
-        return self._check_lsof()
+        lsof = self._check_lsof()
+        if lsof == PortReleaseOutcome.PORT_FREE:
+            return lsof
 
-    def wait_serial_release(self, timeout: float = 8) -> bool:
-        """Public bool contract unchanged (existing callers - server.py's
-        thin wrapper, SerialTransport's connect(force=True) branch,
-        claim_exclusive_access() below - all just need "did it free up in
-        time"). What changed: every retry now goes through the layered
-        check_port_release_once() instead of an unconditional `lsof`
-        call, so a busy port, an inconclusive/timed-out/missing-tool
-        check, and a genuinely free port are distinguished internally
-        (see PortReleaseOutcome) even though only the final True/False
-        crosses this method's own boundary - callers that need the
-        distinction can call check_port_release_once() directly."""
+        # Droidian follow-up: lsof is the slowest, flakiest layer (a
+        # subprocess spawn with no guaranteed latency, unlike the
+        # in-process /proc scan) - live-measured on that device, its own
+        # 2s busy_timeout is regularly too short (lsof itself commonly
+        # takes 1.7-2.8s there), turning a perfectly free port into
+        # CHECK_TIMEOUT on every send attempt. When BOTH independent,
+        # already-completed cheaper layers affirmatively found no owner
+        # (not merely "inconclusive" - an actual PORT_FREE from each),
+        # trust that combination over lsof failing to finish in time,
+        # rather than making every caller wait out the full retry budget
+        # for a check that structurally can't reliably complete on this
+        # hardware. This does NOT weaken busy-detection on any layer -
+        # every PORT_BUSY above still short-circuits immediately,
+        # unchanged; this only strengthens what counts as a confirmed
+        # PORT_FREE in the one case where lsof specifically (not fd_scan,
+        # not fuser) is the layer that couldn't answer.
+        if (
+            fd_scan == PortReleaseOutcome.PORT_FREE
+            and fuser == PortReleaseOutcome.PORT_FREE
+            and lsof in (
+                PortReleaseOutcome.CHECK_TIMEOUT,
+                PortReleaseOutcome.CHECK_FAILED,
+                PortReleaseOutcome.UTILITY_MISSING,
+            )
+        ):
+            self._on_log(
+                f"Serial port release inferred free (proc+fuser clean, "
+                f"lsof {lsof.value}): {self._port}",
+                "WARNING",
+            )
+            return PortReleaseOutcome.PORT_FREE
+
+        return lsof
+
+    def _wait_for_release_outcome(self, timeout: float = 8) -> PortReleaseOutcome:
+        """Retry check_port_release_once() until it reports PORT_FREE or
+        `timeout` elapses, returning the actual final PortReleaseOutcome -
+        the detail wait_serial_release()'s bool contract used to discard
+        (Droidian follow-up: that loss is exactly what let a mere
+        CHECK_TIMEOUT surface to the user as a false "Serial port busy",
+        indistinguishable from a real PORT_BUSY - see
+        claim_exclusive_access() below, the actual consumer that needed
+        this distinction preserved)."""
         if not self._port:
-            return True
+            return PortReleaseOutcome.PORT_FREE
 
         start = time.time()
         last_outcome: Optional[PortReleaseOutcome] = None
         while time.time() - start < timeout:
             last_outcome = self.check_port_release_once()
             if last_outcome == PortReleaseOutcome.PORT_FREE:
-                return True
+                return last_outcome
             time.sleep(0.2)
 
         detail = last_outcome.value if last_outcome is not None else "no check completed"
@@ -486,12 +527,22 @@ class SerialPortSupervisor:
             f"(last outcome: {detail}): {self._port}",
             file=sys.stderr, flush=True,
         )
-        return False
+        return last_outcome if last_outcome is not None else PortReleaseOutcome.CHECK_FAILED
 
-    def _prepare_command(self, timeout: float = 8) -> bool:
+    def wait_serial_release(self, timeout: float = 8) -> bool:
+        """Public bool contract unchanged (existing callers - server.py's
+        thin wrapper, SerialTransport's connect(force=True) branch - all
+        just need "did it free up in time"). claim_exclusive_access()
+        below no longer goes through this method - it calls
+        _wait_for_release_outcome() directly so it can keep the
+        distinction this bool boundary still discards for these other
+        callers, none of which currently need it."""
+        return self._wait_for_release_outcome(timeout=timeout) == PortReleaseOutcome.PORT_FREE
+
+    def _prepare_command(self, timeout: float = 8) -> PortReleaseOutcome:
         self._pause_listen.set()
         self.stop_listener_process()
-        return self.wait_serial_release(timeout=timeout)
+        return self._wait_for_release_outcome(timeout=timeout)
 
     @contextmanager
     def claim_exclusive_access(self, *, timeout: float = 8, cooldown: float = 2.0):
@@ -527,13 +578,30 @@ class SerialPortSupervisor:
         (stayed in that file - it exercises SerialTransport's connect()/
         send_text() through a composed SerialPortSupervisor via the
         supervisor= DI seam, not SerialPortSupervisor in isolation).
+
+        Droidian follow-up: _prepare_command() now returns the actual
+        PortReleaseOutcome instead of a bare bool, so this can raise a
+        TransportError that honestly reflects what happened - BUSY only
+        for a confirmed PORT_BUSY (a real owner was found), and the
+        distinct PORT_CHECK_INCONCLUSIVE for anything else that isn't
+        PORT_FREE (the check itself couldn't reach a definitive answer -
+        an external tool timed out/errored/is missing). Previously both
+        cases raised the identical BUSY error, which is what let a mere
+        checking failure surface to the user as a false "Serial port
+        busy" claim.
         """
         with self._radio_lock:
-            prepared = self._prepare_command(timeout=timeout)
+            outcome = self._prepare_command(timeout=timeout)
             try:
-                if not prepared:
+                if outcome != PortReleaseOutcome.PORT_FREE:
+                    if outcome == PortReleaseOutcome.PORT_BUSY:
+                        raise TransportError(
+                            TransportErrorCode.BUSY, f"Serial port busy: {self._port or 'auto-detect'}"
+                        )
                     raise TransportError(
-                        TransportErrorCode.BUSY, f"Serial port busy: {self._port or 'auto-detect'}"
+                        TransportErrorCode.PORT_CHECK_INCONCLUSIVE,
+                        f"Could not confirm serial port release ({outcome.value}): "
+                        f"{self._port or 'auto-detect'}",
                     )
                 yield
             finally:

--- a/tests/test_serial_port_supervisor.py
+++ b/tests/test_serial_port_supervisor.py
@@ -10,10 +10,14 @@ why this is a shared primitive, not Core-exclusive logic.
 No server.py import needed - SerialPortSupervisor takes radio_lock/
 pause_listen by DI and never imports server.py or meshtastic itself.
 """
+import os
 import subprocess
 import threading
 import time
 
+import pytest
+
+from meshsrv.radio_transport import TransportError, TransportErrorCode
 from meshsrv.serial_port_supervisor import PortReleaseOutcome, SerialPortSupervisor
 
 
@@ -72,14 +76,14 @@ def test_get_listener_pid_still_works_normally_when_the_lock_is_free():
 def test_claim_exclusive_access_raises_busy_when_the_port_never_frees():
     """claim_exclusive_access() (renamed from claim_for_external_command()/
     _claim_radio() during this stabilization follow-up) must still raise
-    TransportError(BUSY) when prepare_command() reports the port never
-    freed up - unchanged behavior from before the move, just relocated.
-    wait_serial_release() is stubbed to always report "still busy" so
-    this doesn't depend on real `lsof`/OS state."""
+    TransportError(BUSY) when the port is confirmed genuinely occupied -
+    unchanged behavior from before the move, just relocated.
+    _wait_for_release_outcome() is stubbed to always report a real
+    PORT_BUSY so this doesn't depend on real `lsof`/OS state."""
     from meshsrv.radio_transport import TransportError, TransportErrorCode
 
     supervisor = _make_supervisor()
-    supervisor.wait_serial_release = lambda timeout=8: False
+    supervisor._wait_for_release_outcome = lambda timeout=8: PortReleaseOutcome.PORT_BUSY
 
     try:
         with supervisor.claim_exclusive_access(timeout=0.2, cooldown=0):
@@ -223,21 +227,248 @@ def test_intermediate_layer_port_free_is_not_trusted_falls_through_to_next_layer
     assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_BUSY
 
 
-def test_only_the_final_layer_lsof_can_confirm_port_free():
-    """Every intermediate PORT_FREE must fall through all the way to
-    lsof - the last layer in the chain - before the result is trusted as
-    a genuine "confirmed free". If lsof itself can't confirm either
-    (timeout/failed/missing), that inconclusive outcome is the final
-    answer - it must never be silently upgraded to PORT_FREE just
-    because earlier layers guessed free."""
+def test_lsof_confirming_free_is_still_trusted_on_its_own():
+    """The baseline case, unchanged: every intermediate layer saying
+    PORT_FREE and lsof itself also confirming PORT_FREE is a genuine
+    confirmed-free result."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_lsof = lambda: PortReleaseOutcome.PORT_FREE
+
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_FREE
+
+
+# --- Droidian follow-up: fd_scan + fuser both PORT_FREE outweighs a
+# merely-inconclusive lsof (live-measured on Droidian: lsof's own 2s
+# busy_timeout is regularly too short there, 1.7-2.8s observed, turning a
+# genuinely free port into a false "busy" on every send attempt) - but
+# ONLY when both independent layers actually agree; any layer that
+# didn't cleanly confirm PORT_FREE itself must not be papered over.
+
+
+def test_proc_and_fuser_both_free_outweighs_an_inconclusive_lsof():
+    """Case 4 from the task's required test list: /proc and fuser both
+    confirm no owner, lsof times out - the new safe policy treats this as
+    PORT_FREE rather than leaving it CHECK_TIMEOUT (which used to
+    surface to the user as a false "Serial port busy")."""
     supervisor = _make_supervisor()
     supervisor._port = "/dev/ttyACM0"
     supervisor._check_known_pid = lambda: None
     supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
     supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
 
-    supervisor._check_lsof = lambda: PortReleaseOutcome.PORT_FREE
-    assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_FREE
+    for lsof_outcome in (
+        PortReleaseOutcome.CHECK_TIMEOUT,
+        PortReleaseOutcome.CHECK_FAILED,
+        PortReleaseOutcome.UTILITY_MISSING,
+    ):
+        supervisor._check_lsof = lambda outcome=lsof_outcome: outcome
+        assert supervisor.check_port_release_once() == PortReleaseOutcome.PORT_FREE
 
+
+def test_inconclusive_lsof_is_not_upgraded_unless_both_proc_and_fuser_agree():
+    """The narrower guarantee that survives from the old test: an
+    inconclusive lsof is NOT silently upgraded to PORT_FREE unless BOTH
+    fd_scan and fuser affirmatively agree - a single clean layer (or a
+    layer that was itself inconclusive) must not trigger the fallback,
+    since the whole point is trusting two independent confirmations, not
+    just one guess."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+    supervisor._check_known_pid = lambda: None
     supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+
+    # Only fd_scan clean, fuser itself inconclusive - must not upgrade.
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.CHECK_TIMEOUT
     assert supervisor.check_port_release_once() == PortReleaseOutcome.CHECK_TIMEOUT
+
+    # Only fuser clean, fd_scan itself inconclusive - must not upgrade.
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.CHECK_FAILED
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+    assert supervisor.check_port_release_once() == PortReleaseOutcome.CHECK_TIMEOUT
+
+
+# --- Real /proc fd scan and real fuser/lsof-shaped subprocess results
+# (not stubbed at the check_port_release_once() layer) - cases 2/3/6/7
+# from the task's required test list.
+
+
+def test_proc_fd_scan_detects_a_real_owner_via_matching_realpath(monkeypatch, tmp_path):
+    """Case 2: /proc detects an owner -> PORT_BUSY. Exercises
+    _check_proc_fd_scan() itself, not a stub of its return value - builds
+    a synthetic /proc/<pid>/fd/<n> entry and makes os.path.realpath()
+    resolve it to the target port, without needing a real symlink (which
+    can fail without extra privilege on Windows) - matching the actual
+    check's own logic (os.path.realpath(fd_entry) == target)."""
+    import meshsrv.serial_port_supervisor as spv_module
+
+    proc_dir = tmp_path / "proc"
+    fd_dir = proc_dir / "4242" / "fd"
+    fd_dir.mkdir(parents=True)
+    fake_fd_entry = fd_dir / "3"
+    fake_fd_entry.write_text("")
+
+    target_port = "/dev/ttyACM0"
+    real_realpath = os.path.realpath
+
+    def fake_realpath(path):
+        path_str = str(path)
+        if path_str == target_port:
+            return target_port
+        if path_str == str(fake_fd_entry):
+            return target_port
+        return real_realpath(path)
+
+    real_path_ctor = spv_module.Path
+
+    def fake_path_ctor(path, *args, **kwargs):
+        if str(path) == "/proc":
+            return real_path_ctor(proc_dir)
+        return real_path_ctor(path, *args, **kwargs)
+
+    monkeypatch.setattr(spv_module, "Path", fake_path_ctor)
+    monkeypatch.setattr(spv_module.os.path, "realpath", fake_realpath)
+
+    supervisor = _make_supervisor()
+    supervisor._port = target_port
+
+    assert supervisor._check_proc_fd_scan() == PortReleaseOutcome.PORT_BUSY
+
+
+def test_fuser_detects_a_real_owner(monkeypatch):
+    """Case 3: fuser detects an owner -> PORT_BUSY. Mocks subprocess.run
+    itself (not _check_fuser()'s return value) with the actual shape
+    fuser produces for a held file: returncode 0, the PID on stdout."""
+    supervisor = _make_supervisor()
+    supervisor._port = "/dev/ttyACM0"
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[0] == "fuser"
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout="1234\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert supervisor._check_fuser() == PortReleaseOutcome.PORT_BUSY
+
+
+def test_check_external_tool_reports_utility_missing_for_a_nonexistent_binary():
+    """Case 6: the external tool binary itself is entirely absent -
+    genuinely exercises FileNotFoundError from a real subprocess.run()
+    call (no such binary exists on any platform), not a stubbed
+    shortcut."""
+    supervisor = _make_supervisor()
+
+    outcome = supervisor._check_external_tool(
+        "this-binary-does-not-exist-anywhere-on-any-platform", ["/dev/ttyACM0"]
+    )
+
+    assert outcome == PortReleaseOutcome.UTILITY_MISSING
+
+
+def test_check_external_tool_reports_check_failed_on_permission_error(monkeypatch):
+    """Case 7: the external tool errors out / access is refused ->
+    CHECK_FAILED, distinct from both UTILITY_MISSING (tool absent) and
+    CHECK_TIMEOUT (tool present but too slow)."""
+    supervisor = _make_supervisor()
+
+    def fake_run(cmd, **kwargs):
+        raise PermissionError("Access denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    outcome = supervisor._check_external_tool("fuser", ["/dev/ttyACM0"])
+
+    assert outcome == PortReleaseOutcome.CHECK_FAILED
+
+
+# --- Listener-restart guarantees (requirement #4) - cases 8/9/10 -----------
+
+
+def test_pause_listen_is_cleared_after_a_successful_claim():
+    """Case 8: listener resumes after a successful send."""
+    supervisor = _make_supervisor()
+    supervisor._wait_for_release_outcome = lambda timeout=8: PortReleaseOutcome.PORT_FREE
+    supervisor.stop_listener_process = lambda: True
+
+    with supervisor.claim_exclusive_access(timeout=1, cooldown=0):
+        pass
+
+    assert not supervisor._pause_listen.is_set()
+
+
+def test_pause_listen_is_cleared_after_a_send_error_inside_the_claim():
+    """Case 9: listener resumes after a send error - an ordinary
+    exception raised from inside the claimed block."""
+    supervisor = _make_supervisor()
+    supervisor._wait_for_release_outcome = lambda timeout=8: PortReleaseOutcome.PORT_FREE
+    supervisor.stop_listener_process = lambda: True
+
+    with pytest.raises(RuntimeError):
+        with supervisor.claim_exclusive_access(timeout=1, cooldown=0):
+            raise RuntimeError("send failed")
+
+    assert not supervisor._pause_listen.is_set()
+
+
+def test_pause_listen_is_cleared_after_an_adapter_timeout_inside_the_claim():
+    """Case 10: listener resumes after an adapter-side timeout/IPC
+    exception - claim_exclusive_access()'s finally must not care what
+    kind of exception propagated through the yield, a TransportError(
+    TIMEOUT) (the shape AdapterSupervisor.call() actually raises on a
+    wedged adapter) included."""
+    supervisor = _make_supervisor()
+    supervisor._wait_for_release_outcome = lambda timeout=8: PortReleaseOutcome.PORT_FREE
+    supervisor.stop_listener_process = lambda: True
+
+    with pytest.raises(TransportError) as excinfo:
+        with supervisor.claim_exclusive_access(timeout=1, cooldown=0):
+            raise TransportError(TransportErrorCode.TIMEOUT, "adapter subprocess did not respond")
+
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+    assert not supervisor._pause_listen.is_set()
+
+
+def test_claim_exclusive_access_raises_port_check_inconclusive_not_busy_when_check_cannot_confirm():
+    """The addendum's central point: a check that couldn't reach a
+    definitive answer must raise a distinct, honest error - not the same
+    BUSY a real owner would produce."""
+    supervisor = _make_supervisor()
+    supervisor._wait_for_release_outcome = lambda timeout=8: PortReleaseOutcome.CHECK_TIMEOUT
+
+    with pytest.raises(TransportError) as excinfo:
+        with supervisor.claim_exclusive_access(timeout=0.2, cooldown=0):
+            raise AssertionError("should never reach the yield - the check never confirmed free")
+
+    assert excinfo.value.code == TransportErrorCode.PORT_CHECK_INCONCLUSIVE
+    assert "check_timeout" in excinfo.value.message
+
+
+# --- Case 13: both Core's and the adapter's own instance are the SAME
+# class, so this single fix covers both layers - proven directly with two
+# independent instances, not asserted from the shared-code claim alone.
+
+
+def test_two_independent_supervisor_instances_both_benefit_from_the_same_fallback():
+    """Mirrors the real architecture: Core's own SerialPortSupervisor and
+    the adapter's own composed instance are two separate instances of the
+    same class, each with its own radio_lock/pause_listen (never shared
+    across the process boundary - see this module's own docstring).
+    Fixing check_port_release_once() once must resolve the false-BUSY
+    for both layers independently, not just whichever one a test happens
+    to construct."""
+    core_side = _make_supervisor()
+    adapter_side = _make_supervisor()
+
+    for supervisor in (core_side, adapter_side):
+        supervisor._port = "/dev/ttyACM0"
+        supervisor._check_known_pid = lambda: None
+        supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+        supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+        supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+
+    assert core_side.check_port_release_once() == PortReleaseOutcome.PORT_FREE
+    assert adapter_side.check_port_release_once() == PortReleaseOutcome.PORT_FREE

--- a/tests/test_serial_transport_timeout.py
+++ b/tests/test_serial_transport_timeout.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 import pytest
 
 from adapters.meshtastic.serial_transport import SerialTransport
-from meshsrv.serial_port_supervisor import SerialPortSupervisor
+from meshsrv.serial_port_supervisor import PortReleaseOutcome, SerialPortSupervisor
 from meshsrv.radio_transport import (
     ConnectionDescriptor,
     ConnectionState,
@@ -214,10 +214,16 @@ def test_concurrent_connect_and_send_do_not_race_prepare_phase():
 
     def tracked_wait(timeout=8):
         with _track_critical_section():
-            return True
+            return PortReleaseOutcome.PORT_FREE
 
     supervisor.stop_listener_process = tracked_stop
-    supervisor.wait_serial_release = tracked_wait
+    # Droidian follow-up: claim_exclusive_access()'s prepare phase now
+    # calls _wait_for_release_outcome() directly (not wait_serial_release(),
+    # which stays a thin bool-returning wrapper around it for other
+    # callers) - mock the method actually on the call path, or this
+    # tracker silently stops being exercised and the test would pass
+    # without proving anything about the wait phase.
+    supervisor._wait_for_release_outcome = tracked_wait
 
     class _FakePacket:
         id = 1
@@ -268,6 +274,56 @@ def test_concurrent_connect_and_send_do_not_race_prepare_phase():
         "overlapped - radio_lock is not fully serializing the prepare "
         "sequence, reintroducing the serial-port-contention risk"
     )
+
+
+# --- Case 12 from the task's required test list: send_messages() end-to-
+# end must not fail on a false BUSY when lsof is slow but the port is
+# actually free (the exact scenario live-measured on Droidian - fd_scan
+# and fuser both clean, lsof timing out around 2-3.8s against the
+# supervisor's own 2s busy_timeout).
+
+
+def test_send_messages_succeeds_when_lsof_is_slow_but_proc_and_fuser_confirm_free():
+    supervisor = SerialPortSupervisor(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyFAKE",
+        radio_lock=threading.RLock(),
+        pause_listen=threading.Event(),
+    )
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+    supervisor.stop_listener_process = lambda: True
+
+    transport = SerialTransport(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyFAKE",
+        radio_lock=supervisor._radio_lock,
+        pause_listen=supervisor._pause_listen,
+        supervisor=supervisor,
+    )
+
+    class _FakePacket:
+        id = 42
+
+    class _FakeInterface:
+        def sendText(self, **kwargs):
+            return _FakePacket()
+
+        def close(self):
+            pass
+
+    transport._open_interface = lambda: _FakeInterface()
+
+    results = transport.send_messages(
+        [OutgoingMessage(text="hi", destination_id="^all")], timeout=5.0
+    )
+
+    assert len(results) == 1
+    assert results[0].accepted is True
+    assert results[0].error is None
+    assert results[0].packet_id == 42
 
 
 # --- Task 48 follow-up: connect()/disconnect() state correctness ----------


### PR DESCRIPTION
## Summary
- `claim_exclusive_access()` collapsed every non-`PORT_FREE` outcome from the layered port-release check into an identical `TransportError(BUSY, "Serial port busy")` - live-reproduced on Droidian: `lsof` routinely takes 1.7-2.8s there, longer than its own 2s `busy_timeout`, turning a genuinely free port into a false "busy" on every send attempt even though two independent, already-completed checks (`/proc` fd scan, `fuser`) both confirmed no owner.
- **A**: `_prepare_command()`/`claim_exclusive_access()` now preserve the actual `PortReleaseOutcome` instead of collapsing to bool, raising the new `TransportErrorCode.PORT_CHECK_INCONCLUSIVE` instead of `BUSY` when the check itself couldn't reach a definitive answer. `wait_serial_release()`'s public bool contract is unchanged for its other callers (`server.py`'s wrapper, `connect(force=True)`) - it now delegates to a new `_wait_for_release_outcome()` rather than duplicating the retry loop.
- **B**: `check_port_release_once()` trusts a `PORT_FREE` from BOTH `/proc` fd scan AND `fuser` together over a merely-inconclusive `lsof` (timeout/error/missing) - two independent affirmative confirmations outweighing one slow/flaky last-resort tool. A real `PORT_BUSY` from any layer still short-circuits immediately, unchanged.
- Deliberately deferred (separate follow-up, not in this PR): eliminating the redundant double-check between Core's own `SerialPortSupervisor` instance and the adapter's own composed instance (a `port_preclaimed` IPC flag or similar); `server.py`'s parallel `radio_session()`/`RadioBusyError` mechanism has the same lossy-bool anti-pattern but is unrelated to the send path this bug was found in.

## Test plan
- [x] All 13 required cases from the task doc covered in `tests/test_serial_port_supervisor.py`/`tests/test_serial_transport_timeout.py`, including a real (unstubbed) `/proc` fd-scan match, a real `fuser`/`lsof`-shaped subprocess mock, listener-restart guarantees after success/error/timeout, and an explicit invariant test that the two-of-three fallback does NOT trigger unless both `fd_scan` and `fuser` affirmatively agree.
- [x] Two pre-existing tests repaired: one was silently mocking `wait_serial_release`, which `claim_exclusive_access()` no longer calls after this refactor (fixed to target the real call path so it actually exercises what its docstring claims).
- [x] `pytest -q` - 414 passed, 25 skipped (pre-existing platform skips)
- [x] Live-reproduced the root cause on Droidian directly against the real port before implementing (`check_port_release_once()`: fd_scan/fuser both `PORT_FREE` in ~1.1s each, `lsof` `CHECK_TIMEOUT` at 2.0s)
- [x] Modified files deployed to Droidian and confirmed: compile cleanly in the real venv, service starts/runs without error under the new code
- [ ] Full live send-message verification (packet ID, listener resumption, continued nodeinfo/telemetry) - blocked right now: no radio is physically attached to the Droidian device. Tracked as an open follow-up until it's reconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)