### PR TITLE
Add root pyproject.toml with minimal, Core-only descriptive metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+# [project] describes MIT-licensed Core only (server.py, api/, meshsrv/,
+# storage/, telemetry/, camera/, weather/, utils/) - NOT the whole
+# repository. adapters/meshtastic/ is GPLv3-licensed, isolated into its
+# own subprocess/venv (see THIRD_PARTY_NOTICES.md and
+# adapters/meshtastic/LICENSE) and deliberately excluded from this
+# project's own metadata scope.
+#
+# This scoping is descriptive for humans reading this file, NOT a
+# technical enforcement boundary - setuptools/pip's own package
+# auto-discovery doesn't know or care what this comment says. The
+# actual safety guarantee is structural: this repo has multiple
+# top-level Python packages (api/, meshsrv/, adapters/, camera/, ...)
+# with no packages=[...] configuration, so setuptools' own flat-layout
+# auto-discovery safety check refuses to build a wheel at all rather
+# than guess which ones belong together - verified directly, live,
+# against this exact repository (`pip install .` in a disposable clean
+# checkout: "Multiple top-level packages discovered in a flat-layout...
+# setuptools will not proceed with this build" - exit 1, no wheel
+# produced, nothing named "meshcenter" or "adapters" ever reaches
+# site-packages). No [build-system] table below is what this project
+# actually relies on day to day: MeshCenter is never installed via
+# `pip install .`/built as a wheel anywhere in this repo's own tooling
+# (install.sh/meshcenter-firstboot.sh only ever run
+# `pip install -r requirements.txt`, confirmed unaffected by this
+# file's presence - same installed package set, with or without it).
+# Adding [build-system] machinery here would imply otherwise without a
+# real reason to.
+[project]
+name = "meshcenter"
+version = "1.8.0"
+# Descriptive metadata only. Runtime version remains authoritative and
+# is derived from git describe --tags (see server.py's
+# resolve_app_version()) - update this manually when tagging a new
+# release; IDEs, dependency scanners, and other packaging tools may
+# read this field even though nothing in this codebase's own runtime
+# does.
+description = "MIT-licensed Flask Core of MeshCenter, a web control center for a Meshtastic LoRa radio"
+license = {file = "LICENSE"}
+requires-python = ">=3.11"
+authors = [{name = "Kostiantyn Vynohradov"}]
+
+# No [project.dependencies]: requirements.txt (range-pinned, live-
+# verified) stays the single source of truth - install.sh reads that
+# file directly, not this one. Duplicating it here would create a
+# second list nothing keeps in sync.
+
+[project.urls]
+Homepage = "https://github.com/FlintUA/MeshCenter"
+Repository = "https://github.com/FlintUA/MeshCenter"
+Issues = "https://github.com/FlintUA/MeshCenter/issues"


### PR DESCRIPTION
## Summary
Small packaging-metadata task from an external audit - not a rewrite of the deployment model. `install.sh`/`meshcenter-firstboot.sh` are unchanged and still work exactly as before (`git clone` + venv + `pip install -r requirements.txt`).

Given elevated scrutiny for anything touching the MIT/GPLv3 licensing boundary this project already invested heavily in getting right (Tasks 43-49), this went through two rounds of investigation before implementation - full detail in the PR discussion/session, condensed here:

- **No `[build-system]` table, no `[project.dependencies]`** - MeshCenter is never installed via `pip install .`/built as a wheel anywhere in this repo's tooling (verified: recursive grep across `install.sh`, `meshcenter-firstboot.sh`, `deploy/`, `scripts/`, `.github/workflows/` for `pip install .`, `-e .`, `twine`, `python -m build`, etc. - zero hits, no Dockerfile exists either). `requirements.txt` (range-pinned, live-verified) stays the single source of truth for dependencies.
- **`[project]` scopes to MIT-licensed Core only**, stated explicitly in the file's own comment - this repo mixes MIT Core with GPLv3 `adapters/meshtastic/`. The comment is documentation for humans, not enforcement: verified directly that `pip install .` on this exact repo fails *before ever reaching metadata* - setuptools' own flat-layout auto-discovery safety guard refuses to guess which of this repo's many top-level packages (`api/`, `meshsrv/`, `adapters/`, `camera/`, ...) belong together (`error: Multiple top-level packages discovered in a flat-layout`, listing `adapters` right in the error). No wheel is ever produced, nothing named `meshcenter`/`adapters` ever reaches `site-packages` - confirmed with a live A/B test in disposable clean checkouts, and again with `pip wheel .` for full certainty. No GPLv3-adjacent code can end up bundled into an installable artifact under this file's MIT-labeled metadata.
- **`requirements.txt` safety re-confirmed empirically**: two clean venvs, one with `pyproject.toml` present, one without, `pip install -r requirements.txt` in both - byte-identical installed package set (only cosmetic cache-hit differences in the log).
- **`readme` field omitted** - `README.md` documents the whole project including the GPLv3 adapter, which would contradict the Core-only scoping stated above.
- **`license = {file = "LICENSE"}`** (legacy form, not the newer PEP 639 SPDX string) - both forms tested against the actual toolchain this project's `pip` resolves (`setuptools==84.0.0`), both work cleanly; legacy form chosen for broader backward compatibility since nothing here needs the newer syntax.
- **`version = "1.8.0"`** (static, PEP 440-valid, matches the current release tag) with a comment noting it's descriptive-only and will go stale between manual updates - the app's own runtime version display is unaffected, already independently derived from `git describe --tags` (`server.py`'s `resolve_app_version()`).
- **`requires-python = ">=3.11"`** cross-checked against three independent sources, not picked from one: `install.sh`'s actual gating code (`MIN_PYTHON_MAJOR=3`/`MIN_PYTHON_MINOR=11`), `INSTALL.md`'s stated text, and Droidian's live-confirmed interpreter (`Python 3.13.5`, both venvs) - all agree.
- **`name = "meshcenter"`** - checked PyPI directly (`https://pypi.org/pypi/meshcenter/json` → 404), no namespace conflict, no publish intent implied (no `[build-system]`, no dormant publish infra found anywhere in this repo).
- **`[project.urls]`** - only real, verified URLs (checked via `gh api repos/FlintUA/MeshCenter`, not guessed).

## Test plan
- [x] `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` - valid TOML
- [x] `git diff --stat` scoped to `pyproject.toml` only, 1 file changed
- [x] Live-verified on dev (192.168.2.104): copied the file in as an uncommitted test, ran `install.sh`'s actual `pip install -r requirements.txt` step against the real venv - succeeded cleanly; ran `scripts/verify-install.sh` - 20 OK, 0 warnings, 0 failures; confirmed `meshcenter.service` still active throughout. Test file removed after verification, dev restored to its pre-test state (nothing merged onto dev yet - that happens via the normal post-merge sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)