### PR TITLE
Log listener-stop intent at request time, not reconstructed after the fact

### DIFF
--- a/meshsrv/serial_port_supervisor.py
+++ b/meshsrv/serial_port_supervisor.py
@@ -84,7 +84,7 @@ class SerialPortSupervisor:
         pause_listen: threading.Event,
         on_raw_line: Optional[Callable[[str], None]] = None,
         on_lifecycle_event: Optional[Callable[[str, Optional[bool]], None]] = None,
-        on_log: Optional[Callable[[str, str], None]] = None,
+        on_log: Optional[Callable[..., None]] = None,
     ) -> None:
         self._cli_path = cli_path
         self._port = port
@@ -92,7 +92,11 @@ class SerialPortSupervisor:
         self._pause_listen = pause_listen
         self._on_raw_line = on_raw_line or (lambda line: None)
         self._on_lifecycle_event = on_lifecycle_event or (lambda event, intentional=None: None)
-        self._on_log = on_log or (lambda msg, level="INFO": None)
+        # Task 7 (listener-stop-intent logging) follow-up: accepts optional
+        # title/source kwargs now, mirroring how on_lifecycle_event was
+        # extended with **kwargs/intentional in PR #168 - same pattern, same
+        # file. The no-op default below just needs to not blow up on them.
+        self._on_log = on_log or (lambda msg, level="INFO", **kwargs: None)
 
         self._listen_process: Optional[subprocess.Popen] = None
         self._connected_since: Optional[float] = None
@@ -290,6 +294,23 @@ class SerialPortSupervisor:
     # ------------------------------------------------------------------
     def stop_listener_process(self) -> bool:
         self._pause_listen.set()
+        # Task 7 (observability follow-up): log intent at the ONE place
+        # it's actually known for certain - this is the single choke point
+        # both callers that ever intentionally stop the listener go
+        # through (server.py's prepare_radio_command() via stop_listener(),
+        # and claim_exclusive_access()'s internal _prepare_command()).
+        # Task 6's investigation hit a wall reconstructing "was this stop
+        # intentional" after the fact from run_listener()'s own
+        # ended-with-code/stop_was_intentional read - both a genuine crash
+        # and a legitimate stop can print an identical shutdown signature,
+        # making them indistinguishable in hindsight. Logging the request
+        # here, at the moment it's issued, means a future "ERROR: Listener
+        # stopped - exited unexpectedly" with no "Listener stop requested"
+        # in the few seconds before it is real signal, not an inference.
+        self._on_log(
+            "Listener stop requested (intentional)", "INFO",
+            title="Listener Control", source="radio",
+        )
         time.sleep(1.5)
 
         with self._radio_lock:

--- a/server.py
+++ b/server.py
@@ -837,8 +837,16 @@ listener_supervisor = SerialPortSupervisor(
     pause_listen=pause_listen,
     on_raw_line=lambda line: _handle_listener_line(line),
     on_lifecycle_event=lambda event, **kwargs: radio_event(event, **kwargs),
-    on_log=lambda msg, level="INFO": log_system_event(
-        title="Node Time Sync", details=msg, level=level, source="time_sync"
+    # Task 7 follow-up: title/source used to be hardcoded to "Node Time
+    # Sync"/"time_sync" regardless of what the message was actually about
+    # (a stale/misleading routing artifact flagged during Task 4's review,
+    # never actioned) - now forwarded from the call site, defaulting to
+    # those same values so every EXISTING _on_log(...) call in
+    # serial_port_supervisor.py (none of which pass title/source) keeps
+    # landing exactly where it always has. Only the new "Listener stop
+    # requested" call (stop_listener_process()) passes something accurate.
+    on_log=lambda msg, level="INFO", title="Node Time Sync", source="time_sync": log_system_event(
+        title=title, details=msg, level=level, source=source
     ),
 )
 

--- a/tests/test_serial_port_supervisor.py
+++ b/tests/test_serial_port_supervisor.py
@@ -472,3 +472,101 @@ def test_two_independent_supervisor_instances_both_benefit_from_the_same_fallbac
 
     assert core_side.check_port_release_once() == PortReleaseOutcome.PORT_FREE
     assert adapter_side.check_port_release_once() == PortReleaseOutcome.PORT_FREE
+
+
+# --- Task 7: log intent at the moment a listener stop is actually
+# requested, instead of reconstructing it later from a racy pause_listen
+# read (the wall Task 6's investigation hit). stop_listener_process() is
+# the single choke point both intentional-stop callers go through
+# (server.py's prepare_radio_command() via stop_listener(), and
+# claim_exclusive_access()'s internal _prepare_command()).
+
+
+def test_stop_listener_process_logs_intent_exactly_once():
+    """The actual fix: a real _on_log call, with the expected message/
+    level/title/source, fired exactly once per stop_listener_process()
+    call - not zero (silently reconstructing intent later, same wall
+    Task 6 hit), not more than once (noise), and routed to title=
+    "Listener Control"/source="radio" - NOT the old hardcoded "Node Time
+    Sync"/"time_sync" this callback used to always log under, which would
+    have buried this new line somewhere confusing to look for it."""
+    logged = []
+    supervisor = SerialPortSupervisor(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyFAKE",
+        radio_lock=threading.RLock(),
+        pause_listen=threading.Event(),
+        on_log=lambda msg, level="INFO", **kwargs: logged.append((msg, level, kwargs)),
+    )
+    # No process attached - stop_listener_process() returns True almost
+    # immediately after its own internal sleeps, without needing a real
+    # subprocess to terminate.
+    assert supervisor._listen_process is None
+
+    result = supervisor.stop_listener_process()
+
+    assert result is True
+    assert len(logged) == 1, f"expected exactly one _on_log call, got {len(logged)}: {logged}"
+    msg, level, kwargs = logged[0]
+    assert msg == "Listener stop requested (intentional)"
+    assert level == "INFO"
+    assert kwargs == {"title": "Listener Control", "source": "radio"}
+
+
+def test_stop_listener_process_sets_pause_listen_before_logging():
+    """The task's own ordering requirement: the _on_log call must come
+    right after pause_listen.set() - the very first line - not buried
+    after other prepare-phase work. Proven directly: by the time on_log
+    fires, pause_listen must already read True."""
+    observed_pause_state = []
+    supervisor = SerialPortSupervisor(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyFAKE",
+        radio_lock=threading.RLock(),
+        pause_listen=threading.Event(),
+        on_log=lambda msg, level="INFO", **kwargs: observed_pause_state.append(
+            supervisor._pause_listen.is_set()
+        ),
+    )
+
+    supervisor.stop_listener_process()
+
+    assert observed_pause_state == [True]
+
+
+def test_existing_on_log_call_site_keeps_its_original_title_and_source_after_the_signature_change():
+    """Regression guard for the default-argument backward-compat: the
+    port-release-inferred-free call site (check_port_release_once(), the
+    ONE pre-existing _on_log(...) call in this module) never passes
+    title/source itself - it must keep landing wherever it always has
+    once the on_log signature grows those optional kwargs, not silently
+    start passing None or blow up on the new default-carrying lambda
+    server.py actually uses (title="Node Time Sync"/source="time_sync"
+    defaults)."""
+    routed = []
+    supervisor = SerialPortSupervisor(
+        cli_path="/does/not/matter/for/this/test",
+        port="/dev/ttyACM0",
+        radio_lock=threading.RLock(),
+        pause_listen=threading.Event(),
+        # Mirrors server.py's real listener_supervisor on_log lambda
+        # exactly, defaults included - the actual production shape, not a
+        # simplified stand-in.
+        on_log=lambda msg, level="INFO", title="Node Time Sync", source="time_sync": routed.append(
+            (msg, level, title, source)
+        ),
+    )
+    supervisor._check_known_pid = lambda: None
+    supervisor._check_proc_fd_scan = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_fuser = lambda: PortReleaseOutcome.PORT_FREE
+    supervisor._check_lsof = lambda: PortReleaseOutcome.CHECK_TIMEOUT
+
+    outcome = supervisor.check_port_release_once()
+
+    assert outcome == PortReleaseOutcome.PORT_FREE
+    assert len(routed) == 1
+    msg, level, title, source = routed[0]
+    assert "Serial port release inferred free" in msg
+    assert level == "WARNING"
+    assert title == "Node Time Sync"
+    assert source == "time_sync"


### PR DESCRIPTION
## Summary

Task 6's investigation hit a wall: `[SerialPortSupervisor] Listener process ended with code:` can't cleanly distinguish a genuine crash from a legitimate stop whose later classification read a stale `pause_listen` - both produce an identical shutdown signature after the fact. Reconstructing intent from a shared, racy flag is inherently ambiguous.

`stop_listener_process()` (`meshsrv/serial_port_supervisor.py`) is the single choke point both callers that ever intentionally stop the listener go through - `server.py`'s `prepare_radio_command()` via `stop_listener()`, and `claim_exclusive_access()`'s internal `_prepare_command()`. It now logs `"Listener stop requested (intentional)"` as the very first thing after `pause_listen.set()`, before anything else happens - so a future `ERROR: Listener stopped - exited unexpectedly` with no matching "stop requested" line in the few seconds before it is real signal, not an inference.

Also fixes the `on_log` routing for Core's `listener_supervisor` instance, which was hardcoded to `title="Node Time Sync"`/`source="time_sync"` regardless of what the message was actually about (flagged during Task 4's review, never actioned). `title`/`source` are now forwarded from the call site, defaulting to those same values so the one pre-existing `_on_log()` call (the "Serial port release inferred free" line) is unaffected; only the new stop-intent line routes to `title="Listener Control"`/`source="radio"`, alongside the rest of the listener lifecycle events.

Blast radius checked: the adapter's own composed `SerialPortSupervisor` instance (via `SerialTransport`) never passes `on_log`, so it falls through to the no-op default - which was widened to accept `**kwargs` alongside everything else, so it doesn't raise `TypeError` on the new `title=`/`source=` kwargs.

**Pure observability - no change to when/whether the listener stops, no change to `radio_lock`/`pause_listen` semantics, nothing touching P1-A's fix.**

## Test plan

- [x] 3 new tests in `tests/test_serial_port_supervisor.py`:
  - `test_stop_listener_process_logs_intent_exactly_once` - exactly one `_on_log` call with the expected message/level/title/source.
  - `test_stop_listener_process_sets_pause_listen_before_logging` - `pause_listen` reads `True` by the time `on_log` fires.
  - `test_existing_on_log_call_site_keeps_its_original_title_and_source_after_the_signature_change` - regression guard using the real production lambda shape, confirming the port-release-inferred-free line is unaffected.
- [x] Both behavioral tests verified to genuinely fail against the pre-fix code (`git stash` on the two source files) and pass after; the regression guard correctly passes in both states.
- [x] Full suite green: 509 passed, 25 skipped.
- [ ] Dev-only deploy first, per policy. Short soak given how low-risk this is (additive logging + a default-preserving signature change), before considering prod/camtest.
- [ ] P1-C as a clean follow-up once this lands - not folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)