### PR TITLE
Fix Stage F CLI: read-only show, ordering, remove --force race

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -16,18 +16,18 @@ It identifies **this installation of the MeshCenter software** - one particular 
 
 - **Not a hardware identifier.** It contains no MAC address, no CPU serial number, no radio serial number, no disk ID - nothing derived from the physical device it's running on. Moving MeshCenter to different hardware (a fresh SD card, a replacement Pi) and copying `data/` over would carry the same ID with it; conversely, wiping and reinstalling on the *same* hardware produces a brand new one. It tracks the install, not the machine.
 - **Not tied to your Meshtastic radio.** Swapping which physical radio is connected to a given MeshCenter install (see the "Multi-radio profiles" section above) does not change this ID, and regenerating this ID does not affect the radio, its node ID, or anything about the mesh.
-- **Not personal data.** Nothing about you - name, location, email, anything you've typed into MeshCenter - is used to generate it or derivable from it. It is, deliberately, pure entropy with nothing meaningful folded in.
+- **Not personal data by itself.** Nothing about you - name, location, email, anything you've typed into MeshCenter - is used to generate it or derivable from it; it is, deliberately, pure entropy with nothing meaningful folded in. That said, an identifier is only ever as anonymous as what it eventually gets linked to: if this ID were ever attached to something identifying (a support ticket with your name on it, an account, an email thread), it would become a pseudonymous identifier for you at that point, the same way any random reference number would. Nothing in MeshCenter does that linking today, but that's a statement about current behavior, not a property the ID carries on its own.
 
 ## Where it goes
 
 **Nowhere, currently.** As of this writing, nothing in the MeshCenter codebase transmits the Installation ID anywhere:
 
 - It is not sent to Meshtastic devices or over the mesh network.
-- It is not included in any outbound network request MeshCenter makes. The only outbound HTTP call anywhere in this codebase is the optional update checker (`meshsrv/update_service.py`), which polls GitHub's public releases API for version information - a plain, unauthenticated request with no instance-identifying data attached, not even in a header.
+- It is not included in any outbound network request MeshCenter makes. MeshCenter makes outbound requests for a few optional features - checking for software updates (`meshsrv/update_service.py`, against GitHub's public releases API), fetching weather data (`weather/providers/openweather.py`, `weather/providers/weatherapi.py`), and reverse geocoding a map reference point into a place name (`api/api_settings.py`, against OpenStreetMap's Nominatim). Checked each of these directly: none of them include the Installation ID, or any other instance-identifying value, in their request parameters or headers.
 - It is not written to logs sent anywhere external, or included in exported node/chat data.
 
 It exists today purely for local reference (visible on the System card, retrievable via `GET /api/instance`) and as groundwork for future tooling that may need to distinguish one MeshCenter installation from another - for example, correlating support requests or, eventually, an opt-in fleet-management feature. If a future feature ever does transmit this ID anywhere, that will be a deliberate, documented change to this file, not a silent one - and any such feature should be opt-in, not on by default.
 
 ## Regenerating it
 
-You can generate a new Installation ID at any time - see the [User Guide](docs/User_Guide.md#installation-id) for the command. This permanently replaces the old value; nothing links the new ID back to the old one. There's no server-side registry of issued IDs to notify or reconcile with - it's a purely local value, so regenerating it has no effect outside this one installation.
+You can generate a new Installation ID with the service stopped - see the [User Guide](docs/User_Guide.md#installation-id) for the command. This permanently replaces the old value; nothing links the new ID back to the old one. There's no server-side registry of issued IDs to notify or reconcile with - it's a purely local value, so regenerating it has no effect outside this one installation.

--- a/docs/User_Guide.md
+++ b/docs/User_Guide.md
@@ -520,7 +520,7 @@ python3 scripts/manage_installation_id.py regenerate
 sudo systemctl start meshcenter.service
 ```
 
-The service must be stopped first - MeshCenter caches the ID in memory while running, so regenerating it while the service is up would change the file on disk without the running app (or the System card) noticing until restarted. The tool checks this and refuses by default if the service is still active. Run `python3 scripts/manage_installation_id.py show` any time to see the current ID without changing anything.
+The service must be stopped first - MeshCenter caches the ID in memory while running, so regenerating it while the service is up would change the file on disk without the running app (or the System card) noticing until restarted. The tool checks this and refuses to proceed if the service is still active - there's no override, on purpose. Run `python3 scripts/manage_installation_id.py show` any time to see the current ID without changing anything; it's genuinely read-only, safe to run even if `instance.json` is missing or corrupted.
 
 ### Updates
 

--- a/meshsrv/instance_manager.py
+++ b/meshsrv/instance_manager.py
@@ -230,6 +230,31 @@ class InstanceManager:
         with self._lock:
             return copy.deepcopy(self._data)
 
+    def peek(self) -> dict[str, Any] | None:
+        """Read the file's raw "installation" block, if any, WITHOUT
+        writing, normalizing, or generating anything - safe to call on a
+        missing or corrupted file without destroying it (unlike
+        load_or_create(), which self-heals by writing a freshly-normalized
+        replacement the moment raw data doesn't match its normalized form -
+        exactly what a missing/corrupted file always produces).
+
+        Deliberately does not route through _normalize(): that function
+        calls generate_installation_id() (a different random value on every
+        call) and logs a WARNING via _log_corrupted_id_replaced() whenever
+        it sees an invalid existing id - both are real side effects that a
+        genuinely read-only peek must never trigger. Returns the stored
+        sub-dict verbatim, unvalidated - for a corrupted file, this is the
+        diagnostic value: showing exactly what's actually stored, not a
+        fabricated replacement.
+
+        Returns None if the file doesn't exist, isn't valid JSON, or has no
+        "installation" key yet - callers should treat that as "not yet
+        initialized", not attempt to interpret a placeholder.
+        """
+        raw = self._read_raw()
+        installation = raw.get("installation")
+        return dict(installation) if isinstance(installation, dict) else None
+
     def save(self, data: Mapping[str, Any]) -> dict[str, Any]:
         """Validate and atomically persist supplied identity data."""
         with self._lock:

--- a/scripts/manage_installation_id.py
+++ b/scripts/manage_installation_id.py
@@ -15,7 +15,20 @@ CRITICAL: InstanceManager caches in memory - a running meshcenter.service
 process holds the old id in memory and keeps serving it via /api/instance and
 the "MeshCenter Instance" UI card until restarted, even after this script has
 already changed the file on disk. `regenerate` checks systemctl is-active and
-refuses to proceed by default while the service is running (see --force).
+refuses to proceed while the service is running - there is no override. An
+earlier version of this script had a --force flag; it was removed after a
+corrective review found a real race: meshsrv/installation_time_assignment.py
+runs its own get()/save() cycle on a background thread inside the live
+service process, using an in-memory snapshot that never notices an external
+file change - a --force regenerate landing in the narrow window before that
+thread's first NTP confirmation could be silently clobbered back to the old
+ID with no error surfaced to the operator. The 5-second `systemctl stop`
+this now requires is the documented normal path anyway; nothing justified
+keeping a flag whose safety depended on an invisible timing window.
+
+`show` is genuinely read-only (InstanceManager.peek(), not load_or_create())
+- a corrupted or missing instance.json is left completely untouched, so it's
+still readable as diagnostic evidence after running `show` against it.
 
 Core logic (show_installation/regenerate_installation) takes an InstanceManager
 and, for regenerate, injected is_service_active/confirm callables - callers
@@ -61,12 +74,21 @@ def is_service_active(service_name: str = SERVICE_NAME) -> bool:
 
 
 def show_installation(manager: InstanceManager) -> str:
-    installation = manager.load_or_create({}).get("installation", {})
+    """Read-only: uses peek(), never load_or_create() - see the module
+    docstring and InstanceManager.peek()'s own docstring for why a naive
+    load_or_create() here would silently overwrite a missing/corrupted
+    file as a side effect of a command meant to be safe to run anytime."""
+    installation = manager.peek()
+    if installation is None:
+        return (
+            "No installation identity found yet - it will be created "
+            f"automatically the next time {SERVICE_NAME} starts."
+        )
     return (
-        f"Installation ID:   {installation.get('id', '(none)')}\n"
+        f"Installation ID:   {installation.get('id') or '(none)'}\n"
         f"Assigned at:       {installation.get('assigned_at') or '(not yet confirmed)'}\n"
-        f"Time source:       {installation.get('time_source', 'pending')}\n"
-        f"Assignment reason: {installation.get('assignment_reason', '(unknown)')}"
+        f"Time source:       {installation.get('time_source') or 'pending'}\n"
+        f"Assignment reason: {installation.get('assignment_reason') or '(unknown)'}"
     )
 
 
@@ -74,38 +96,41 @@ def regenerate_installation(
     manager: InstanceManager,
     is_service_active_fn: Callable[[], bool],
     confirm_fn: Callable[[str], bool],
-    force: bool = False,
     assume_yes: bool = False,
 ) -> tuple[int, str]:
     """Returns (exit_code, message). exit_code 0 means the ID was changed;
     1 means refused/aborted with no changes made. Never calls systemctl or
     input() directly - those come in as is_service_active_fn/confirm_fn so
-    this function is fully testable without touching the real system."""
-    identity = manager.load_or_create({})
-    old_id = identity.get("installation", {}).get("id", "(none)")
+    this function is fully testable without touching the real system.
+
+    Ordering matters: the service-active check and the confirmation prompt
+    both run BEFORE load_or_create() (the first call capable of writing) -
+    a corrective fix, see the module docstring. If the file happens to be
+    missing/corrupted, load_or_create() below will still self-heal it (mint
+    and discard one throwaway id) before this function's own explicit
+    regeneration immediately overwrites that - harmless, just means two ids
+    get generated internally in that one edge case, not a bug.
+    """
+    old_installation = manager.peek()
+    old_id = (old_installation or {}).get("id") or "(none)"
     lines = [f"Current Installation ID: {old_id}"]
 
     if is_service_active_fn():
-        if not force:
-            lines.append(
-                f"\n{SERVICE_NAME} is currently running. Regenerating now would change "
-                "the file on disk, but the running process caches the old ID in memory "
-                "and would keep serving it via /api/instance and the System card until "
-                "restarted - the UI and the file would silently disagree.\n\n"
-                f"Stop the service first:\n  sudo systemctl stop {SERVICE_NAME}\n"
-                "then run this command again, or pass --force to proceed anyway."
-            )
-            return 1, "\n".join(lines)
         lines.append(
-            f"\nWARNING: {SERVICE_NAME} is running and --force was given - proceeding "
-            "anyway. The running process will keep showing the OLD ID until you restart "
-            f"it: sudo systemctl restart {SERVICE_NAME}"
+            f"\n{SERVICE_NAME} is currently running. Regenerating now would change "
+            "the file on disk, but the running process caches the old ID in memory "
+            "and would keep serving it via /api/instance and the System card until "
+            "restarted - the UI and the file would silently disagree.\n\n"
+            f"Stop the service first:\n  sudo systemctl stop {SERVICE_NAME}\n"
+            "then run this command again."
         )
+        return 1, "\n".join(lines)
 
     if not assume_yes and not confirm_fn(old_id):
         lines.append("\nAborted - no changes made.")
         return 1, "\n".join(lines)
 
+    identity = manager.load_or_create({})
     updated = dict(identity)
     updated["installation"] = {
         "id": generate_installation_id(),
@@ -139,7 +164,6 @@ def cmd_regenerate(args: argparse.Namespace, manager: InstanceManager) -> int:
         manager,
         is_service_active_fn=is_service_active,
         confirm_fn=_prompt_confirm,
-        force=args.force,
         assume_yes=args.yes,
     )
     print(message, file=sys.stderr if exit_code else sys.stdout)
@@ -155,12 +179,11 @@ def build_parser() -> argparse.ArgumentParser:
     show_parser = subparsers.add_parser("show", help="Print the current installation identity (read-only).")
     show_parser.set_defaults(func=cmd_show)
 
-    regen_parser = subparsers.add_parser("regenerate", help="Generate a new installation ID, replacing the current one.")
-    regen_parser.add_argument("-y", "--yes", action="store_true", help="Skip the interactive confirmation prompt.")
-    regen_parser.add_argument(
-        "--force", action="store_true",
-        help=f"Proceed even if {SERVICE_NAME} is currently running (not recommended - see warning).",
+    regen_parser = subparsers.add_parser(
+        "regenerate",
+        help=f"Generate a new installation ID, replacing the current one. Refuses while {SERVICE_NAME} is active.",
     )
+    regen_parser.add_argument("-y", "--yes", action="store_true", help="Skip the interactive confirmation prompt.")
     regen_parser.set_defaults(func=cmd_regenerate)
 
     return parser

--- a/tests/test_instance_manager.py
+++ b/tests/test_instance_manager.py
@@ -260,3 +260,72 @@ def test_save_with_missing_installation_key_still_preserves_id_via_defaults(inst
     bare_update = {"active_profile_id": "no-installation-key-here"}
     result = manager.save(bare_update)
     assert result["installation"]["id"] == original_id
+
+
+def test_peek_returns_none_for_a_missing_file(instance_path):
+    manager = InstanceManager(instance_path)
+    assert manager.peek() is None
+    assert not instance_path.exists()
+
+
+def test_peek_returns_none_for_a_corrupted_file_without_touching_it(instance_path):
+    corrupted_bytes = b"{not valid json"
+    instance_path.write_bytes(corrupted_bytes)
+    manager = InstanceManager(instance_path)
+
+    assert manager.peek() is None
+    assert instance_path.read_bytes() == corrupted_bytes
+
+
+def test_peek_returns_the_stored_installation_block_verbatim(instance_path):
+    manager = InstanceManager(instance_path)
+    identity = manager.load_or_create({})
+    original_id = identity["installation"]["id"]
+
+    peeked = manager.peek()
+    assert peeked["id"] == original_id
+    assert peeked == identity["installation"]
+
+
+def test_peek_does_not_validate_or_regenerate_a_corrupted_id(instance_path):
+    # peek() must show a format-invalid stored value exactly as-is, not
+    # silently "fix" it - that's the whole point: a genuinely read-only
+    # diagnostic view, not a second normalize() path.
+    raw = {
+        "schema_version": 2, "radio": {}, "runtime": {},
+        "installation": {"id": "GARBAGE", "assigned_at": None, "time_source": "pending", "assignment_reason": "fresh_install"},
+    }
+    instance_path.write_text(json.dumps(raw), encoding="utf-8")
+    manager = InstanceManager(instance_path)
+
+    peeked = manager.peek()
+    assert peeked["id"] == "GARBAGE"
+    # And no write happened - the corrupted id is still exactly what's on disk.
+    on_disk = json.loads(instance_path.read_text(encoding="utf-8"))
+    assert on_disk["installation"]["id"] == "GARBAGE"
+
+
+def test_peek_never_calls_generate_installation_id(instance_path):
+    raw = {
+        "schema_version": 2, "radio": {}, "runtime": {},
+        "installation": {"id": "GARBAGE", "assigned_at": None, "time_source": "pending", "assignment_reason": "fresh_install"},
+    }
+    instance_path.write_text(json.dumps(raw), encoding="utf-8")
+    manager = InstanceManager(instance_path)
+
+    with patch("meshsrv.instance_manager.generate_installation_id") as mock_generate:
+        manager.peek()
+    mock_generate.assert_not_called()
+
+
+def test_peek_does_not_log_a_corrupted_id_warning(instance_path, monkeypatch):
+    mock_log = _stub_system_log(monkeypatch)
+    raw = {
+        "schema_version": 2, "radio": {}, "runtime": {},
+        "installation": {"id": "GARBAGE", "assigned_at": None, "time_source": "pending", "assignment_reason": "fresh_install"},
+    }
+    instance_path.write_text(json.dumps(raw), encoding="utf-8")
+    manager = InstanceManager(instance_path)
+
+    manager.peek()
+    mock_log.assert_not_called()

--- a/tests/test_manage_installation_id.py
+++ b/tests/test_manage_installation_id.py
@@ -1,11 +1,21 @@
 """Tests for scripts/manage_installation_id.py - Task F (final stage) of the
-installation-ID rollout. No prior Python CLI script in this repo has test
-coverage (checked - scripts/check-i18n.py, scripts/check_startup_calls.py,
-the _smoke_test_*_harness.py files all have none), so this is the first.
+installation-ID rollout, plus its corrective follow-up (an external audit
+found show wasn't actually read-only, the service-check ran after a
+write-capable call, and --force raced with
+meshsrv/installation_time_assignment.py's background thread - see that
+PR's own investigation report for the full trace). No prior Python CLI
+script in this repo has test coverage (checked - scripts/check-i18n.py,
+scripts/check_startup_calls.py, the _smoke_test_*_harness.py files all
+have none), so this is the first.
+
 Per the investigation report: test the core logic functions
 (show_installation/regenerate_installation) against a real InstanceManager
 in a tmp_path, injecting is_service_active/confirm rather than touching
-systemctl or input() - not testing argparse's own wiring in detail.
+systemctl or input() - not testing argparse's own wiring in detail. The
+original test suite's fixture always pre-created a valid instance.json via
+load_or_create() before every test, which is exactly why the "show isn't
+read-only" bug never surfaced here - this file now covers a missing and a
+corrupted instance.json specifically, without that fixture.
 
 manage_installation_id.py defers `from config import DATA_DIR` to main()
 specifically so importing the rest of the module never needs config.py -
@@ -52,38 +62,56 @@ def test_show_installation_reports_resolved_time_source(manager):
     assert "2026-09-01T07:00:00+00:00" in output
 
 
-def test_regenerate_refuses_by_default_while_service_active(manager):
+def test_show_installation_against_a_missing_file_does_not_create_it(tmp_path):
+    instance_path = tmp_path / "instance.json"
+    fresh_manager = InstanceManager(instance_path)  # load_or_create() never called
+
+    output = cli.show_installation(fresh_manager)
+
+    assert "No installation identity found yet" in output
+    assert not instance_path.exists()
+
+
+def test_show_installation_against_a_corrupted_file_leaves_bytes_unchanged(tmp_path):
+    instance_path = tmp_path / "instance.json"
+    corrupted_bytes = b"{not valid json at all"
+    instance_path.write_bytes(corrupted_bytes)
+    fresh_manager = InstanceManager(instance_path)
+
+    output = cli.show_installation(fresh_manager)
+
+    assert "No installation identity found yet" in output
+    assert instance_path.read_bytes() == corrupted_bytes
+
+
+def test_regenerate_refuses_while_service_active_with_no_override(manager):
     old_id = manager.get()["installation"]["id"]
 
     exit_code, message = cli.regenerate_installation(
         manager,
         is_service_active_fn=lambda: True,
         confirm_fn=lambda old: True,
-        force=False,
         assume_yes=True,
     )
 
     assert exit_code == 1
     assert "currently running" in message
+    assert "force" not in message.lower()
     assert manager.get()["installation"]["id"] == old_id
 
 
-def test_regenerate_proceeds_with_force_while_service_active(manager):
-    old_id = manager.get()["installation"]["id"]
+def test_regenerate_installation_has_no_force_parameter():
+    import inspect
+    signature = inspect.signature(cli.regenerate_installation)
+    assert "force" not in signature.parameters
 
-    exit_code, message = cli.regenerate_installation(
-        manager,
-        is_service_active_fn=lambda: True,
-        confirm_fn=lambda old: True,
-        force=True,
-        assume_yes=True,
-    )
 
-    assert exit_code == 0
-    assert "WARNING" in message
-    new_id = manager.get()["installation"]["id"]
-    assert new_id != old_id
-    assert is_valid_installation_id(new_id)
+def test_regenerate_subcommand_has_no_force_flag():
+    parser = cli.build_parser()
+    args = parser.parse_args(["regenerate", "--yes"])
+    assert not hasattr(args, "force")
+    with pytest.raises(SystemExit):
+        parser.parse_args(["regenerate", "--force"])
 
 
 def test_regenerate_aborts_when_confirmation_declined(manager):
@@ -93,7 +121,6 @@ def test_regenerate_aborts_when_confirmation_declined(manager):
         manager,
         is_service_active_fn=lambda: False,
         confirm_fn=lambda old: False,
-        force=False,
         assume_yes=False,
     )
 
@@ -109,7 +136,6 @@ def test_regenerate_skips_confirmation_with_assume_yes(manager):
         manager,
         is_service_active_fn=lambda: False,
         confirm_fn=lambda old: confirm_calls.append(old) or True,
-        force=False,
         assume_yes=True,
     )
 
@@ -124,7 +150,6 @@ def test_regenerate_sets_expected_fields_on_success(manager):
         manager,
         is_service_active_fn=lambda: False,
         confirm_fn=lambda old: True,
-        force=False,
         assume_yes=False,
     )
 
@@ -151,13 +176,75 @@ def test_regenerate_preserves_every_other_existing_field(manager):
         manager,
         is_service_active_fn=lambda: False,
         confirm_fn=lambda old: True,
-        force=False,
         assume_yes=False,
     )
 
     identity = manager.get()
     assert identity["active_profile_id"] == "067a40fa"
     assert identity["radio"]["node_id"] == "!067a40fa"
+
+
+def test_regenerate_service_check_runs_before_any_write_capable_call(tmp_path):
+    # Call-order spy: is_service_active_fn must be invoked while the file is
+    # still exactly as it started (missing) - proving the check happens
+    # before load_or_create()/save(), not after. If the ordering regressed
+    # back to the original bug, the file would already exist by the time
+    # is_service_active_fn runs.
+    instance_path = tmp_path / "instance.json"
+    fresh_manager = InstanceManager(instance_path)
+    file_existed_at_check_time = []
+
+    def spy_is_active():
+        file_existed_at_check_time.append(instance_path.exists())
+        return True
+
+    exit_code, _ = cli.regenerate_installation(
+        fresh_manager,
+        is_service_active_fn=spy_is_active,
+        confirm_fn=lambda old: True,
+        assume_yes=True,
+    )
+
+    assert exit_code == 1
+    assert file_existed_at_check_time == [False]
+    assert not instance_path.exists()
+
+
+def test_regenerate_against_a_missing_file_works_end_to_end(tmp_path):
+    instance_path = tmp_path / "instance.json"
+    fresh_manager = InstanceManager(instance_path)
+
+    exit_code, message = cli.regenerate_installation(
+        fresh_manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: True,
+        assume_yes=False,
+    )
+
+    assert exit_code == 0
+    assert instance_path.exists()
+    installation = fresh_manager.get()["installation"]
+    assert is_valid_installation_id(installation["id"])
+    assert installation["assignment_reason"] == "regeneration"
+
+
+def test_regenerate_against_a_corrupted_file_works_end_to_end(tmp_path):
+    instance_path = tmp_path / "instance.json"
+    instance_path.write_bytes(b"{not valid json at all")
+    fresh_manager = InstanceManager(instance_path)
+
+    exit_code, message = cli.regenerate_installation(
+        fresh_manager,
+        is_service_active_fn=lambda: False,
+        confirm_fn=lambda old: True,
+        assume_yes=False,
+    )
+
+    assert exit_code == 0
+    installation = fresh_manager.get()["installation"]
+    assert is_valid_installation_id(installation["id"])
+    assert installation["assignment_reason"] == "regeneration"
+    assert "(none)" in message  # old id was unreadable from the corrupted file
 
 
 def test_is_service_active_returns_false_when_systemctl_unavailable(monkeypatch):


### PR DESCRIPTION
## Summary
Corrective PR for Task F (#155) - an external audit found five real issues, all independently re-verified before fixing (see the investigation report in this conversation's history for the full trace of each).

1. **PRIVACY.md factual error, confirmed false**: "the only outbound HTTP call anywhere in this codebase is the update checker" — actually 4 files make outbound calls (`meshsrv/update_service.py`, `weather/providers/openweather.py`, `weather/providers/weatherapi.py`, `api/api_settings.py`'s Nominatim reverse-geocoding). Reworded to name all three feature categories, after checking each one's actual request parameters/headers to confirm the *narrower* claim ("none of these include the Installation ID") is true.
2. **`show` wasn't actually read-only, confirmed**: it called `load_or_create()`, which writes whenever `raw != normalized` — true for both a missing *and* a corrupted `instance.json` (`_read_raw()` can't distinguish them, both become `{}`). Running the documented-as-safe `show` against a corrupted file silently overwrote it with a fresh random ID, destroying the exact diagnostic evidence an operator would want. Fixed with a new `InstanceManager.peek()`: reads the raw `installation` block verbatim, never routes through `_normalize()` (so never generates a phantom ID, never logs a phantom "corrupted ID replaced" warning), never writes.
3. **Service-check ran after the write-capable call**, same root cause as #2. Reordered `regenerate`: `peek()` (read-only display) → service-active check → confirmation → `load_or_create()` → `save()`.
4. **`--force` raced with `installation_time_assignment.py`'s background thread**: traced the mechanism precisely — that thread holds its own in-memory snapshot (`get()`/`save()`), has no way to notice an external file change, and could silently clobber a `--force` regenerate back to the old ID with zero error surfaced to the operator. Considered three options (remove `--force`; a real `fcntl` inter-process lock touching the core already-deployed `InstanceManager`; a lighter CLI-only optimistic-concurrency check) — removed `--force` entirely per the user's decision: the race's silent-data-loss consequence outweighs skipping a 5-second `systemctl stop`, which was already the documented normal path.
5. **GDPR wording too categorical**: reworded "not personal data" to acknowledge the ID could become pseudonymous personal data if ever linked to identifying information later, without overclaiming a property it doesn't inherently carry — written in the document's own existing voice, not pasted from the audit.

## Test plan
- [x] New `InstanceManager.peek()` tests (6): returns `None` for missing/corrupted files without writing, returns the stored block verbatim (including a corrupted value, unvalidated), never calls `generate_installation_id()`, never logs a warning.
- [x] `show` against a missing file — doesn't create it. `show` against a corrupted file — bytes byte-for-byte unchanged after the call. Both scenarios the original test suite's always-pre-create fixture happened to avoid entirely.
- [x] `regenerate` against both missing and corrupted files — works end-to-end, produces a valid ID with `assignment_reason: "regeneration"`.
- [x] Call-order spy proving the service-active check runs before any write-capable call (asserts the file still doesn't exist at check time).
- [x] `--force` removed from argparse (`parser.parse_args(["regenerate", "--force"])` now raises `SystemExit`) and from `regenerate_installation()`'s signature (`inspect.signature` check).
- [x] Manual end-to-end smoke test against a scratch `config.py`/`DATA_DIR`: `--help` confirms no `--force` listed; `show` against a real corrupted file on disk leaves it byte-for-byte unchanged; `regenerate -y` against that same corrupted file recovers cleanly and reports `Current Installation ID: (none)` (the corrupted value was genuinely unreadable, correctly not shown as a fake ID).
- [x] Full suite: `pytest -q` — 485 passed, 25 pre-existing platform skips, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)