### PR TITLE
🛡️ Sentinel: Fix unhandled exception in waypoint expiration parsing

### DIFF
--- a/api/api_waypoints.py
+++ b/api/api_waypoints.py
@@ -135,10 +135,13 @@ def register_waypoint_routes(
             return jsonify({"ok": False, "error": "Channel index must be between 0 and 7", "error_code": "waypoint_invalid_channel_index"}), 400
         if expire_at <= int(time.time()) + 30:
             return jsonify({"ok": False, "error": "Expiration must be in the future", "error_code": "waypoint_expiration_in_past"}), 400
+        try:
+            expires_text = datetime.fromtimestamp(expire_at).strftime("%d.%m.%Y %H:%M")
+        except (OverflowError, ValueError, OSError):
+            return jsonify({"ok": False, "error": "Expiration timestamp is out of valid range", "error_code": "waypoint_expiration_out_of_range"}), 400
+
         if not is_radio_available():
             return jsonify({"ok": False, "error": "Meshtastic radio is currently unavailable", "error_code": "radio_released"}), 503
-
-        expires_text = datetime.fromtimestamp(expire_at).strftime("%d.%m.%Y %H:%M")
         notification_text = f"📍 Waypoint: {name}"
         if description:
             notification_text += f"\n{description}"

--- a/tests/test_api_waypoints.py
+++ b/tests/test_api_waypoints.py
@@ -312,6 +312,14 @@ def test_send_rejects_expiration_in_the_past(waypoint_env):
     assert response.get_json()["error_code"] == "waypoint_expiration_in_past"
 
 
+def test_send_rejects_expiration_out_of_range(waypoint_env):
+    response = waypoint_env["client"].post(
+        "/api/waypoints/send", json=_valid_send_payload(expire_at=9999999999999),
+    )
+    assert response.status_code == 400
+    assert response.get_json()["error_code"] == "waypoint_expiration_out_of_range"
+
+
 def test_send_returns_503_when_radio_unavailable(waypoint_env):
     waypoint_env["radio"].available = False
 


### PR DESCRIPTION
🛡️ Sentinel Security Improvement Report:

🚨 Severity: MEDIUM
💡 Vulnerability: Unhandled `OverflowError`/`ValueError`/`OSError` when parsing `expire_at` timestamps in `POST /api/waypoints/send`.
🎯 Impact: Supplying an extremely large integer for `expire_at` (e.g. `9999999999999`) caused `datetime.fromtimestamp(expire_at)` to raise an unhandled exception, causing the request to crash with an HTTP 500 Internal Server Error (and potential error leakage) instead of failing gracefully with validation error.
🔧 Fix: Wrapped `datetime.fromtimestamp(expire_at)` in a `try...except (OverflowError, ValueError, OSError)` block in `api/api_waypoints.py` to return HTTP 400 with `error_code: waypoint_expiration_out_of_range`.
✅ Verification: Added a unit test in `tests/test_api_waypoints.py` (`test_send_rejects_expiration_out_of_range`) and verified all 535 tests pass cleanly.

---
*PR created automatically by Jules for task [58550099639683144](https://jules.google.com/task/58550099639683144) started by @FlintUA*