### PR TITLE
🛡️ Sentinel: Fix directory deletion error in delete_screenshot

### DIFF
--- a/camera/camera.py
+++ b/camera/camera.py
@@ -839,7 +839,7 @@ def list_screenshots():
 def delete_screenshot(filename):
     filepath = safe_screenshot_path(filename)
 
-    if filepath is None or not os.path.exists(filepath):
+    if filepath is None or not os.path.isfile(filepath):
         return {"ok": False, "error": "File not found"}, 404
 
     os.remove(filepath)

--- a/tests/test_api_camera.py
+++ b/tests/test_api_camera.py
@@ -119,3 +119,27 @@ def test_api_camera_screenshot_file_serves_the_already_validated_path(api_env, m
     send_file_spy.assert_called_once()
     served_path = send_file_spy.call_args[0][0]
     assert served_path == camera_module.safe_screenshot_path("plain.jpg")
+
+
+def test_api_camera_screenshot_delete_file_valid(api_env):
+    screenshots_dir = api_env["screenshots_dir"]
+    sub_dir = screenshots_dir / "2025" / "01" / "01"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    file_path = sub_dir / "MC_delete_test.jpg"
+    file_path.write_bytes(b"data to delete")
+
+    response = api_env["client"].delete("/api/camera/screenshot/2025/01/01/MC_delete_test.jpg")
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    assert not file_path.exists()
+
+
+def test_api_camera_screenshot_delete_directory_returns_404(api_env):
+    screenshots_dir = api_env["screenshots_dir"]
+    sub_dir = screenshots_dir / "2025" / "01" / "01"
+    sub_dir.mkdir(parents=True, exist_ok=True)
+
+    response = api_env["client"].delete("/api/camera/screenshot/2025/01/01")
+    assert response.status_code == 404
+    assert response.get_json() == {"ok": False, "error": "File not found"}
+    assert sub_dir.exists()


### PR DESCRIPTION
Fixed an issue in `delete_screenshot` where requesting deletion of a directory path caused an unhandled `IsADirectoryError` (500 internal server error). Replaced `os.path.exists(filepath)` with `os.path.isfile(filepath)` to ensure directory paths are rejected cleanly with a 404 response. Added corresponding unit tests in `tests/test_api_camera.py`.

---
*PR created automatically by Jules for task [13581019532100655796](https://jules.google.com/task/13581019532100655796) started by @FlintUA*