### PR TITLE
Fix P1-B: listener-stop misclassification race, plus P0-A observability logging

### DIFF
--- a/meshsrv/adapter_ipc_client.py
+++ b/meshsrv/adapter_ipc_client.py
@@ -544,6 +544,10 @@ class AdapterSupervisor:
             if isinstance(payload, dict) and payload.get("ok") is False:
                 error_code = (payload.get("error") or {}).get("code")
                 if error_code == TransportErrorCode.TIMEOUT.value:
+                    self._on_log(
+                        "adapter subprocess invalidated after a self-reported TIMEOUT (killed, will respawn)",
+                        "INFO",
+                    )
                     self._kill_locked(ble_address_for_cleanup)
 
             return payload

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -83,7 +83,7 @@ class SerialPortSupervisor:
         radio_lock: threading.RLock,
         pause_listen: threading.Event,
         on_raw_line: Optional[Callable[[str], None]] = None,
-        on_lifecycle_event: Optional[Callable[[str], None]] = None,
+        on_lifecycle_event: Optional[Callable[[str, Optional[bool]], None]] = None,
         on_log: Optional[Callable[[str, str], None]] = None,
     ) -> None:
         self._cli_path = cli_path
@@ -91,7 +91,7 @@ class SerialPortSupervisor:
         self._radio_lock = radio_lock
         self._pause_listen = pause_listen
         self._on_raw_line = on_raw_line or (lambda line: None)
-        self._on_lifecycle_event = on_lifecycle_event or (lambda event: None)
+        self._on_lifecycle_event = on_lifecycle_event or (lambda event, intentional=None: None)
         self._on_log = on_log or (lambda msg, level="INFO": None)
 
         self._listen_process: Optional[subprocess.Popen] = None
@@ -143,7 +143,7 @@ class SerialPortSupervisor:
                     )
                     self._listen_process = proc
                     self._connected_since = time.time()
-                    self._on_lifecycle_event("listener_start")
+                    self._on_lifecycle_event("listener_start", intentional=None)
                     consecutive_errors = 0
 
                 for line in proc.stdout:
@@ -165,7 +165,24 @@ class SerialPortSupervisor:
                     current = self._listen_process
                 return_code = current.poll() if current is not None else None
 
-                if self._pause_listen.is_set():
+                # P1-B stabilization follow-up: this is the ONLY moment
+                # that actually knows whether the stop about to be
+                # reported was intentional (pause_listen already set) or
+                # not - captured once, into a plain bool, and threaded
+                # through to on_lifecycle_event() below instead of being
+                # re-read later by whatever handles the event. Between
+                # this read and that later handling, a DIFFERENT caller
+                # (radio_session()/prepare_radio_command() elsewhere)
+                # can legitimately set/clear this same shared
+                # threading.Event - a re-read at that later, asynchronous
+                # point can observe a value that no longer reflects what
+                # was true at the actual transition, misclassifying a
+                # routine, intentional stop as an unexpected one (or vice
+                # versa). See server.py's radio_event() for the consumer
+                # side of this fix.
+                stop_was_intentional = self._pause_listen.is_set()
+
+                if stop_was_intentional:
                     if current is not None:
                         try:
                             current.terminate()
@@ -175,7 +192,7 @@ class SerialPortSupervisor:
                                 current.kill()
                             except Exception:
                                 pass
-                    self._on_lifecycle_event("listener_stop")
+                    self._on_lifecycle_event("listener_stop", intentional=True)
                     with self._radio_lock:
                         self._listen_process = None
                     time.sleep(0.5)
@@ -190,7 +207,7 @@ class SerialPortSupervisor:
                 else:
                     consecutive_errors = 0
 
-                self._on_lifecycle_event("listener_stop")
+                self._on_lifecycle_event("listener_stop", intentional=stop_was_intentional)
                 with self._radio_lock:
                     self._listen_process = None
 

--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -180,6 +180,27 @@ class SerialPortSupervisor:
                 # routine, intentional stop as an unexpected one (or vice
                 # versa). See server.py's radio_event() for the consumer
                 # side of this fix.
+                #
+                # KNOWN, DEFERRED (live-observed on dev during this same
+                # fix's own soak test, not fixed here): this read is
+                # synchronous and correct for the bug above, but it's
+                # still a plain, un-locked read of a shared
+                # threading.Event - a DIFFERENT, concurrent, overlapping
+                # claim_exclusive_access()/radio_session() call can still
+                # toggle pause_listen in the narrow window between "the
+                # listener process actually dies" and "this thread gets
+                # scheduled to reach this line", producing one
+                # occasional, isolated "Listener stopped (unexpected)"
+                # even though the stop really was contention-driven, not
+                # a genuine crash. Live-confirmed: happened once during
+                # dev's own post-deploy soak, self-recovered within
+                # seconds, no sustained outage. A real fix would mean
+                # holding radio_lock across this whole notice-and-report
+                # sequence, claim_exclusive_access()-style (see that
+                # method's own DELIBERATE DIVERGENCE note) - a bigger,
+                # architectural change that overlaps with the P1-A
+                # follow-up, not attempted here. Tracked as backlog, not
+                # scheduled separately (rare, narrow, self-recovering).
                 stop_was_intentional = self._pause_listen.is_set()
 
                 if stop_was_intentional:

--- a/server.py
+++ b/server.py
@@ -836,7 +836,7 @@ listener_supervisor = SerialPortSupervisor(
     radio_lock=radio_lock,
     pause_listen=pause_listen,
     on_raw_line=lambda line: _handle_listener_line(line),
-    on_lifecycle_event=lambda event: radio_event(event),
+    on_lifecycle_event=lambda event, **kwargs: radio_event(event, **kwargs),
     on_log=lambda msg, level="INFO": log_system_event(
         title="Node Time Sync", details=msg, level=level, source="time_sync"
     ),
@@ -960,7 +960,7 @@ def _radio_history_locked(event, level="INFO", details=""):
         del history[:-50]
 
 
-def radio_event(event, error=""):
+def radio_event(event, error="", intentional=None):
     now_ts = time.time()
 
     with state_lock:
@@ -1017,7 +1017,19 @@ def radio_event(event, error=""):
                 radio_connection_manager.listener_stopped()
 
             if was_running:
-                if pause_listen.is_set():
+                # P1-B stabilization follow-up: `intentional` is the
+                # pause_listen.is_set() value the monitor loop already
+                # captured synchronously at the actual stop, in
+                # meshsrv/serial_port_supervisor.py's run_listener() -
+                # NOT re-read here. A re-read at this point (this
+                # function runs asynchronously relative to that moment)
+                # could observe a different caller's radio_session()/
+                # prepare_radio_command() having already set/cleared the
+                # same shared pause_listen Event in between, misclassifying
+                # a routine, intentional stop as an unexpected one - the
+                # exact bug this fix closes (live-observed on dev: this
+                # ERROR firing on almost every routine radio command).
+                if intentional:
                     _radio_history_locked(
                         "Listener paused",
                         "INFO",

--- a/tests/test_radio_event_listener_stop_classification.py
+++ b/tests/test_radio_event_listener_stop_classification.py
@@ -1,0 +1,118 @@
+"""Tests for server.py's radio_event() "listener_stop" classification -
+P1-B stabilization follow-up.
+
+Root cause (live-observed on dev after PR #166: an ERROR "Listener
+stopped ... exited unexpectedly" firing on almost every routine radio
+command): meshsrv/serial_port_supervisor.py's run_listener() knows,
+synchronously at the exact moment of a stop, whether it was intentional
+(pause_listen.is_set() at that instant) - but that value used to only
+cross the on_lifecycle_event("listener_stop") boundary as an event name,
+not a value. radio_event() then re-read pause_listen.is_set() itself,
+asynchronously, at whatever later moment its own callback actually ran -
+and a different radio_session()/prepare_radio_command() caller could
+have legitimately changed the same shared pause_listen Event in that
+window, misclassifying a routine stop as unexpected (or vice versa).
+
+The fix threads the already-known value through as an `intentional`
+parameter instead of re-deriving it later - these tests exercise
+radio_event() directly with that parameter, using the same
+server_module + log_system_event-monkeypatch pattern as
+tests/test_listener_paused_recovery.py's own `logged` fixture (not
+modified here, just followed as a template).
+"""
+import pytest
+
+
+@pytest.fixture
+def radio_env(server_module):
+    """radio_health/its history list and pause_listen are module-global
+    state - reset around every test so one test's transition can't leak
+    into the next. listener_running=True going in, since radio_event()'s
+    listener_stop branch only logs anything when was_running is True."""
+    original_running = server_module.radio_health.get("listener_running")
+    original_history = list(server_module.radio_health.get("history", []))
+    original_pause_listen_set = server_module.pause_listen.is_set()
+
+    server_module.radio_health["listener_running"] = True
+
+    yield server_module
+
+    server_module.radio_health["listener_running"] = original_running
+    server_module.radio_health["history"] = original_history
+    if original_pause_listen_set:
+        server_module.pause_listen.set()
+    else:
+        server_module.pause_listen.clear()
+
+
+@pytest.fixture
+def logged(radio_env, monkeypatch):
+    """Captures every log_system_event() call - _radio_history_locked()
+    (radio_event()'s own logging helper) calls it with source="radio"."""
+    calls = []
+    monkeypatch.setattr(
+        radio_env, "log_system_event",
+        lambda title, level="INFO", details="", source="system": calls.append(
+            {"title": title, "level": level, "details": details, "source": source}
+        ),
+    )
+    return calls
+
+
+def test_intentional_stop_logs_listener_paused_info(radio_env, logged):
+    radio_env.radio_event("listener_stop", intentional=True)
+
+    assert len(logged) == 1
+    assert logged[0]["title"] == "Listener paused"
+    assert logged[0]["level"] == "INFO"
+    assert logged[0]["details"] == "Listener stopped temporarily for a radio command"
+
+
+def test_unintentional_stop_logs_listener_stopped_error(radio_env, logged):
+    radio_env.radio_event("listener_stop", intentional=False)
+
+    assert len(logged) == 1
+    assert logged[0]["title"] == "Listener stopped"
+    assert logged[0]["level"] == "ERROR"
+    assert logged[0]["details"] == "Meshtastic listener exited unexpectedly"
+
+
+def test_classification_uses_the_passed_value_not_a_fresh_reread_of_pause_listen(radio_env, logged):
+    """The actual bug this fixes, proven directly: set pause_listen to
+    the OPPOSITE of what `intentional` says, and confirm the log follows
+    the passed-in value - not pause_listen.is_set(). If radio_event()
+    were still re-deriving the classification from a fresh read (the
+    pre-fix behavior), this test would get the wrong log entry."""
+    # pause_listen is SET (a stale re-read would say "intentional") but
+    # the value captured at the actual transition says otherwise - the
+    # exact race window this fix closes.
+    radio_env.pause_listen.set()
+    radio_env.radio_event("listener_stop", intentional=False)
+
+    assert len(logged) == 1
+    assert logged[0]["title"] == "Listener stopped"
+    assert logged[0]["level"] == "ERROR"
+
+    logged.clear()
+    radio_env.radio_health["listener_running"] = True
+
+    # And the reverse: pause_listen is CLEAR (a stale re-read would say
+    # "unexpected") but the captured value says it was intentional.
+    radio_env.pause_listen.clear()
+    radio_env.radio_event("listener_stop", intentional=True)
+
+    assert len(logged) == 1
+    assert logged[0]["title"] == "Listener paused"
+    assert logged[0]["level"] == "INFO"
+
+
+def test_stop_while_not_running_logs_nothing(radio_env, logged):
+    """was_running gates the log entirely (unchanged pre-existing
+    behavior) - a stop event with listener_running already False must
+    not produce a spurious log line either way."""
+    radio_env.radio_health["listener_running"] = False
+
+    radio_env.radio_event("listener_stop", intentional=True)
+    radio_env.radio_event("listener_stop", intentional=False)
+
+    assert logged == []


### PR DESCRIPTION
## Summary
Live-observed on dev after PR #166's ~1h soak: `ERROR "Listener stopped ... exited unexpectedly"` firing on almost every routine radio command, paired closely with `WARNING "Status changed: OK -> PAUSED"`.

**Precise mechanism**: `meshsrv/serial_port_supervisor.py`'s `run_listener()` (the only caller of `on_lifecycle_event("listener_stop")`) already knows, synchronously at the exact moment of a stop, whether it was intentional (`pause_listen.is_set()`, read in the same `with radio_lock:` block). That value only crossed the callback boundary as an event name, not a value - `server.py`'s `radio_event()` then re-read `pause_listen.is_set()` itself, asynchronously, at whatever later moment its own callback actually ran. A different `radio_session()`/`prepare_radio_command()` caller can legitimately set/clear the same shared `pause_listen` `threading.Event` in between - radio commands fire back-to-back often enough on dev that this window is regularly hit.

**Fix**: both `listener_stop` call sites now capture the value once and pass it through as `intentional`; `radio_event()` uses it directly instead of re-reading. Log wording unchanged - classification-accuracy fix only. `radio_health_worker()`'s separate 30s-poll `"Status changed: ... -> PAUSED"` line is untouched (different, independent mechanism).

**P0-A observability add-on**: one `_on_log(...)` line where PR #166's TIMEOUT-kill branch fires, matching the existing convention - purely observational.

## Live verification - found something worth reporting honestly
Deployed to dev as an uncommitted test, confirmed the described bug pattern in the pre-fix log (repeated false ERRORs), confirmed **no recurrence of that exact pattern post-fix** - but did catch one residual `ERROR "Listener stopped"` post-restart, exactly coinciding with a `get_channels()` timeout. Traced it precisely (see the new comment in `serial_port_supervisor.py`): a **different, narrower** race than the one this PR fixes - a concurrent, overlapping claim can still toggle `pause_listen` in the window between the listener process dying and `run_listener()`'s thread getting scheduled to read the flag, i.e. a TOCTOU at the read itself, not the "re-read later, asynchronously" bug this PR closes (which the unit tests conclusively prove is fixed - no case of that specific pattern recurred). Self-recovered within seconds, no sustained outage.

Documented as `KNOWN, DEFERRED` (same style `server.py`'s `radio_session()` already uses for its own prepare-phase race) rather than fixed here - a real fix would mean holding `radio_lock` across the whole notice-and-report sequence, `claim_exclusive_access()`-style, which overlaps with the P1-A follow-up and is a bigger architectural change. Tracked as backlog per explicit agreement, not scheduled separately.

## Test plan
- [x] 4 new tests in `tests/test_radio_event_listener_stop_classification.py`, including one that directly proves the fix: sets `pause_listen` to the *opposite* of the passed `intentional` value and confirms classification follows the parameter, not a fresh read. Verified all 4 genuinely fail pre-fix (`TypeError: unexpected keyword argument 'intentional'`).
- [x] Full suite: `pytest` - 504 passed, 25 skipped (pre-existing platform skips)
- [x] Live-verified on dev (192.168.2.104): deployed as uncommitted test files, clean compile, clean restart, confirmed the described bug pattern present pre-fix and absent post-fix (aside from the separately-documented residual race above) - dev restored to its pre-test state, this PR is what actually lands the change.

## Scope guardrails followed
Own PR, no P0-B/P0-C/P1-A/P1-D/P1-E folded in. The "Node Time Sync" source-label mislabeling noticed in passing (`server.py:838`, `on_log` always logs `source="time_sync"` even for non-time-sync messages) is flagged back as a separate candidate fix, not touched here. Dev-only deploy pending, per policy - prod/camtest stay on the pre-this-PR commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)