### PR TITLE
Fix container-level spacing/font-size mismatch: System Log vs Activity

### DIFF
--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -1038,7 +1038,12 @@
     display: flex;
     align-items: center;
     color: #2d4057;
-    font-size: 13px;
+    /* Matches --mc-card-title-size (.system-card-title's own font-size,
+       used by System Log/Updates/etc.) - was a hardcoded 13px, one
+       pixel off from every other card-title in the same right column,
+       for no documented reason. Only consumer of this class (checked),
+       so safe to change directly. */
+    font-size: var(--mc-card-title-size, 14px);
     font-weight: 750;
 }
 
@@ -2005,9 +2010,21 @@
    class (see templates/index.html) instead of duplicating it, so title
    stays left and .system-log-actions (copy/export/arrow) stays right,
    matching .notifications-card-header's layout in the Activity card. */
+/* Container-consistency pass (follow-up to Task 4): this header's own
+   padding/margin was already 0/10px, but its ambient spacing from the
+   card edge is NOT zero - .system-card's shared --mc-card-pad token
+   (16px) + its 1px border already put ~17px between the card edge and
+   this header's buttons, measured live via getBoundingClientRect() -
+   noticeably more than the Activity card's ~12px (.notifications-card
+   itself has no padding of its own; .notifications-card-header supplies
+   11px 12px 8px directly). --mc-card-pad is shared by every .system-card
+   on the page (Updates, System Information, Radio Health, ...), so it's
+   deliberately not touched here - a small negative top margin on just
+   this header pulls its buttons back in line with Activity's spacing
+   without touching the shared token or any other card. */
 .system-log-card-header {
     padding: 0;
-    margin: 0 0 10px;
+    margin: -5px 0 10px;
 }
 
 .system-log-card-header .system-card-title {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260821-style-split">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-btn-system">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-header-consistency">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260901-identity-hint-btn-system">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260901-btn-system">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">


### PR DESCRIPTION
## Summary
Follow-up to a false-positive "Activity vs System Log button size" investigation this session — the buttons themselves were already pixel-identical (32×32, `.btn.btn-sm.btn-icon`). This PR fixes the real, verified cause: the surrounding **container** spacing, not the button class.

**Root cause, precisely traced:**
- `.system-card` (System Log's outer wrapper) contributes `--mc-card-pad` (16px — a token shared by *every* `.system-card` on the page: Updates, System Information, Radio Health, ...) + a 1px border = 17px between the card edge and the header's buttons.
- `.notifications-card` (Activity's wrapper) has no padding of its own — `.notifications-card-header` supplies `11px 12px 8px` directly, landing at ~12px.
- `.notifications-card-title` was hardcoded to 13px; every other card-title in the same column uses `--mc-card-title-size` (14px) via `.system-card-title` — no documented reason for the 1px difference.

**Fix, both container-scoped, no button classes touched:**
- `.system-log-card-header` gets a `-5px` top margin, pulling its buttons back in line with Activity's ~12px gap — `--mc-card-pad` itself is untouched (would ripple across every `.system-card` on the page).
- `.notifications-card-title` switches to `var(--mc-card-title-size, 14px)` (checked: its only consumer) instead of a hardcoded 13px.

**Swept the rest of the UI** for the same pattern (other `-card-header`/`-panel-header`/`card-title` containers with an action-button row) — found no other pair of buttons sharing the same class/role across different containers the way Activity/System Log/the Notifications popover do. Other header action groups (chat, video, node panel, node-manager rescan, ...) use entirely their own one-off button classes, not `.btn`/`.btn-icon` — a class-level difference, squarely the deferred ~40-location backlog (`docs/ui/button_audit.md`), not something a container fix addresses.

One related, minor, **left alone** finding: the Notifications popover's own title (a bare `strong` tag, different structural pattern) is still hardcoded 13px, now the odd one out against Activity's fixed 14px — noted, not changed, lower payoff than the two fixes above.

## Test plan
- [x] CSS/markup-only — `pytest -q` unaffected: 498 passed, no regressions
- [x] `python -m compileall .`, `scripts/check-i18n.py` — clean
- [x] Cache-bust bumped (`style-part3.css?v=20260901-header-consistency`)
- [x] **Live-verified on `mc-dev`, settled-state computed values** (learned from this session's earlier false positive — first measurement caught an in-transition 38px/mobile-breakpoint frame, not the real state; all values below are from a second, settled measurement after confirming `window.innerWidth` was correct):

| | topGap (card edge → button) | titleFontSize | button box |
|---|---|---|---|
| Activity (before/after, unchanged) | 12px | 13px → **14px** | 32×32 |
| System Log (before → after) | **17px → 12px** | 14px (unchanged) | 32×32 (unchanged) |

Reverted dev back to `main` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)