### PR TITLE
Document v1.8.1 in Version History

### DIFF
--- a/README.md
+++ b/README.md
@@ -1789,6 +1789,7 @@ Possible future integrations include:
 
 | Version | Highlights |
 |----------|------------|
+| v1.8.1 | Installation ID: a per-install, privacy-conscious identifier (`PRIVACY.md`) shown on the System card with copy-to-clipboard, plus a `manage_installation_id.py` CLI to inspect/regenerate it; System Log, Activity and the Notifications popover gain Copy and Export buttons on a new unified `.btn` sizing system; the "MeshCenter Instance" card no longer shows raw exception text on a radio identity check failure (now routed to the System Log/Notifications instead); system log entries use the real device model instead of a hardcoded "Raspberry Pi" label |
 | v1.8.0 | I2C device support (RTC + BME280), e-Paper display redesign with auto-rotation, stored-XSS fix, gunicorn in production |
 | v1.7.0 | Auto-Installer (cloud-init), redesigned Time card, channel name/discovery fixes |
 | v1.6.0 | Time System, Notifications & Automation — Schedule Engine, Timers, Notification Center |


### PR DESCRIPTION
## Summary
Adds a v1.8.1 row to README.md's Version History table, per the user's request to document version 1.8.1 with a description of what was done.

Scoped to what this session has full firsthand knowledge of: the Installation ID rollout (#150-156, already merged earlier this session) and the four most recent fixes (#159, #160, #161).

**Flagging explicitly, not silently omitting**: `v1.8.0..main` also contains other already-merged work unrelated to this session (e.g. Backend Protocol v1/BLETransport) that this row does not attempt to summarize — I don't have firsthand context on that work to describe it accurately.

## Test plan
- Docs-only change, no code touched.