### PR TITLE
Add installation-ID CLI tool + docs (Stage F, final)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,33 @@
+# Privacy: Installation ID
+
+This document covers exactly one thing: the **Installation ID** shown on MeshCenter's System card (`MC1-XXXX-XXXX-XXXX-XXXX-XXXX`). It is not a general privacy policy for the MeshCenter project as a whole.
+
+## What it is
+
+A random identifier generated once, the first time MeshCenter starts on a given install:
+
+- Generated with Python's `secrets.token_hex()` - a cryptographically secure random number generator, the same one used to generate passwords and tokens elsewhere in this codebase.
+- 20 hexadecimal characters, formatted as `MC1-XXXX-XXXX-XXXX-XXXX-XXXX` for readability.
+- Stored locally in `data/instance.json`, alongside when it was assigned and how (see `meshsrv/instance_manager.py` if you want to read the actual code).
+
+It identifies **this installation of the MeshCenter software** - one particular `data/` directory on one particular Raspberry Pi (or other host) at one particular point in time.
+
+## What it is not
+
+- **Not a hardware identifier.** It contains no MAC address, no CPU serial number, no radio serial number, no disk ID - nothing derived from the physical device it's running on. Moving MeshCenter to different hardware (a fresh SD card, a replacement Pi) and copying `data/` over would carry the same ID with it; conversely, wiping and reinstalling on the *same* hardware produces a brand new one. It tracks the install, not the machine.
+- **Not tied to your Meshtastic radio.** Swapping which physical radio is connected to a given MeshCenter install (see the "Multi-radio profiles" section above) does not change this ID, and regenerating this ID does not affect the radio, its node ID, or anything about the mesh.
+- **Not personal data.** Nothing about you - name, location, email, anything you've typed into MeshCenter - is used to generate it or derivable from it. It is, deliberately, pure entropy with nothing meaningful folded in.
+
+## Where it goes
+
+**Nowhere, currently.** As of this writing, nothing in the MeshCenter codebase transmits the Installation ID anywhere:
+
+- It is not sent to Meshtastic devices or over the mesh network.
+- It is not included in any outbound network request MeshCenter makes. The only outbound HTTP call anywhere in this codebase is the optional update checker (`meshsrv/update_service.py`), which polls GitHub's public releases API for version information - a plain, unauthenticated request with no instance-identifying data attached, not even in a header.
+- It is not written to logs sent anywhere external, or included in exported node/chat data.
+
+It exists today purely for local reference (visible on the System card, retrievable via `GET /api/instance`) and as groundwork for future tooling that may need to distinguish one MeshCenter installation from another - for example, correlating support requests or, eventually, an opt-in fleet-management feature. If a future feature ever does transmit this ID anywhere, that will be a deliberate, documented change to this file, not a silent one - and any such feature should be opt-in, not on by default.
+
+## Regenerating it
+
+You can generate a new Installation ID at any time - see the [User Guide](docs/User_Guide.md#installation-id) for the command. This permanently replaces the old value; nothing links the new ID back to the old one. There's no server-side registry of issued IDs to notify or reconcile with - it's a purely local value, so regenerating it has no effect outside this one installation.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ serial-access checklist that trips up most first installs: see
 - [Quick Installation](#installation)
 - [Architecture Overview](#application-architecture)
 - [Development Roadmap](#roadmap)
+- [Privacy: Installation ID](PRIVACY.md)
 
 ## Switching to another Meshtastic radio
 
@@ -1248,6 +1249,16 @@ This improves:
 - Future multi-node support
 
 ---
+
+## 🔑 Installation ID
+
+Each MeshCenter *install* (not the radio) has its own identifier - a random `MC1-XXXX-XXXX-XXXX-XXXX-XXXX` string, visible on the System card as **Installation ID**. It's pure entropy generated on first run, with no hardware serial number, MAC address, or personal data folded into it - it identifies this installation of the software, not you or your device. See [PRIVACY.md](PRIVACY.md) for the full detail.
+
+It's shown for reference and for pairing with future tooling that needs to distinguish one MeshCenter install from another - click it to copy. If you ever want a fresh identifier (for example, before giving away or reselling the device), stop the service and run:
+
+```bash
+python3 scripts/manage_installation_id.py regenerate
+```
 
 ## Camera Notes
 

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -508,6 +508,20 @@ The Wi-Fi Manager can change the Raspberry Pi network connection. Changing to an
 
 The Workspace menu also controls Base and Nodes panel visibility, theme and compact mode. These visual preferences are stored in the current browser, not globally on the Raspberry Pi.
 
+### Installation ID
+
+The System card shows an **Installation ID** (`MC1-XXXX-XXXX-XXXX-XXXX-XXXX`) - click it to copy. It identifies this MeshCenter *installation*, not your radio and not you: it's a random value generated on first run, with no hardware serial number, MAC address, or personal data of any kind in it. See [PRIVACY.md](../PRIVACY.md) for the full detail on what it is and isn't.
+
+You'd want a fresh one mainly when handing the device to someone else - before donating or reselling a Raspberry Pi running MeshCenter, for example, so the new owner's installation starts with its own identifier rather than inheriting yours. Regenerating is a command-line operation, on purpose (it's a rare, deliberate action, not something to expose as a casual button in the UI):
+
+```bash
+sudo systemctl stop meshcenter.service
+python3 scripts/manage_installation_id.py regenerate
+sudo systemctl start meshcenter.service
+```
+
+The service must be stopped first - MeshCenter caches the ID in memory while running, so regenerating it while the service is up would change the file on disk without the running app (or the System card) noticing until restarted. The tool checks this and refuses by default if the service is still active. Run `python3 scripts/manage_installation_id.py show` any time to see the current ID without changing anything.
+
 ### Updates
 
 The **Updates** card checks GitHub for a newer release (once a day by default - togglable, and never more often than the interval you set) and shows the current version, the latest version, and the real release changelog. **Check now** refreshes that check on demand.

--- a/scripts/manage_installation_id.py
+++ b/scripts/manage_installation_id.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Inspect or regenerate this MeshCenter installation's identifier.
+
+Stage F (final) of the installation-ID rollout - see meshsrv/instance_manager.py
+(schema v2's "installation" block) and meshsrv/installation_identity.py (the
+generator/validator this script calls directly, the same one server.py uses).
+
+This script never imports server.py - it constructs its own InstanceManager,
+same DI-everywhere pattern every other consumer in this codebase follows, and
+avoids triggering server.py's whole module-level startup sequence (radio
+detection, Meshtastic CLI resolution, etc.), which would be entirely wrong
+for a standalone CLI tool.
+
+CRITICAL: InstanceManager caches in memory - a running meshcenter.service
+process holds the old id in memory and keeps serving it via /api/instance and
+the "MeshCenter Instance" UI card until restarted, even after this script has
+already changed the file on disk. `regenerate` checks systemctl is-active and
+refuses to proceed by default while the service is running (see --force).
+
+Core logic (show_installation/regenerate_installation) takes an InstanceManager
+and, for regenerate, injected is_service_active/confirm callables - callers
+(the cmd_* argparse glue below, or a test) supply the side-effecting bits
+directly rather than this module reaching for systemctl/input() itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from meshsrv.installation_identity import generate_installation_id  # noqa: E402
+from meshsrv.instance_manager import InstanceManager  # noqa: E402
+
+SERVICE_NAME = "meshcenter.service"
+
+
+def instance_file_path(data_dir: str | Path) -> Path:
+    return Path(data_dir) / "instance.json"
+
+
+def is_service_active(service_name: str = SERVICE_NAME) -> bool:
+    """True if systemd reports the service as currently running. False on
+    any failure to determine this (systemctl missing, not under systemd,
+    etc.) - a script running outside a real deployment (e.g. a dev machine)
+    should not be blocked by an environment that has no such service at all."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", service_name],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "active"
+
+
+def show_installation(manager: InstanceManager) -> str:
+    installation = manager.load_or_create({}).get("installation", {})
+    return (
+        f"Installation ID:   {installation.get('id', '(none)')}\n"
+        f"Assigned at:       {installation.get('assigned_at') or '(not yet confirmed)'}\n"
+        f"Time source:       {installation.get('time_source', 'pending')}\n"
+        f"Assignment reason: {installation.get('assignment_reason', '(unknown)')}"
+    )
+
+
+def regenerate_installation(
+    manager: InstanceManager,
+    is_service_active_fn: Callable[[], bool],
+    confirm_fn: Callable[[str], bool],
+    force: bool = False,
+    assume_yes: bool = False,
+) -> tuple[int, str]:
+    """Returns (exit_code, message). exit_code 0 means the ID was changed;
+    1 means refused/aborted with no changes made. Never calls systemctl or
+    input() directly - those come in as is_service_active_fn/confirm_fn so
+    this function is fully testable without touching the real system."""
+    identity = manager.load_or_create({})
+    old_id = identity.get("installation", {}).get("id", "(none)")
+    lines = [f"Current Installation ID: {old_id}"]
+
+    if is_service_active_fn():
+        if not force:
+            lines.append(
+                f"\n{SERVICE_NAME} is currently running. Regenerating now would change "
+                "the file on disk, but the running process caches the old ID in memory "
+                "and would keep serving it via /api/instance and the System card until "
+                "restarted - the UI and the file would silently disagree.\n\n"
+                f"Stop the service first:\n  sudo systemctl stop {SERVICE_NAME}\n"
+                "then run this command again, or pass --force to proceed anyway."
+            )
+            return 1, "\n".join(lines)
+        lines.append(
+            f"\nWARNING: {SERVICE_NAME} is running and --force was given - proceeding "
+            "anyway. The running process will keep showing the OLD ID until you restart "
+            f"it: sudo systemctl restart {SERVICE_NAME}"
+        )
+
+    if not assume_yes and not confirm_fn(old_id):
+        lines.append("\nAborted - no changes made.")
+        return 1, "\n".join(lines)
+
+    updated = dict(identity)
+    updated["installation"] = {
+        "id": generate_installation_id(),
+        "assigned_at": None,
+        "time_source": "pending",
+        "assignment_reason": "regeneration",
+    }
+    new_identity = manager.save(updated)
+    new_id = new_identity["installation"]["id"]
+
+    lines.append(f"\nNew Installation ID: {new_id}")
+    lines.append(f"Restart the service for this to take effect: sudo systemctl restart {SERVICE_NAME}")
+    return 0, "\n".join(lines)
+
+
+def _prompt_confirm(old_id: str) -> bool:
+    answer = input(
+        f"\nThis will permanently invalidate Installation ID {old_id} for any "
+        "external correlation. Continue? [y/N] "
+    ).strip().lower()
+    return answer in ("y", "yes")
+
+
+def cmd_show(args: argparse.Namespace, manager: InstanceManager) -> int:
+    print(show_installation(manager))
+    return 0
+
+
+def cmd_regenerate(args: argparse.Namespace, manager: InstanceManager) -> int:
+    exit_code, message = regenerate_installation(
+        manager,
+        is_service_active_fn=is_service_active,
+        confirm_fn=_prompt_confirm,
+        force=args.force,
+        assume_yes=args.yes,
+    )
+    print(message, file=sys.stderr if exit_code else sys.stdout)
+    return exit_code
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect or regenerate this MeshCenter installation's identifier.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    show_parser = subparsers.add_parser("show", help="Print the current installation identity (read-only).")
+    show_parser.set_defaults(func=cmd_show)
+
+    regen_parser = subparsers.add_parser("regenerate", help="Generate a new installation ID, replacing the current one.")
+    regen_parser.add_argument("-y", "--yes", action="store_true", help="Skip the interactive confirmation prompt.")
+    regen_parser.add_argument(
+        "--force", action="store_true",
+        help=f"Proceed even if {SERVICE_NAME} is currently running (not recommended - see warning).",
+    )
+    regen_parser.set_defaults(func=cmd_regenerate)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)  # --help/-h exits here, before config.py is needed
+
+    from config import DATA_DIR  # noqa: E402 - deferred: only a real command needs config.py present
+
+    manager = InstanceManager(instance_file_path(DATA_DIR))
+    return args.func(args, manager)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_manage_installation_id.py
+++ b/tests/test_manage_installation_id.py
@@ -1,0 +1,172 @@
+"""Tests for scripts/manage_installation_id.py - Task F (final stage) of the
+installation-ID rollout. No prior Python CLI script in this repo has test
+coverage (checked - scripts/check-i18n.py, scripts/check_startup_calls.py,
+the _smoke_test_*_harness.py files all have none), so this is the first.
+Per the investigation report: test the core logic functions
+(show_installation/regenerate_installation) against a real InstanceManager
+in a tmp_path, injecting is_service_active/confirm rather than touching
+systemctl or input() - not testing argparse's own wiring in detail.
+
+manage_installation_id.py defers `from config import DATA_DIR` to main()
+specifically so importing the rest of the module never needs config.py -
+these tests rely on that and never touch config.py at all.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import manage_installation_id as cli  # noqa: E402
+
+from meshsrv.installation_identity import is_valid_installation_id
+from meshsrv.instance_manager import InstanceManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    m = InstanceManager(tmp_path / "instance.json")
+    m.load_or_create({})
+    return m
+
+
+def test_show_installation_reports_current_id(manager):
+    identity = manager.get()
+    output = cli.show_installation(manager)
+    assert identity["installation"]["id"] in output
+    assert "pending" in output
+    assert "(not yet confirmed)" in output
+
+
+def test_show_installation_reports_resolved_time_source(manager):
+    identity = manager.get()
+    updated = dict(identity)
+    updated["installation"] = dict(identity["installation"])
+    updated["installation"]["assigned_at"] = "2026-09-01T07:00:00+00:00"
+    updated["installation"]["time_source"] = "system_ntp"
+    manager.save(updated)
+
+    output = cli.show_installation(manager)
+    assert "system_ntp" in output
+    assert "2026-09-01T07:00:00+00:00" in output
+
+
+def test_regenerate_refuses_by_default_while_service_active(manager):
+    old_id = manager.get()["installation"]["id"]
+
+    exit_code, message = cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: True,
+        confirm_fn=lambda old: True,
+        force=False,
+        assume_yes=True,
+    )
+
+    assert exit_code == 1
+    assert "currently running" in message
+    assert manager.get()["installation"]["id"] == old_id
+
+
+def test_regenerate_proceeds_with_force_while_service_active(manager):
+    old_id = manager.get()["installation"]["id"]
+
+    exit_code, message = cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: True,
+        confirm_fn=lambda old: True,
+        force=True,
+        assume_yes=True,
+    )
+
+    assert exit_code == 0
+    assert "WARNING" in message
+    new_id = manager.get()["installation"]["id"]
+    assert new_id != old_id
+    assert is_valid_installation_id(new_id)
+
+
+def test_regenerate_aborts_when_confirmation_declined(manager):
+    old_id = manager.get()["installation"]["id"]
+
+    exit_code, message = cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: False,
+        force=False,
+        assume_yes=False,
+    )
+
+    assert exit_code == 1
+    assert "Aborted" in message
+    assert manager.get()["installation"]["id"] == old_id
+
+
+def test_regenerate_skips_confirmation_with_assume_yes(manager):
+    confirm_calls = []
+
+    exit_code, message = cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: confirm_calls.append(old) or True,
+        force=False,
+        assume_yes=True,
+    )
+
+    assert exit_code == 0
+    assert confirm_calls == []
+
+
+def test_regenerate_sets_expected_fields_on_success(manager):
+    old_id = manager.get()["installation"]["id"]
+
+    exit_code, message = cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: True,
+        force=False,
+        assume_yes=False,
+    )
+
+    assert exit_code == 0
+    installation = manager.get()["installation"]
+    assert installation["id"] != old_id
+    assert is_valid_installation_id(installation["id"])
+    assert installation["assigned_at"] is None
+    assert installation["time_source"] == "pending"
+    assert installation["assignment_reason"] == "regeneration"
+    assert old_id in message
+    assert installation["id"] in message
+
+
+def test_regenerate_preserves_every_other_existing_field(manager):
+    identity_before = manager.get()
+    updated = dict(identity_before)
+    updated["active_profile_id"] = "067a40fa"
+    updated["radio"] = dict(identity_before["radio"])
+    updated["radio"]["node_id"] = "!067a40fa"
+    manager.save(updated)
+
+    cli.regenerate_installation(
+        manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: True,
+        force=False,
+        assume_yes=False,
+    )
+
+    identity = manager.get()
+    assert identity["active_profile_id"] == "067a40fa"
+    assert identity["radio"]["node_id"] == "!067a40fa"
+
+
+def test_is_service_active_returns_false_when_systemctl_unavailable(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise FileNotFoundError("systemctl not found")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    assert cli.is_service_active() is False
+
+
+def test_instance_file_path_is_data_dir_slash_instance_json(tmp_path):
+    assert cli.instance_file_path(tmp_path) == tmp_path / "instance.json"


### PR DESCRIPTION
## Summary
Final stage of the installation-ID rollout (Tasks A-E already merged: #150-154).

- **`scripts/manage_installation_id.py`** — `show` (read-only) / `regenerate` (destructive) subcommands. Constructs its own `InstanceManager`, never imports `server.py`. Resolves `DATA_DIR` from `config.py` the same way `server.py` does.
- **Handles the confirmed in-memory-caching hazard explicitly**: `InstanceManager.get()` returns a deepcopy of `self._data` without re-reading the file (verified by reading the code, not assumed) — a running `meshcenter.service` would keep serving the old ID until restarted if this weren't accounted for. `regenerate` checks `systemctl is-active` and **refuses by default** while the service is running; `--force` overrides with a loud warning, `-y/--yes` skips the interactive y/N prompt for scripted use.
- No confirmation-prompt convention exists anywhere in this repo's scripts (checked `build-release.sh`/`verify-install.sh` directly — only comment-text false positives) — used Python's standard `input()` y/N, nothing invented.
- Sets `assignment_reason: "regeneration"` — already accepted by Task B's schema, no new enum value needed.
- **Documentation**: a new README section, a User Guide subsection (practical: what it is, when you'd want to regenerate it — e.g. before donating/reselling a device — and the command), and a new `PRIVACY.md` scoped narrowly to this one ID. `PRIVACY.md`'s "never transmitted anywhere" claim was checked, not assumed: grepped the whole codebase for every file touching `installation` (4 files, none of which are outbound-network code) and confirmed the only HTTP call anywhere in this repo (`meshsrv/update_service.py`'s GitHub release check) carries no instance-identifying data.

## Test plan
- [x] `pytest tests/test_manage_installation_id.py -v` — 10/10 passed. First tested Python script under `scripts/` in this repo (checked — none of the existing ones have coverage); core logic (`show_installation`/`regenerate_installation`) takes an injected `is_service_active`/`confirm` callable and is tested against a real `InstanceManager` in a `tmp_path`, not mocking `InstanceManager` itself
- [x] Manual end-to-end smoke test against a scratch `config.py`/`DATA_DIR`: `show` and `regenerate -y` both work correctly against the real CLI entrypoint (argparse glue included), `regenerate` (interactive decline) correctly aborts with no changes, `--help` works without `config.py` present (fixed: `config` import deferred until after `parse_args()`)
- [x] `scripts/check-i18n.py` — unaffected, still in sync (no i18n changes this stage)
- [x] Full suite: `pytest -q` — 473 passed, 25 pre-existing platform skips, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)