### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error message leakage in top-processes endpoint

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -226,8 +226,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
             results.sort(key=lambda item: item["cpu_percent"], reverse=True)
 
             return jsonify({"ok": True, "processes": results[:5]})
-        except Exception as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 500
+        except Exception:
+            # Security: Don't leak internal stack traces or error details to client
+            return jsonify({"ok": False, "error": "Failed to fetch top processes"}), 500
 
     def get_saved_wifi_names():
         result = network_config.list_wifi_connections()

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -103,3 +103,20 @@ def test_wifi_scan_success_path_does_not_log(client, monkeypatch):
     assert data["ok"] is True
     assert data["networks"] == []
     assert logged == []
+
+
+def test_top_processes_exception_does_not_leak_stack_details(client, monkeypatch):
+    import psutil
+
+    def _failing_iter(*args, **kwargs):
+        raise RuntimeError("Internal psutil failure: secret_token_xyz")
+
+    monkeypatch.setattr(psutil, "process_iter", _failing_iter)
+
+    response = client.get("/api/system/top-processes")
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["ok"] is False
+    assert data["error"] == "Failed to fetch top processes"
+    assert "secret_token_xyz" not in data["error"]


### PR DESCRIPTION
### 🚨 Severity
MEDIUM

### 💡 Vulnerability
Exposing internal exception details and stack traces to clients in `/api/system/top-processes` HTTP 500 response (`str(exc)`).

### 🎯 Impact
Internal system state, file paths, or underlying module exception details could be leaked to unauthenticated or external clients upon process inspection failure.

### 🔧 Fix
Replaced returning raw `str(exc)` with a generic error message `{"ok": False, "error": "Failed to fetch top processes"}` and HTTP 500 status code. Added a security comment explaining the error details masking rationale.

### ✅ Verification
Added unit test `test_top_processes_exception_does_not_leak_stack_details` in `tests/test_api_system.py` verifying that exception details are not exposed. All pytest tests passed cleanly.

---
*PR created automatically by Jules for task [14549825997312877234](https://jules.google.com/task/14549825997312877234) started by @FlintUA*