### PR TITLE
Fix P0-A: kill adapter subprocess on a self-reported TIMEOUT

### DIFF
--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -95,6 +95,20 @@ is real as of Task 48's process boundary — `AdapterSupervisor.call()`
 for a response and `SIGKILL`s the adapter subprocess on expiry, so a
 wedged call's orphaned resources (event loop, live bleak/GATT session) go
 away with the process, not just get abandoned in a still-running thread.
+Tier 2 covers a fifth case too (radio-stability review, P0-A): the
+adapter's own internal `TimeoutEnforced` watchdog
+(`adapters/meshtastic/_timeout_support.py`) can fire *first* and report
+the timeout back as a well-formed response instead of the caller-side
+reader ever timing out waiting for one — `AdapterSupervisor.call()`
+recognizes this specific shape (`ok: false`, `error.code == "timeout"`)
+and kills the subprocess before returning, same as the no-response/dead-
+process/malformed-output cases, since the daemon thread that was running
+the timed-out operation is only abandoned inside it, never stopped,
+exactly like the no-response case above. Every other `ok: false` domain
+error (`NOT_CONNECTED`, `UNSUPPORTED`, `IDENTITY_MISMATCH`, ...) means the
+adapter's own call stack already unwound cleanly and does not trigger a
+kill — only `TIMEOUT` specifically indicates an abandoned daemon thread
+with unknown resource-ownership state.
 BLE cleanup on a kill is handled explicitly too: a `SIGKILL`'d adapter's
 serial file descriptors are reclaimed by the kernel automatically, but a
 BLE GATT session (brokered through BlueZ over D-Bus) can outlive the

--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -404,7 +404,21 @@ class AdapterSupervisor:
         diagnosable on its own) - kills the adapter (+ BLE cleanup if
         `ble_address_for_cleanup` is set) and raises TransportError, so
         the caller's thread is always released by `timeout`, never left
-        waiting on the subprocess itself."""
+        waiting on the subprocess itself.
+
+        Radio-stability review, P0-A: also kills (but does NOT raise a
+        different error - the caller still sees the same TransportError
+        it always would have) when the adapter itself responds cleanly
+        but that response IS a TIMEOUT - the adapter's own internal
+        TimeoutEnforced watchdog fired first and reported it as a
+        well-formed error, but the daemon thread that was running the
+        timed-out operation is only abandoned, never stopped (see
+        adapters/meshtastic/_timeout_support.py), so it can still be
+        holding the serial port. Every OTHER `ok: false` domain error
+        (NOT_CONNECTED, UNSUPPORTED, IDENTITY_MISMATCH, ...) means the
+        adapter's call stack already unwound cleanly and is deliberately
+        NOT killed here - see the check's own comment below for why this
+        stays narrow to TIMEOUT specifically."""
         with self._proc_lock:
             if self._proc is None or self._proc.poll() is not None:
                 try:
@@ -506,6 +520,31 @@ class AdapterSupervisor:
             if status == "protocol_error":
                 self._kill_locked(ble_address_for_cleanup)
                 raise TransportError(TransportErrorCode.ADAPTER_PROTOCOL_ERROR, str(payload))
+
+            # Radio-stability review, P0-A: a fifth case the four branches
+            # above don't cover. The adapter's own internal TimeoutEnforced
+            # watchdog (adapters/meshtastic/_timeout_support.py) can fire
+            # first and report this back as a well-formed JSON response
+            # (ipc_protocol.make_error_response() -> {"ok": false, "error":
+            # {"code": "timeout", ...}}) - status is "ok" here (a valid
+            # response WAS read), so none of the branches above trigger,
+            # and this used to fall straight through to `return payload`
+            # with no kill at all. Unlike the other four branches, the
+            # adapter process itself isn't untrustworthy here - it
+            # responded correctly - but the operation it was running IS
+            # orphaned inside it: TimeoutEnforced's own docstring is
+            # explicit that the daemon thread executing the timed-out call
+            # is never stopped, only abandoned, so it can still be holding
+            # the serial port when the next call is dispatched to this
+            # same "still alive" subprocess. Narrow to TIMEOUT specifically
+            # - an ordinary domain error (NOT_CONNECTED, UNSUPPORTED,
+            # IDENTITY_MISMATCH, ...) means the adapter's call stack
+            # already unwound cleanly, and killing the subprocess for
+            # those would be pure churn with no safety benefit.
+            if isinstance(payload, dict) and payload.get("ok") is False:
+                error_code = (payload.get("error") or {}).get("code")
+                if error_code == TransportErrorCode.TIMEOUT.value:
+                    self._kill_locked(ble_address_for_cleanup)
 
             return payload
 

--- a/tests/fixtures/fake_adapter.py
+++ b/tests/fixtures/fake_adapter.py
@@ -29,6 +29,18 @@ adapter protocol never uses:
     thread, the write blocks once the buffer fills and the whole call
     wedges until the caller's own timeout fires instead of completing
     normally.
+  "adapter_timeout" - responds IMMEDIATELY (not a hang) with a
+    well-formed ok=false/error.code="timeout" response, matching the
+    exact shape ipc_protocol.make_error_response() produces on the real
+    adapter side when its own internal TimeoutEnforced watchdog
+    (adapters/meshtastic/_timeout_support.py) fires first and reports
+    the timeout back cleanly instead of the caller-side reader ever
+    hitting queue.Empty - radio-stability review P0-A's exact scenario.
+  "adapter_error:<code>" - responds immediately with a well-formed
+    ok=false response carrying the given TransportErrorCode value (e.g.
+    "adapter_error:unsupported") - an ordinary domain error, NOT a
+    timeout, for proving P0-A's fix stays narrowly scoped to TIMEOUT
+    specifically and doesn't kill the subprocess for these.
 
 Writes its own PID to stdout on the FIRST request's response
 (`_pid` key) so a test can confirm a kill+respawn actually launched a
@@ -57,6 +69,27 @@ def main() -> None:
 
         if behavior == "hang":
             time.sleep(3600)
+            continue
+
+        if behavior == "adapter_timeout":
+            response = {
+                "protocol_version": 1,
+                "ok": False,
+                "error": {"code": "timeout", "message": "simulated adapter-side TimeoutEnforced firing"},
+            }
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+            continue
+
+        if behavior.startswith("adapter_error:"):
+            code = behavior.split(":", 1)[1]
+            response = {
+                "protocol_version": 1,
+                "ok": False,
+                "error": {"code": code, "message": f"simulated {code} domain error"},
+            }
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
             continue
 
         if behavior.startswith("sleep:"):

--- a/tests/test_adapter_ipc_client.py
+++ b/tests/test_adapter_ipc_client.py
@@ -174,6 +174,81 @@ def test_killed_adapter_respawns_as_a_genuinely_different_process():
     assert second_pid != first_pid, "respawn must be a genuinely new OS process, not the killed one still running"
 
 
+def test_adapter_self_reported_timeout_kills_and_respawns_the_subprocess():
+    """Radio-stability review, P0-A regression test: the adapter's own
+    internal TimeoutEnforced watchdog (adapters/meshtastic/
+    _timeout_support.py) can fire first and report the timeout back as
+    a well-formed response - status == "ok" at call()'s own read-result
+    layer (a valid JSON line WAS read), payload carries
+    ok=false/error.code="timeout". Before this fix, that fell straight
+    through to `return payload` with no kill at all, leaving the
+    subprocess - and whatever daemon thread was running the timed-out
+    operation inside it, per TimeoutEnforced's own docstring never
+    stopped, only abandoned - alive and reused for the next call.
+
+    First call gets the real PID (normal behavior). Second call
+    self-reports a timeout - caller-visible behavior must NOT change
+    (still the same TransportError(TIMEOUT) it always raised). Third
+    call (normal behavior again) must get a DIFFERENT PID, proving the
+    adapter was actually killed and respawned, not silently reused -
+    this assertion fails before the fix (same PID), passes after."""
+    supervisor = _make_supervisor()
+    transport = AdapterIPCTransport(ConnectionType.BLUETOOTH, supervisor)
+
+    first = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    first_pid = first["result"]["_pid"]
+    assert first_pid is not None
+
+    with pytest.raises(TransportError) as excinfo:
+        transport._call("get_metadata", {"_test_behavior": "adapter_timeout"}, 5.0)
+    assert excinfo.value.code == TransportErrorCode.TIMEOUT
+
+    third = supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    third_pid = third["result"]["_pid"]
+    assert third_pid is not None
+    assert third_pid != first_pid, (
+        "adapter must be killed+respawned after self-reporting a timeout, not silently reused"
+    )
+
+
+def test_ordinary_adapter_domain_error_does_not_kill_the_subprocess():
+    """Negative test guarding P0-A's narrow scope: an ordinary ok=false
+    domain error (the adapter's own call stack already unwound cleanly)
+    must NOT trigger a kill - only TIMEOUT specifically does. Guards
+    against a future accidental widening back to "kill on any error".
+
+    Checks supervisor._proc.pid directly (Python's own Popen.pid, always
+    available) rather than fake_adapter.py's embedded result._pid -
+    that's only stamped on a process's very first echo-shaped response
+    (see fake_adapter.py's own docstring), so a second, still-alive-
+    process call would read back None there regardless of whether a
+    kill happened - not what this test needs to distinguish."""
+    supervisor = _make_supervisor()
+    transport = AdapterIPCTransport(ConnectionType.BLUETOOTH, supervisor)
+
+    supervisor.call(
+        {"operation": "get_metadata", "transport_type": "serial", "params": {}, "timeout": 5.0},
+        timeout=5.0,
+        ble_address_for_cleanup=None,
+    )
+    pid_before = supervisor._proc.pid
+
+    with pytest.raises(TransportError) as excinfo:
+        transport._call("get_metadata", {"_test_behavior": "adapter_error:unsupported"}, 5.0)
+    assert excinfo.value.code == TransportErrorCode.UNSUPPORTED
+
+    assert supervisor._proc is not None, "an ordinary domain error must not kill the subprocess - only TIMEOUT should"
+    assert supervisor._proc.pid == pid_before, "same OS process must still be running, not killed and respawned"
+
+
 def test_crashed_adapter_raises_adapter_unavailable_not_a_raw_exception():
     supervisor = _make_supervisor()
 


### PR DESCRIPTION
## Summary
Highest-severity, genuinely new finding from the radio-stability review (not one of the several already self-documented "known, deferred" gaps elsewhere).

`AdapterSupervisor.call()` (`meshsrv/adapter_ipc_client.py`) only killed and respawned the adapter subprocess in four branches: no response at all (`queue.Empty`), a read error, the pipe closing, or malformed output past tolerance. A fifth case fell through uncaught: the adapter's own internal `TimeoutEnforced` watchdog (`adapters/meshtastic/_timeout_support.py`) can fire *first* and report the timeout back as a well-formed JSON response (`ipc_protocol.make_error_response()` -> `{"ok": false, "error": {"code": "timeout", ...}}`) - `status == "ok"` at `call()`'s own read-result layer (a valid response WAS read), so none of the four kill branches triggered, and it fell straight through to `return payload` with no kill at all.

Unlike the other four branches, the adapter process itself isn't untrustworthy here - it responded correctly - but the operation it was running is orphaned inside it: `TimeoutEnforced`'s own docstring is explicit that the daemon thread executing a timed-out call is only abandoned, never stopped, so it can still be holding the serial port when the next call is dispatched to the same "still alive" subprocess.

**Scoped narrowly to `TIMEOUT` specifically**, not any `ok: false` response - an ordinary domain error (`NOT_CONNECTED`, `UNSUPPORTED`, `IDENTITY_MISMATCH`, ...) means the adapter's call stack already unwound cleanly, and killing the subprocess for those would be pure churn with no safety benefit. Caller-visible behavior is unchanged: `return payload` still happens unconditionally after the (new, conditional) kill, so callers still see the exact same `TransportError(TIMEOUT)` they always would have - only the subprocess lifecycle changes.

Also softens `docs/BACKEND_API.md`'s "Both tiers are implemented now that Task 48 has landed" claim, which wasn't fully true for this one path, to describe this fifth case explicitly rather than removing the claim.

## Test plan
- [x] New `_test_behavior` in `tests/fixtures/fake_adapter.py`: `"adapter_timeout"` (responds immediately with the exact well-formed shape `ipc_protocol.make_error_response()` produces) and `"adapter_error:<code>"` (for the negative test).
- [x] `test_adapter_self_reported_timeout_kills_and_respawns_the_subprocess` - proves caller-visible behavior is unchanged (same `TransportError(TIMEOUT)`) while the subprocess is actually killed+respawned (different PID on the next call). Verified this fails before the fix (reverted the fix, confirmed `AssertionError: assert None is not None` - same still-alive process) and passes after.
- [x] `test_ordinary_adapter_domain_error_does_not_kill_the_subprocess` - negative test guarding the narrow scope: an ordinary domain error does NOT trigger a kill (same OS PID before/after).
- [x] Full suite: `pytest` - 500 passed, 25 skipped (pre-existing platform skips)
- [x] Live-verified on dev (192.168.2.104) in isolation, per scope guardrails: deployed the patched file as an uncommitted test, confirmed clean compile, restarted the service, confirmed no regressions (`status=OK`, real nodeinfo/telemetry flowing, radio identity `MATCH`, no new errors in the journal) - dev restored to its pre-test state afterward, this PR is what will actually land the change. Forcing the exact self-reported-timeout race against dev's *real* adapter subprocess wasn't attempted: `_test_behavior` is a test-fixture-only hook, not present in the real `adapters/meshtastic/ipc_server.py`, and adding one there temporarily to force this on live hardware was judged too risky for a production-representative node. The mechanism itself is proven by the deterministic regression test above instead (fails before the fix, passes after - confirmed directly, not assumed).

## Scope guardrails followed
Own PR, no other radio-stability items folded in (P0-B budget floor, P0-C channel-refresh single-flight, P1-A/C/D are separate, already-scoped-out follow-ups). Not deployed to prod/camtest - dev-only per this task's explicit instruction, pending further sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)