### PR TITLE
Consolidate node-icon path validation with defense-in-depth (Jules finding, not exploitable)

### DIFF
--- a/api/api_node_icons.py
+++ b/api/api_node_icons.py
@@ -8,8 +8,21 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
     icons_dir.mkdir(parents=True, exist_ok=True)
 
     def icon_path(node_id):
+        """Defense-in-depth, not a fix for a confirmed vulnerability: every
+        caller already validates node_id with is_valid_node_id() (server.py,
+        `re.fullmatch(r"![0-9a-fA-F]{8}", value)`) before this is ever
+        reached, and that regex already rejects any traversal-shaped value
+        - verified directly against '!../../etc/passwd', '!../secret',
+        '!....//....//etc/passwd', '!b0f14d2a/../../secret', all REJECTED.
+        This guard exists so a future loosening of that regex (for an
+        unrelated reason, without realizing this route depends on its
+        strictness) fails safe here too, instead of only at the one call
+        site that happened to prompt the change."""
         safe_name = node_id.lstrip("!").lower()
-        return icons_dir / f"{safe_name}.png"
+        target = (icons_dir / f"{safe_name}.png").resolve()
+        if not target.is_relative_to(icons_dir.resolve()):
+            raise ValueError(f"resolved outside icons_dir: {node_id!r}")
+        return target
 
     @app.route("/api/nodes/<node_id>/icon", methods=["GET"])
     def get_node_icon(node_id):
@@ -17,7 +30,10 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
         if not node_id_validator(normalized_id):
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
-        path = icon_path(normalized_id)
+        try:
+            path = icon_path(normalized_id)
+        except ValueError:
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
         if not path.exists():
             return jsonify({"ok": False, "error": "Node icon not found"}), 404
 
@@ -29,6 +45,11 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
     def upload_node_icon(node_id):
         normalized_id = node_id if node_id.startswith("!") else f"!{node_id}"
         if not node_id_validator(normalized_id):
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
+
+        try:
+            destination = icon_path(normalized_id)
+        except ValueError:
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
         uploaded = request.files.get("icon")
@@ -49,7 +70,6 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
                 x = (256 - source.width) // 2
                 y = (256 - source.height) // 2
                 canvas.alpha_composite(source, (x, y))
-                destination = icon_path(normalized_id)
                 temporary = destination.with_suffix(".tmp")
                 canvas.save(temporary, format="PNG", optimize=True)
                 temporary.replace(destination)
@@ -68,7 +88,20 @@ def register_node_icon_routes(app, data_dir, local_node_id, node_id_validator):
         if not node_id_validator(normalized_id):
             return jsonify({"ok": False, "error": "Invalid node_id"}), 400
 
-        path = icon_path(normalized_id)
+        try:
+            path = icon_path(normalized_id)
+        except ValueError:
+            return jsonify({"ok": False, "error": "Invalid node_id"}), 400
         if path.exists():
             path.unlink()
         return jsonify({"ok": True, "node_id": normalized_id})
+
+    # Test-only seam: icon_path()'s own traversal guard needs to be
+    # exercised directly, bypassing the route-level regex check, to prove
+    # it holds on its own - Flask's <node_id> URL converter already
+    # rejects any "/"-containing payload before it would ever reach a
+    # view function, so a real HTTP request can't reach this closure with
+    # a traversal-shaped value to test it that way. Unused by server.py's
+    # own call site (return value previously discarded), so this is
+    # additive, not a behavior change.
+    return icon_path

--- a/tests/test_api_node_icons.py
+++ b/tests/test_api_node_icons.py
@@ -1,0 +1,159 @@
+"""Tests for api/api_node_icons.py's node-icon routes.
+
+icon_path()'s resolve()+is_relative_to() guard is defense-in-depth, not
+a fix for a confirmed vulnerability: is_valid_node_id() (server.py,
+`re.fullmatch(r"![0-9a-fA-F]{8}", value)`) is already called before
+icon_path() in all three routes and already rejects every
+traversal-shaped node_id tried against it directly
+('!../../etc/passwd', '!../secret', '!....//....//etc/passwd',
+'!b0f14d2a/../../secret' - all REJECTED). The guard protects against a
+future loosening of that regex (for an unrelated reason) silently
+reopening this route, not an active bug today.
+"""
+import io
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from PIL import Image
+
+import api.api_node_icons as api_node_icons_module
+from api.api_node_icons import register_node_icon_routes
+
+
+def _real_validator(node_id):
+    import re
+    return bool(re.fullmatch(r"![0-9a-fA-F]{8}", node_id))
+
+
+def _make_app(tmp_path, validator=_real_validator):
+    app = Flask(__name__)
+    app.testing = True
+    register_node_icon_routes(app, str(tmp_path), "!12345678", validator)
+    return app
+
+
+# --- Baseline behavior, unchanged by the new guard ---------------------
+
+
+def test_invalid_node_id_rejected_by_the_regex_before_icon_path_is_reached(tmp_path):
+    client = _make_app(tmp_path).test_client()
+
+    resp = client.get("/api/nodes/invalid_node/icon")
+    assert resp.status_code == 400
+    assert resp.json == {"ok": False, "error": "Invalid node_id"}
+
+    resp = client.get("/api/nodes/!short/icon")
+    assert resp.status_code == 400
+    assert resp.json == {"ok": False, "error": "Invalid node_id"}
+
+
+def test_get_missing_icon_returns_404(tmp_path):
+    client = _make_app(tmp_path).test_client()
+
+    resp = client.get("/api/nodes/!12345678/icon")
+    assert resp.status_code == 404
+    assert resp.json == {"ok": False, "error": "Node icon not found"}
+
+
+def test_upload_get_delete_round_trip_unaffected_by_the_new_guard(tmp_path):
+    client = _make_app(tmp_path).test_client()
+
+    img = Image.new("RGBA", (100, 100), (255, 0, 0, 255))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+
+    resp = client.post(
+        "/api/nodes/!12345678/icon",
+        data={"icon": (buf, "test.png")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert resp.json["ok"] is True
+    assert resp.json["node_id"] == "!12345678"
+
+    resp = client.get("/api/nodes/!12345678/icon")
+    assert resp.status_code == 200
+    assert resp.content_type == "image/png"
+    resp.close()  # release send_file()'s underlying file handle (Windows keeps it locked otherwise)
+
+    resp = client.delete("/api/nodes/!12345678/icon")
+    assert resp.status_code == 200
+    assert resp.json == {"ok": True, "node_id": "!12345678"}
+
+    resp = client.get("/api/nodes/!12345678/icon")
+    assert resp.status_code == 404
+
+
+# --- The new guard, tested in isolation from the regex ------------------
+# Uses a permissive validator (always True) to simulate the regex having
+# been loosened/bypassed - exactly the scenario the guard exists for -
+# so these requests reach icon_path() with a traversal-shaped node_id
+# the route-level check would normally have already stopped.
+
+
+TRAVERSAL_NODE_IDS = [
+    "!../../etc/passwd",
+    "!../secret",
+    "!....//....//etc/passwd",
+    "!b0f14d2a/../../secret",
+]
+
+# Of the four payloads above, three genuinely resolve outside icons_dir
+# (real ".." parent-references) - icon_path()'s guard must reject them.
+# "!....//....//etc/passwd" is different: "...." (four dots) is not a
+# parent-directory operator to pathlib's resolve() at all, just an
+# unusual literal path component - verified directly below, not assumed.
+# It stays in TRAVERSAL_NODE_IDS because is_valid_node_id()'s regex
+# still rejects it (non-hex characters), which is the layer actually
+# relevant to the original finding - but it would NOT be caught by
+# icon_path()'s own guard specifically, because it was never a real
+# escape attempt against a resolve()-based check to begin with.
+ESCAPING_NODE_IDS = [nid for nid in TRAVERSAL_NODE_IDS if "...." not in nid]
+
+
+@pytest.mark.parametrize("node_id", TRAVERSAL_NODE_IDS)
+def test_slash_containing_payloads_never_even_reach_the_view_function(tmp_path, monkeypatch, node_id):
+    """A layer discovered while writing these tests, not assumed going
+    in: Flask's default <node_id> URL converter only matches a single
+    path segment ([^/]+) - every one of these "/"-containing payloads
+    404s at routing, before is_valid_node_id() or icon_path() ever runs.
+    Proven with a spy on the validator itself, not just the response
+    code (a 404 could otherwise coincidentally mean something else)."""
+    validator_spy = MagicMock(side_effect=AssertionError("node_id_validator() must never be called - routing should reject this first"))
+    client = _make_app(tmp_path, validator=validator_spy).test_client()
+
+    resp = client.get(f"/api/nodes/{node_id}/icon")
+
+    assert resp.status_code == 404
+    validator_spy.assert_not_called()
+
+
+def test_icon_path_guard_rejects_traversal_when_called_directly(tmp_path):
+    """The actual case the task asked for: icon_path()'s own guard,
+    tested in isolation, bypassing the route/regex layer entirely - not
+    just proving it's unreachable via HTTP (the test above), but proving
+    the guard itself would catch these values if it were ever reached
+    directly (e.g. from a future call site that doesn't go through
+    is_valid_node_id() first). Uses ESCAPING_NODE_IDS, not the full
+    TRAVERSAL_NODE_IDS list - see that list's own comment for why one
+    entry doesn't belong here."""
+    app = Flask(__name__)
+    app.testing = True
+    icon_path = register_node_icon_routes(app, str(tmp_path), "!12345678", _real_validator)
+
+    for node_id in ESCAPING_NODE_IDS:
+        with pytest.raises(ValueError):
+            icon_path(node_id)
+
+    # "...." is a literal path component, not a parent-reference - it
+    # never escapes icons_dir under resolve(), verified directly rather
+    # than assumed alongside the genuinely-escaping payloads above.
+    contained = icon_path("!....//....//etc/passwd")
+    assert contained.is_relative_to((tmp_path / "node_icons").resolve())
+
+    # A legitimate node_id must still resolve inside icons_dir, unaffected.
+    resolved = icon_path("!12345678")
+    assert resolved == (tmp_path / "node_icons" / "12345678.png").resolve()
+    assert resolved.is_relative_to((tmp_path / "node_icons").resolve())


### PR DESCRIPTION
## Summary
Third Jules finding this session, independently verified before implementing - same pattern as the screenshot-route (PR #128) and auth-redirect (PR #130) cases.

**Finding**: `api/api_node_icons.py`'s `icon_path()` builds a filename from `node_id` with no path-traversal guard of its own.

**Verification, not hypothesis**: `is_valid_node_id()` (`server.py:1095`, `re.fullmatch(r"![0-9a-fA-F]{8}", value)`) is already called before `icon_path()` in all three routes (GET/POST/DELETE). Tested directly against realistic payloads - `'!../../etc/passwd'`, `'!....//....//etc/passwd'`, `'!b0f14d2a/../../secret'`, `'!../secret'` - **all REJECTED**. Only exactly `"!"` + 8 hex chars matches; no traversal-shaped string can reach `icon_path()` today. **False positive, no active vulnerability.**

**Decision**: same resolution as PR #128 (Option B) - adopt the guard mechanism anyway as genuine defense-in-depth, protecting against a future loosening of `is_valid_node_id()`'s regex (for an unrelated reason, without realizing this route depends on its strictness) silently reopening this route. Not merging Jules' branch as-is.

## What changed
- `icon_path()` now resolves the target and checks `is_relative_to(icons_dir.resolve())`, raising `ValueError` on escape - all three routes catch it and return the same 400 they already return for an invalid `node_id`.
- `register_node_icon_routes()` now returns `icon_path` itself as a test-only seam. Discovered while writing tests, not assumed: Flask's `<node_id>` URL converter only matches a single path segment, so a real HTTP request can *never* reach `icon_path()` with a `/`-containing payload - the guard is only reachable for testing by calling it directly.
- One more thing verified directly rather than assumed while writing the isolation test: of the four traversal payloads, `!....//....//etc/passwd` (four dots) does *not* actually escape `icons_dir` under `resolve()` - `"...."` is a literal path component to pathlib, not a parent-reference. It's still correctly rejected by the regex layer (non-hex characters), just not by this specific guard. Documented in the test rather than silently asserting something false.

## Test plan
- [x] `pytest tests/test_api_node_icons.py` - 8 tests: baseline route behavior unchanged (round-trip upload/get/delete, invalid-id rejection, missing-icon 404), a spy proving slash-containing payloads never reach the validator (blocked by Flask routing itself), and the guard tested in true isolation via the new `icon_path` return value
- [x] Full suite: `pytest` - 428 passed, 25 skipped (pre-existing platform skips)

## Related
Closes the investigation into `sentinel/fix-node-icon-path-traversal-...` - that branch will be closed with an honest comment (verified independently, not exploitable as diagnosed, defense-in-depth adopted separately with accurate attribution) and deleted after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)