### PR TITLE
Give PAUSED an upper bound: escalate a stuck listener pause into auto-recovery

### DIFF
--- a/server.py
+++ b/server.py
@@ -3837,6 +3837,23 @@ LISTENER_RECOVERY_MAX_ATTEMPTS = 3
 LISTENER_RECOVERY_WINDOW = 30 * 60
 LISTENER_RECOVERY_RESULT_TIMEOUT = 60
 
+# Droidian-caught follow-up: PAUSED is deliberately excluded from
+# auto-recovery below (a radio command legitimately pauses the listener
+# for its own bounded duration) - but a repeating retry loop (each
+# individual claim/adapter call bounded and killed on schedule, the
+# overall cycle itself not) can keep re-pausing it indefinitely, with no
+# upper bound on how long that's allowed to go on. These two thresholds
+# give PAUSED a ceiling: every legitimate single operation observed in
+# this codebase tops out around 30-40s (send_messages()'s own 30s +
+# claim_exclusive_access()'s ~8s prepare + 2s cooldown), so 60s (>1.5x
+# that) can't false-positive on one slow-but-fine command. 180s reuses
+# the same number already meaningful elsewhere in this file (the OK/IDLE
+# packet-age boundary) applied to a strictly stronger signal (nothing can
+# even attempt to run), and is well under the 5-6 minute stalls actually
+# observed live on Droidian before this fix.
+LISTENER_PAUSED_WARNING_THRESHOLD_S = 60
+LISTENER_PAUSED_ESCALATE_THRESHOLD_S = 180
+
 listener_recovery_state = {
     "down_since": None,
     "attempts": [],
@@ -3844,16 +3861,86 @@ listener_recovery_state = {
     "restart_requested_at": None,
     "limit_logged": False,
     "last_enabled": None,
+    "paused_since": None,
+    "paused_warning_logged": False,
 }
 
 
-def process_listener_autorecovery(status, listener_running, now_ts):
+def resolve_paused_recovery_status(status, now_ts):
+    """Droidian-caught follow-up: a repeating retry loop can keep
+    re-pausing the listener indefinitely even though every individual
+    claim/adapter call is itself bounded and killed on schedule (see
+    LISTENER_PAUSED_ESCALATE_THRESHOLD_S's own comment above) - PAUSED
+    itself has no ceiling, so process_listener_autorecovery()'s existing
+    "PAUSED never triggers recovery" rule can leave it stuck forever.
+
+    Tracks how long `status` has been continuously "PAUSED" (using
+    listener_recovery_state's own paused_since/paused_warning_logged
+    fields, reset the moment status is anything else) and returns
+    (recovery_status, escalated_from_paused) for
+    process_listener_autorecovery() to act on - "LISTENER_DOWN"/True once
+    the pause has persisted past LISTENER_PAUSED_ESCALATE_THRESHOLD_S,
+    otherwise `status` unchanged/False. Logs a WARNING once at
+    LISTENER_PAUSED_WARNING_THRESHOLD_S so a stuck pause is visible in
+    System Log well before it's long enough to escalate.
+
+    Extracted out of radio_health_worker() (its only caller) so this can
+    be tested directly against a fake `now_ts` progression, without
+    driving that worker's own 30s sleep loop."""
+    if status != "PAUSED":
+        listener_recovery_state["paused_since"] = None
+        listener_recovery_state["paused_warning_logged"] = False
+        return status, False
+
+    state = listener_recovery_state
+    if state["paused_since"] is None:
+        state["paused_since"] = now_ts
+        state["paused_warning_logged"] = False
+
+    paused_duration = now_ts - state["paused_since"]
+
+    if (
+        paused_duration >= LISTENER_PAUSED_WARNING_THRESHOLD_S
+        and not state["paused_warning_logged"]
+    ):
+        log_system_event(
+            title="Listener PAUSED unusually long",
+            level="WARNING",
+            details=(
+                "pause_listen has been continuously set for "
+                f"{int(paused_duration)}s - a radio command may be stuck "
+                "in a retry loop rather than completing normally"
+            ),
+            source="recovery",
+        )
+        state["paused_warning_logged"] = True
+
+    if paused_duration >= LISTENER_PAUSED_ESCALATE_THRESHOLD_S:
+        return "LISTENER_DOWN", True
+
+    return status, False
+
+
+def process_listener_autorecovery(status, listener_running, now_ts, escalated_from_paused=False):
     """
     Restart the Meshtastic listener after a persistent LISTENER_DOWN state.
 
     Safety limits:
     - maximum 3 attempts in 30 minutes;
-    - PAUSED, STARTING, IDLE and NO_PACKETS never trigger recovery;
+    - PAUSED, STARTING, IDLE and NO_PACKETS never trigger recovery on their
+      own - but radio_health_worker() escalates a PAUSED state that has
+      persisted past LISTENER_PAUSED_ESCALATE_THRESHOLD_S into a synthetic
+      status="LISTENER_DOWN" call here (Droidian-caught: a repeating
+      retry loop can keep the listener paused indefinitely even though
+      every individual claim/adapter call is itself bounded and killed on
+      schedule - see LISTENER_PAUSED_ESCALATE_THRESHOLD_S's own comment).
+      `escalated_from_paused` is True for exactly those calls, so this
+      function's own log messages can say what actually triggered
+      recovery instead of always claiming a literal listener-process
+      crash - this function's attempt-counting/delay/limit logic is
+      otherwise identical and shared for both origins, deliberately: a
+      genuine crash and a stuck-PAUSED thrash draw from the same 3-per-
+      30-minutes budget, not two independent ones.
     - recovery is cancelled if the listener returns before the delay expires.
     """
     state = listener_recovery_state
@@ -3987,8 +4074,13 @@ def process_listener_autorecovery(status, listener_running, now_ts):
         log_system_event(
             title="Listener failure detected",
             level="WARNING",
-            details=f"Waiting {delay} seconds before "
-                "automatic recovery",
+            details=(
+                "Listener has been PAUSED unusually long "
+                f"({LISTENER_PAUSED_ESCALATE_THRESHOLD_S}s+), treating as "
+                f"down. Waiting {delay} seconds before automatic recovery"
+                if escalated_from_paused else
+                f"Waiting {delay} seconds before automatic recovery"
+            ),
             source="recovery",
         )
         return
@@ -4008,8 +4100,14 @@ def process_listener_autorecovery(status, listener_running, now_ts):
             log_system_event(
                 title="Automatic recovery limit reached",
                 level="ERROR",
-                details=f"{LISTENER_RECOVERY_MAX_ATTEMPTS} attempts "
-                    "within 30 minutes. Manual action required.",
+                details=(
+                    f"Auto-recovery exhausted its {LISTENER_RECOVERY_MAX_ATTEMPTS} "
+                    f"attempts in {LISTENER_RECOVERY_WINDOW // 60} minutes, PAUSED "
+                    "persists - manual intervention required."
+                    if escalated_from_paused else
+                    f"{LISTENER_RECOVERY_MAX_ATTEMPTS} attempts "
+                    "within 30 minutes. Manual action required."
+                ),
                 source="recovery",
             )
             state["limit_logged"] = True
@@ -4190,10 +4288,13 @@ def radio_health_worker():
                 flush=True
             )
 
+            recovery_status, escalated_from_paused = resolve_paused_recovery_status(status, now_ts)
+
             process_listener_autorecovery(
-                status=status,
+                status=recovery_status,
                 listener_running=listener_running,
                 now_ts=now_ts,
+                escalated_from_paused=escalated_from_paused,
             )
 
         except Exception as e:

--- a/tests/test_listener_paused_recovery.py
+++ b/tests/test_listener_paused_recovery.py
@@ -1,0 +1,199 @@
+"""Tests for server.py's PAUSED-ceiling fix (Droidian-caught follow-up).
+
+A repeating retry loop (each individual claim/adapter call bounded and
+killed on schedule, the overall cycle itself not) can keep re-pausing the
+listener indefinitely, with process_listener_autorecovery()'s own
+"PAUSED never triggers recovery" rule leaving it stuck with no upper
+bound - live-observed on Droidian: two separate 3-6 minute stalls, one
+ended only by a manual "Release radio" action, the other by chance after
+~3 minutes.
+
+resolve_paused_recovery_status() is the extracted, directly-testable
+piece (radio_health_worker() itself just calls it once per 30s poll and
+is not exercised here - see its own docstring for why).
+"""
+import pytest
+
+
+@pytest.fixture
+def _clean_recovery_state(server_module):
+    """listener_recovery_state is module-global - reset it around every
+    test so one test's progression can't leak into the next."""
+    state = server_module.listener_recovery_state
+    original = dict(state)
+    state.update({
+        "down_since": None,
+        "attempts": [],
+        "restart_pending": False,
+        "restart_requested_at": None,
+        "limit_logged": False,
+        "last_enabled": None,
+        "paused_since": None,
+        "paused_warning_logged": False,
+    })
+    yield server_module
+    state.clear()
+    state.update(original)
+
+
+@pytest.fixture
+def logged(_clean_recovery_state, monkeypatch):
+    """Captures every log_system_event() call made through server.py's
+    module-level reference (resolve_paused_recovery_status() and
+    process_listener_autorecovery() both call it by that name)."""
+    calls = []
+    monkeypatch.setattr(
+        _clean_recovery_state, "log_system_event",
+        lambda title, level="INFO", details="", source="system": calls.append(
+            {"title": title, "level": level, "details": details, "source": source}
+        ),
+    )
+    return calls
+
+
+# --- resolve_paused_recovery_status() ---------------------------------
+
+
+def test_status_unchanged_before_warning_threshold(_clean_recovery_state, logged):
+    server_module = _clean_recovery_state
+    status, escalated = server_module.resolve_paused_recovery_status("PAUSED", now_ts=1000)
+
+    assert status == "PAUSED"
+    assert escalated is False
+    assert logged == []
+
+
+def test_warning_logged_once_at_threshold_not_repeated(_clean_recovery_state, logged):
+    server_module = _clean_recovery_state
+    T = server_module.LISTENER_PAUSED_WARNING_THRESHOLD_S
+
+    server_module.resolve_paused_recovery_status("PAUSED", now_ts=0)  # starts the timer
+    status, escalated = server_module.resolve_paused_recovery_status("PAUSED", now_ts=T)
+
+    assert status == "PAUSED"
+    assert escalated is False
+    assert len(logged) == 1
+    assert logged[0]["title"] == "Listener PAUSED unusually long"
+    assert logged[0]["level"] == "WARNING"
+
+    # A later poll still under the escalate threshold must not log again.
+    server_module.resolve_paused_recovery_status("PAUSED", now_ts=T + 1)
+    assert len(logged) == 1
+
+
+def test_escalates_to_listener_down_at_threshold(_clean_recovery_state, logged):
+    server_module = _clean_recovery_state
+    T = server_module.LISTENER_PAUSED_ESCALATE_THRESHOLD_S
+
+    server_module.resolve_paused_recovery_status("PAUSED", now_ts=0)
+    status, escalated = server_module.resolve_paused_recovery_status("PAUSED", now_ts=T)
+
+    assert status == "LISTENER_DOWN"
+    assert escalated is True
+
+
+def test_escalation_requires_continuous_pause_not_a_single_sample(_clean_recovery_state, logged):
+    """A PAUSED sample that's immediately followed by a non-PAUSED one
+    must reset the timer - escalation is about a persisted condition,
+    not one unlucky 30s sample."""
+    server_module = _clean_recovery_state
+    T = server_module.LISTENER_PAUSED_ESCALATE_THRESHOLD_S
+
+    server_module.resolve_paused_recovery_status("PAUSED", now_ts=0)
+    server_module.resolve_paused_recovery_status("OK", now_ts=10)
+
+    status, escalated = server_module.resolve_paused_recovery_status("PAUSED", now_ts=10 + T - 1)
+
+    assert status == "PAUSED"
+    assert escalated is False
+
+
+def test_non_paused_status_passes_through_unchanged(_clean_recovery_state, logged):
+    server_module = _clean_recovery_state
+    for other_status in ("OK", "STARTING", "IDLE", "NO_PACKETS", "LISTENER_DOWN", "RELEASED"):
+        status, escalated = server_module.resolve_paused_recovery_status(other_status, now_ts=99999)
+        assert status == other_status
+        assert escalated is False
+    assert logged == []
+
+
+# --- process_listener_autorecovery()'s escalated-specific wording -----
+
+
+@pytest.fixture
+def _stub_restart_actions(server_module, monkeypatch):
+    """The RESTART LISTENER branch calls real stop_listener()/radio_event()
+    - stub them so the test exercises only the recovery state machine and
+    log wording, not actual subprocess/listener management."""
+    monkeypatch.setattr(server_module, "stop_listener", lambda: True)
+    monkeypatch.setattr(server_module, "radio_event", lambda *a, **k: None)
+    with server_module.state_lock:
+        server_module.settings["listener_autorecovery"] = {"enabled": True, "delay": 30}
+    return server_module
+
+
+def _drive_to_limit(server_module, escalated_from_paused):
+    """Runs process_listener_autorecovery() through enough calls to
+    exhaust LISTENER_RECOVERY_MAX_ATTEMPTS, staying in status="LISTENER_DOWN"
+    (with listener_running=False) throughout so every restart attempt is
+    reported as still-failed - deterministic, no real listener involved.
+
+    Matches the function's own state machine exactly (delay=30, matching
+    _stub_restart_actions' settings): detect -> [wait delay -> trigger
+    restart -> wait RESULT_TIMEOUT -> mark failed] x MAX_ATTEMPTS -> wait
+    delay once more -> safety-limit check fires."""
+    delay = 30
+    now_ts = 0.0
+
+    def _call(ts):
+        server_module.process_listener_autorecovery(
+            status="LISTENER_DOWN", listener_running=False, now_ts=ts,
+            escalated_from_paused=escalated_from_paused,
+        )
+
+    _call(now_ts)  # initial detection, sets down_since
+
+    for _ in range(server_module.LISTENER_RECOVERY_MAX_ATTEMPTS):
+        now_ts += delay
+        _call(now_ts)  # triggers a restart attempt
+        now_ts += server_module.LISTENER_RECOVERY_RESULT_TIMEOUT
+        _call(now_ts)  # marks that attempt failed, resets down_since
+
+    now_ts += delay
+    _call(now_ts)  # attempts == MAX_ATTEMPTS -> "limit reached"
+
+
+def test_limit_reached_message_mentions_paused_when_escalated(_stub_restart_actions, logged):
+    server_module = _stub_restart_actions
+    _drive_to_limit(server_module, escalated_from_paused=True)
+
+    limit_logs = [entry for entry in logged if entry["title"] == "Automatic recovery limit reached"]
+    assert len(limit_logs) == 1
+    assert limit_logs[0]["level"] == "ERROR"
+    assert "PAUSED persists" in limit_logs[0]["details"]
+    assert "manual intervention required" in limit_logs[0]["details"].lower()
+
+
+def test_limit_reached_message_stays_generic_when_not_escalated(_stub_restart_actions, logged):
+    """Regression guard: a genuine LISTENER_DOWN (not escalated from a
+    stuck PAUSED state) must keep its original, pre-existing wording -
+    this fix must not change behavior for the case it wasn't about."""
+    server_module = _stub_restart_actions
+    _drive_to_limit(server_module, escalated_from_paused=False)
+
+    limit_logs = [entry for entry in logged if entry["title"] == "Automatic recovery limit reached"]
+    assert len(limit_logs) == 1
+    assert "PAUSED" not in limit_logs[0]["details"]
+    assert limit_logs[0]["details"] == "3 attempts within 30 minutes. Manual action required."
+
+
+def test_initial_detection_message_mentions_paused_when_escalated(_stub_restart_actions, logged):
+    server_module = _stub_restart_actions
+    server_module.process_listener_autorecovery(
+        status="LISTENER_DOWN", listener_running=False, now_ts=0,
+        escalated_from_paused=True,
+    )
+
+    detection_logs = [entry for entry in logged if entry["title"] == "Listener failure detected"]
+    assert len(detection_logs) == 1
+    assert "PAUSED unusually long" in detection_logs[0]["details"]


### PR DESCRIPTION
## Summary
- `process_listener_autorecovery()` deliberately never triggers on `PAUSED` - correct in the common case (a radio command legitimately pauses the listener for its own bounded duration), but a repeating retry loop where every individual claim/adapter call is bounded and killed on schedule while the *overall cycle* keeps re-pausing the listener has no upper bound at all. Live-observed on Droidian: two separate stalls (5.5+ and 3+ minutes) - one ended only by a manual "Release radio" action, the other resolved by chance.
- New `resolve_paused_recovery_status()` tracks how long `status` has been continuously `"PAUSED"` (reusing `radio_health_worker()`'s existing 30s cadence, no new watchdog thread), logs a `WARNING` once at 60s (>1.5x the worst legitimate single operation observed, ~30-40s), and escalates to a synthetic `status="LISTENER_DOWN"` at 180s (reusing a number already meaningful elsewhere in this file) - feeding the *existing*, already-safety-limited (3 attempts/30min) recovery mechanism instead of inventing a new one.
- `process_listener_autorecovery()` gains an `escalated_from_paused` flag purely so its own log messages say what actually triggered recovery - including a new, more specific `ERROR` at attempt-limit exhaustion ("Auto-recovery exhausted its 3 attempts in 30 minutes, PAUSED persists - manual intervention required") instead of leaving that case silent. The pre-existing wording for a genuine `LISTENER_DOWN` is unchanged, verified by a dedicated regression test.
- Investigated separately (not part of this PR - no fix needed): a pyserial-level read timeout. Checked the actual installed `meshtastic` package - `SerialInterface` already sets `timeout=0.5` on its own `serial.Serial()` construction, so individual reads are already bounded upstream. Nothing to add here.

## Test plan
- [x] `pytest tests/test_listener_paused_recovery.py` - 8 new tests: warning-once semantics, escalation timing, reset-on-recovery, non-PAUSED passthrough, both log-wording variants driven through the real attempt/delay/limit state machine (not a shortcut)
- [x] Full suite: `pytest` - 420 passed, 25 skipped (pre-existing platform skips)
- [ ] Live verification on Droidian: confirm the fix loads/runs cleanly, and watch for a real PAUSED escalation given how frequently this device has hit the condition today

🤖 Generated with [Claude Code](https://claude.com/claude-code)