### PR TITLE
Fix P1-A: radio_session() prepare phase raced radio_lock acquisition

### DIFF
--- a/server.py
+++ b/server.py
@@ -3453,58 +3453,70 @@ def radio_session(device=None, timeout=8, cooldown=2.0, extra_release_wait=None)
     `with radio_lock:` with no timeout of its own - once
     claim_exclusive_access() could hold this same lock for a full
     IPC round-trip (Task 48), a caller here could wait unboundedly behind
-    it. Now bounded: the remaining slice of `timeout` after
-    prepare_radio_command() already ran (dynamic, time.monotonic()-measured,
-    matching TransportRouter._delegate()'s Task 47.5 mechanic - not a
-    fixed proportion, and not a second independent timeout stacked on
-    top, which would let a caller's declared budget silently double).
-    Raises the SAME RadioBusyError prepare_radio_command()'s own failure
-    already raises - both existing callers (server.py's rescan_nodes,
-    api_node_tools.py) already `except RadioBusyError` and map it to
-    HTTP 503/error_code="radio_busy", so this needs no new error shape.
+    it. Raises the SAME RadioBusyError prepare_radio_command()'s own
+    failure already raises - both existing callers (server.py's
+    rescan_nodes, api_node_tools.py) already `except RadioBusyError` and
+    map it to HTTP 503/error_code="radio_busy", so this needs no new
+    error shape.
 
-    Lock-hold/cooldown ordering is UNCHANGED from before this fix -
-    verified, not assumed: radio_lock was already released before this
-    function's own cooldown/pause_listen.clear() ran even in the
-    original code (`with radio_lock: yield` only ever wrapped the yield
-    itself, never the surrounding prepare/cooldown), so nothing here
-    changes when the listener actually resumes.
-
-    KNOWN, DEFERRED (Task 49 follow-up, not fixed here): prepare_radio_
-    command() above still runs BEFORE radio_lock is acquired, unlike
+    P1-A stabilization follow-up (Task 49 follow-up, now fixed): this
+    function used to run prepare_radio_command() (pause/stop/wait-for-
+    port-release) BEFORE acquiring radio_lock, unlike
     claim_exclusive_access()'s deliberate "hold the lock for the whole
-    prepare+work span" design (Task 44's own DELIBERATE DIVERGENCE fix,
-    meshsrv/serial_port_supervisor.py). Two concurrent radio_session()
-    callers - or a radio_session() caller racing a claim_exclusive_
-    access() caller - can still run their
-    prepare phases (pause/stop/wait-for-port-release) in parallel today.
-    Bounding the lock-acquire above doesn't fix or worsen this - it's a
-    separate, previously-unidentified question this task deliberately
-    does not resolve.
+    prepare+work span" design (Task 44's own DELIBERATE DIVERGENCE
+    choice, meshsrv/serial_port_supervisor.py) - meaning two concurrent
+    radio_session() callers, or a radio_session() caller racing a
+    claim_exclusive_access() caller, could both run their prepare phases
+    in parallel, only serializing once each reached the lock. This now
+    matches claim_exclusive_access()'s shape instead: radio_lock is
+    acquired FIRST (still bounded by `timeout`, preserving Task 49's
+    fail-fast guarantee - not reverted to the old unconditional `with
+    radio_lock:` that caused Task 49's own bug), then prepare/work/
+    cooldown/pause_listen.clear() all run while holding it, released
+    only in the outer `finally`. Verified this is a net improvement for
+    the exact regression risk meshsrv/adapter_ipc_client.py's own
+    SERIAL PORT CLAIM comment already flagged: a Node Tools action
+    landing while a long adapter IPC call holds radio_lock now fails
+    fast on the lock acquire alone, before ever touching the listener/
+    port - strictly less wasted work and port interference than before,
+    not a reopening of that risk.
     """
     start = time.monotonic()
-    prepared = prepare_radio_command(device=device, timeout=timeout)
+    if not radio_lock.acquire(timeout=timeout):
+        raise RadioBusyError(
+            f"radio_lock busy: could not acquire within {timeout}s "
+            "- another long-running radio call is in progress"
+        )
     try:
-        if not prepared:
-            raise RadioBusyError(f"Serial port busy: {device or 'auto-detect'}")
         remaining = max(1.0, timeout - (time.monotonic() - start))
-        if not radio_lock.acquire(timeout=remaining):
-            raise RadioBusyError(
-                f"radio_lock busy: could not acquire within {remaining}s "
-                "- another long-running radio call is in progress"
-            )
+        prepared = prepare_radio_command(device=device, timeout=remaining)
+        # cooldown/extra_release_wait/pause_listen.clear() must run
+        # regardless of whether `prepared` succeeded - prepare_radio_
+        # command() unconditionally calls pause_listen.set() as its very
+        # first action, before it even checks wait_serial_release()'s
+        # result, so pause_listen is left set after calling it either
+        # way and something has to clear it back. This inner try/finally
+        # has to wrap the "not prepared" raise too, not just the yield -
+        # scoping it to only the yield (an earlier draft of this fix did
+        # exactly that) would skip this cleanup entirely on a failed
+        # prepare, leaving the listener paused indefinitely. Matches the
+        # original code's guarantee exactly (there, this cleanup lived in
+        # the outermost finally, covering everything after
+        # prepare_radio_command() returned regardless of outcome).
         try:
+            if not prepared:
+                raise RadioBusyError(f"Serial port busy: {device or 'auto-detect'}")
             yield
         finally:
-            radio_lock.release()
+            if extra_release_wait is not None:
+                wait_serial_release(device=device, timeout=extra_release_wait)
+                time.sleep(0.4)
+            if cooldown:
+                time.sleep(cooldown)
+            if is_radio_available():
+                pause_listen.clear()
     finally:
-        if extra_release_wait is not None:
-            wait_serial_release(device=device, timeout=extra_release_wait)
-            time.sleep(0.4)
-        if cooldown:
-            time.sleep(cooldown)
-        if is_radio_available():
-            pause_listen.clear()
+        radio_lock.release()
 
 
 def _attempt_node_time_sync():

--- a/tests/test_radio_session_timeout.py
+++ b/tests/test_radio_session_timeout.py
@@ -1,5 +1,5 @@
 """Tests for server.py's radio_session()'s Task 49 fix: radio_lock.acquire()
-is now bounded (dynamic remaining-time split, matching TransportRouter.
+is bounded (dynamic remaining-time split, matching TransportRouter.
 _delegate()'s Task 47.5 mechanic) instead of an unconditional `with
 radio_lock:` with no timeout of its own.
 
@@ -7,8 +7,13 @@ prepare_radio_command() is stubbed out in every test here (it shells out to
 `lsof`, unavailable on this project's Windows dev machine, and its own
 pause/stop/wait-for-port-release behavior is not what changed in this fix -
 see server.py's own serial_transport-delegation docstrings for that logic).
-What's under test is specifically the NEW bounded radio_lock.acquire() step
-that runs after prepare_radio_command() succeeds.
+What's under test is specifically the bounded radio_lock.acquire() step -
+P1-A follow-up: that step now runs BEFORE prepare_radio_command() (moved
+earlier to close the prepare-phase race, see radio_session()'s own updated
+docstring), not after it as when this file was first written - these tests
+still pass unchanged since they only assert on RadioBusyError/timing, not
+call ordering, but the acquire-then-prepare ordering here is now the
+opposite of what this file originally described.
 """
 import threading
 import time
@@ -66,7 +71,14 @@ def test_radio_session_raises_radio_busy_error_within_its_own_budget_not_unbound
         # Bounded by the declared timeout (1.0s), not the lock-holder's
         # hold time (this test never releases it until after the assert) -
         # generous upper bound to absorb scheduling jitter without being
-        # a no-op assertion.
+        # a no-op assertion. P1-A follow-up: radio_lock.acquire() now runs
+        # BEFORE prepare_radio_command() (this test's own stubbed version
+        # is never even called here, since the acquire above already
+        # fails) - the busy-lock case no longer touches the listener/port
+        # at all, so there's nothing for cooldown/pause_listen.clear() to
+        # clean up in this specific failure path (unlike a *prepare*
+        # failure, which still runs that cleanup - see
+        # radio_session()'s own updated docstring).
         assert result["elapsed"] < 3.0, f"took {result['elapsed']:.2f}s - should fail within its own ~1s budget"
     finally:
         server_module.radio_lock.release()
@@ -109,3 +121,125 @@ def test_radio_session_short_call_does_not_queue_behind_a_long_one(_stub_prepare
     # pass) but both complete within a generous bound - no spurious
     # RadioBusyError from a call whose own 5.0s timeout was never at risk.
     assert started_second_at[0] - t0 < 0.3
+
+
+# --- P1-A: the prepare phase itself must not race -------------------------
+# Direct counterpart to tests/test_serial_transport_timeout.py's
+# test_concurrent_connect_and_send_do_not_race_prepare_phase - same
+# technique (an exclusive-entry counter around the tracked critical
+# section, not just "both eventually complete").
+
+
+def test_two_concurrent_radio_sessions_do_not_race_their_prepare_phases(server_module, monkeypatch):
+    """Before the P1-A fix, radio_lock was acquired AFTER
+    prepare_radio_command() returned - two concurrent radio_session()
+    calls could both run their prepare phases (pause/stop/wait-for-
+    port-release) at the same time, only serializing once each reached
+    the lock. This proves that window is closed: prepare_radio_command()
+    is now only ever entered by one radio_session() call at a time."""
+    violations = []
+    in_critical_section = {"count": 0}
+    counter_lock = threading.Lock()
+
+    def tracked_prepare(device=None, timeout=8):
+        with counter_lock:
+            in_critical_section["count"] += 1
+            if in_critical_section["count"] > 1:
+                violations.append(in_critical_section["count"])
+        try:
+            time.sleep(0.1)
+            return True
+        finally:
+            with counter_lock:
+                in_critical_section["count"] -= 1
+
+    monkeypatch.setattr(server_module, "prepare_radio_command", tracked_prepare)
+    monkeypatch.setattr(server_module, "wait_serial_release", lambda device=None, timeout=8: True)
+    monkeypatch.setattr(server_module, "is_radio_available", lambda: False)  # skip pause_listen.clear()
+
+    results = {}
+
+    def run(name):
+        with server_module.radio_session(timeout=5.0, cooldown=0):
+            pass
+        results[name] = "done"
+
+    thread_a = threading.Thread(target=run, args=("a",))
+    thread_b = threading.Thread(target=run, args=("b",))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=5.0)
+    thread_b.join(timeout=5.0)
+
+    assert results.get("a") == "done" and results.get("b") == "done"
+    assert violations == [], (
+        "two radio_session() calls entered prepare_radio_command() at the "
+        "same time - the prepare-phase race P1-A is supposed to close"
+    )
+
+
+def test_radio_session_fails_fast_when_radio_lock_is_held_by_a_real_claim_exclusive_access(server_module, monkeypatch):
+    """The exact scenario meshsrv/adapter_ipc_client.py's own SERIAL PORT
+    CLAIM comment worries about: a long-running claim_exclusive_access()
+    call (the real one, not a generic lock-hold simulation) holding
+    radio_lock while a radio_session() caller (e.g. a Node Tools action)
+    lands. Must fail fast with RadioBusyError within radio_session()'s
+    own declared timeout, not wait out claim_exclusive_access()'s much
+    longer hold - and, since the P1-A fix, must do so WITHOUT ever
+    touching the listener/port (prepare_radio_command() is never called
+    at all when the lock itself is what's busy)."""
+    from meshsrv.serial_port_supervisor import SerialPortSupervisor
+
+    supervisor = SerialPortSupervisor(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyFAKE",
+        radio_lock=server_module.radio_lock,
+        pause_listen=server_module.pause_listen,
+    )
+    # A real port-free outcome so claim_exclusive_access() actually
+    # enters its held-lock body instead of raising immediately.
+    supervisor._wait_for_release_outcome = lambda timeout=8: __import__(
+        "meshsrv.serial_port_supervisor", fromlist=["PortReleaseOutcome"]
+    ).PortReleaseOutcome.PORT_FREE
+    supervisor.stop_listener_process = lambda: True
+
+    prepare_calls = []
+    original_prepare = server_module.prepare_radio_command
+
+    def tracked_prepare(*args, **kwargs):
+        prepare_calls.append(True)
+        return original_prepare(*args, **kwargs)
+
+    monkeypatch.setattr(server_module, "prepare_radio_command", tracked_prepare)
+
+    claim_entered = threading.Event()
+    release_claim = threading.Event()
+
+    def hold_claim():
+        with supervisor.claim_exclusive_access(timeout=8, cooldown=0):
+            claim_entered.set()
+            release_claim.wait(timeout=5.0)
+
+    claim_thread = threading.Thread(target=hold_claim)
+    claim_thread.start()
+    assert claim_entered.wait(timeout=5.0), "claim_exclusive_access() never entered its held-lock body"
+
+    result = {}
+    try:
+        start = time.monotonic()
+        try:
+            with server_module.radio_session(timeout=1.0, cooldown=0):
+                pass
+        except server_module.RadioBusyError as error:
+            result["error"] = error
+        result["elapsed"] = time.monotonic() - start
+    finally:
+        release_claim.set()
+        claim_thread.join(timeout=5.0)
+
+    assert "error" in result, "expected RadioBusyError while radio_lock was held by claim_exclusive_access()"
+    assert result["elapsed"] < 3.0, f"took {result['elapsed']:.2f}s - should fail within its own ~1s budget"
+    assert prepare_calls == [], (
+        "prepare_radio_command() must not run at all when radio_lock itself "
+        "is what's busy - P1-A's fail-fast-before-touching-the-listener guarantee"
+    )


### PR DESCRIPTION
## Summary

`radio_session()` used to run `prepare_radio_command()` (pause/stop/wait-for-port-release) **before** acquiring `radio_lock`, unlike `claim_exclusive_access()`'s deliberate "hold the lock for the whole prepare+work span" design (Task 44, `meshsrv/serial_port_supervisor.py`). Two concurrent `radio_session()` callers - or a `radio_session()` caller racing a `claim_exclusive_access()` caller - could both run their prepare phases in parallel, only serializing once each reached the lock.

`radio_lock.acquire()` now runs first (still bounded by `timeout`, preserving Task 49's fail-fast guarantee - not reverted to the old unconditional `with radio_lock:` that caused Task 49's own bug), then prepare/work/cooldown/`pause_listen.clear()` all run while holding it, matching `claim_exclusive_access()`'s shape. Net effect for the regression risk `meshsrv/adapter_ipc_client.py`'s own SERIAL PORT CLAIM comment flagged: a Node Tools action landing while a long adapter IPC call holds `radio_lock` now fails fast on the lock acquire alone, before ever touching the listener/port.

Blast radius verified: the only real callers of `radio_session()` are `server.py`'s rescan_nodes-area code and `api/api_node_tools.py`, both already `except RadioBusyError` - no new error shape. (`meshsrv/schedule_actions.py`'s `send_mesh_message()` does not call `radio_session()` at all - it uses `_radio_transport.send_text()` directly; `meshsrv/node_time_sync.py`'s "call inside an already-open radio_session()" docstring line is stale terminology, not a live dependency.)

- Own PR, dev-only deploy first, per the same staged-rollout policy as #166/#168 - prod/camtest stay on the pre-merge commit pending extended soak time on dev.

## Test plan

- [x] Two new regression tests added to `tests/test_radio_session_timeout.py`:
  - `test_two_concurrent_radio_sessions_do_not_race_their_prepare_phases` - proves two concurrent `radio_session()` calls never enter `prepare_radio_command()` at the same time (exclusive-entry counter, modeled on `test_serial_transport_timeout.py`'s prepare-phase-race test).
  - `test_radio_session_fails_fast_when_radio_lock_is_held_by_a_real_claim_exclusive_access` - proves `radio_session()` fails fast with `RadioBusyError`, without ever calling `prepare_radio_command()`, when `radio_lock` is held by a real `claim_exclusive_access()` call longer than its own `timeout`.
- [x] Both new tests verified to genuinely fail against the pre-fix code (`git stash` on `server.py` alone) and pass after.
- [x] Full suite green: 506 passed, 25 skipped.
- [ ] Dev-only deploy + live verification (compile check, restart, health check, journalctl scan) after merge.
- [ ] Extended soak on dev (a few hours of normal usage, no new `radio_busy` complaints, no regression in Task 3's contention pattern) before considering prod/camtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)