### PR TITLE
Add installation ID generator + validator (Stage A)

### DIFF
--- a/meshsrv/installation_identity.py
+++ b/meshsrv/installation_identity.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Installation ID generation and validation.
+
+Stage A of the installation-ID rollout (see the external implementation
+spec) - generator/validator only. The spec's module also lists
+get_confirmed_utc_time()/format_utc_iso8601() as eventually belonging in
+this same file; those are deferred to a later stage and deliberately not
+present here.
+
+An installation ID identifies a MeshCenter *install*, not a radio - it is
+pure entropy (secrets.token_hex()), with no hardware or personal data of
+any kind folded in, so it carries no fingerprinting risk and stays valid
+across a radio swap or profile switch.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+
+_FORMAT_RE = re.compile(r"^MC1(?:-[0-9A-F]{4}){5}$")
+
+
+def generate_installation_id() -> str:
+    """Return a new installation ID: MC1-XXXX-XXXX-XXXX-XXXX-XXXX.
+
+    10 bytes (secrets.token_hex(10)) produce 20 hex characters, grouped into
+    five 4-character blocks - exactly matching the five groups in the format
+    below.
+    """
+    hex_value = secrets.token_hex(10).upper()
+    groups = [hex_value[i:i + 4] for i in range(0, 20, 4)]
+    return "MC1-" + "-".join(groups)
+
+
+def is_valid_installation_id(value: str) -> bool:
+    """Return True if value matches the installation ID format exactly."""
+    return bool(_FORMAT_RE.fullmatch(str(value or "")))

--- a/tests/test_installation_identity.py
+++ b/tests/test_installation_identity.py
@@ -1,0 +1,70 @@
+"""Tests for meshsrv/installation_identity.py (Stage A: generator/validator
+only - see the installation-ID rollout spec). Randomness is mocked
+throughout per the spec's own requirement (10.1) not to rely on real
+entropy calls for test determinism.
+"""
+
+from unittest.mock import patch
+
+from meshsrv.installation_identity import (
+    generate_installation_id,
+    is_valid_installation_id,
+)
+
+_FAKE_HEX = "0123456789ABCDEF0123"  # 20 chars = secrets.token_hex(10).upper()
+
+
+def test_generated_id_matches_format():
+    with patch("secrets.token_hex", return_value=_FAKE_HEX.lower()):
+        value = generate_installation_id()
+    assert value == "MC1-0123-4567-89AB-CDEF-0123"
+
+
+def test_generated_id_uses_only_hex_characters():
+    with patch("secrets.token_hex", return_value=_FAKE_HEX.lower()):
+        value = generate_installation_id()
+    body = value[len("MC1-"):].replace("-", "")
+    assert all(c in "0123456789ABCDEF" for c in body)
+
+
+def test_generated_id_has_mc1_prefix():
+    with patch("secrets.token_hex", return_value=_FAKE_HEX.lower()):
+        value = generate_installation_id()
+    assert value.startswith("MC1-")
+
+
+def test_generator_requests_exactly_ten_bytes_of_entropy():
+    # Per spec 10.1: verify the call argument itself, not just the output
+    # shape - a generator that produced a correctly-shaped ID from a
+    # different byte count would still pass a purely output-based check.
+    with patch("secrets.token_hex", return_value=_FAKE_HEX.lower()) as mock_token_hex:
+        generate_installation_id()
+    mock_token_hex.assert_called_once_with(10)
+
+
+def test_validator_accepts_a_correct_value():
+    assert is_valid_installation_id("MC1-0123-4567-89AB-CDEF-0123") is True
+
+
+def test_validator_rejects_lowercase():
+    assert is_valid_installation_id("mc1-0123-4567-89ab-cdef-0123") is False
+
+
+def test_validator_rejects_wrong_prefix():
+    assert is_valid_installation_id("MC2-0123-4567-89AB-CDEF-0123") is False
+
+
+def test_validator_rejects_wrong_group_count():
+    assert is_valid_installation_id("MC1-0123-4567-89AB-CDEF") is False
+
+
+def test_validator_rejects_invalid_characters():
+    assert is_valid_installation_id("MC1-012G-4567-89AB-CDEF-0123") is False
+
+
+def test_validator_rejects_trailing_newline():
+    # re.match()'s `$` anchor (without re.MULTILINE) tolerates a trailing
+    # "\n" before end-of-string - fullmatch() is required to actually
+    # reject it, matching server.py's is_valid_node_id() convention for
+    # the same class of strict whole-string format check.
+    assert is_valid_installation_id("MC1-0123-4567-89AB-CDEF-0123\n") is False


### PR DESCRIPTION
## Summary
- Stage A of the installation-ID rollout (external implementation spec): `meshsrv/installation_identity.py` with `generate_installation_id()` / `is_valid_installation_id()` only.
- Pure entropy (`secrets.token_hex(10)`) — no hardware/personal data inputs, no `meshtastic` import, no HTTP, no new requirements.
- `is_valid_installation_id()` uses `re.fullmatch()` (not `.match()`), matching `server.py`'s `is_valid_node_id()` convention for strict whole-string format checks — a review round caught `.match()` letting a trailing `\n` slip through via Python's `$` anchor behavior.

## Test plan
- [x] `pytest tests/test_installation_identity.py -v` — 10/10 passed (7 spec-required cases + format/prefix sanity + trailing-newline regression)
- [x] Full suite: `pytest -q` — 438 passed, 25 pre-existing platform skips, no regressions
- [x] Pseudocode verified independently by running it, not just reading it

🤖 Generated with [Claude Code](https://claude.com/claude-code)