### PR TITLE
Theme registry Stage 0: raw-HEX audit + verification tooling

### DIFF
--- a/docs/theme-registry/computed-styles-baseline.md
+++ b/docs/theme-registry/computed-styles-baseline.md
@@ -1,0 +1,30 @@
+# Computed-styles snapshot — Stage 0 baseline
+
+Computed `background-color` / `color` / `border-color` / `box-shadow` for one representative element per component category, sampled from the Stage 0 fixture pages (`.theme_stage0_scratch/fixtures/fixture_{light,dark}.html`) in headless Chromium. This is the 'before' reference future stages diff against.
+
+| Component | Selector | Theme | background-color | color | border-color | box-shadow |
+|---|---|---|---|---|---|---|
+| Panel (chat area) | `.chat-area` | light | `rgb(245, 247, 250)` | `rgb(16, 35, 63)` | `rgb(16, 35, 63)` | `none` |
+| Panel (chat area) | `.chat-area` | dark | `rgb(24, 33, 44)` | `rgb(242, 247, 252)` | `rgb(10, 18, 28)` | `none` |
+| Card (settings card) | `.settings-card--general` | light | `rgb(247, 249, 252)` | `rgb(16, 35, 63)` | `rgb(215, 224, 234)` | `none` |
+| Card (settings card) | `.settings-card--general` | dark | `rgb(27, 40, 55)` | `rgb(242, 247, 252)` | `rgb(47, 62, 80)` | `none` |
+| Control / input (search box) | `.search-input-wide` | light | `rgb(248, 248, 248)` | `rgb(51, 51, 51)` | `rgb(213, 216, 221)` | `none` |
+| Control / input (search box) | `.search-input-wide` | dark | `rgb(15, 26, 38)` | `rgb(242, 247, 252)` | `rgb(47, 62, 80)` | `none` |
+| Primary button (Send) | `.input-form button[type=submit]` | light | `rgba(0, 0, 0, 0)` | `rgb(255, 255, 255)` | `rgb(255, 255, 255)` | `none` |
+| Primary button (Send) | `.input-form button[type=submit]` | dark | `rgba(0, 0, 0, 0)` | `rgb(255, 255, 255)` | `rgb(255, 255, 255)` | `none` |
+| Popover (notifications) | `.notification-popover` | light | `rgb(255, 255, 255)` | `rgb(38, 54, 75)` | `rgb(215, 222, 232)` | `rgba(15, 23, 42, 0.2) 0px 14px 34px 0px` |
+| Popover (notifications) | `.notification-popover` | dark | `rgb(27, 40, 55)` | `rgb(238, 246, 255)` | `rgb(58, 82, 109)` | `rgba(0, 0, 0, 0.48) 0px 16px 38px 0px` |
+| Dialog (confirm delete) | `.modal-content` | light | `rgb(255, 255, 255)` | `rgb(16, 35, 63)` | `rgb(16, 35, 63)` | `rgba(0, 0, 0, 0.15) 0px 8px 30px 0px` |
+| Dialog (confirm delete) | `.modal-content` | dark | `rgb(27, 45, 64)` | `rgb(217, 231, 245)` | `rgb(58, 82, 106)` | `rgba(0, 0, 0, 0.52) 0px 22px 55px 0px` |
+| Toast (dock notification status) | `.dock-notification-status` | light | `rgba(0, 0, 0, 0)` | `rgb(16, 35, 63)` | `rgba(0, 0, 0, 0)` | `none` |
+| Toast (dock notification status) | `.dock-notification-status` | dark | `rgba(0, 0, 0, 0)` | `rgb(242, 247, 252)` | `rgba(0, 0, 0, 0)` | `none` |
+| Badge (device status pill) | `.device-status-pill` | light | `rgba(0, 0, 0, 0)` | `rgb(20, 36, 58)` | `rgb(20, 36, 58)` | `none` |
+| Badge (device status pill) | `.device-status-pill` | dark | `rgba(0, 0, 0, 0)` | `rgb(243, 247, 251)` | `rgb(243, 247, 251)` | `none` |
+| Table-like list (device detail list) | `.device-detail-list` | light | `rgba(0, 0, 0, 0)` | `rgb(20, 36, 58)` | `rgb(20, 36, 58)` | `none` |
+| Table-like list (device detail list) | `.device-detail-list` | dark | `rgba(0, 0, 0, 0)` | `rgb(243, 247, 251)` | `rgb(243, 247, 251)` | `none` |
+| Node card | `.node-card.favorite` | light | `rgb(255, 247, 223)` | `rgb(16, 35, 63)` | `rgb(226, 189, 69)` | `rgba(47, 115, 217, 0.12) 0px 0px 0px 1px` |
+| Node card | `.node-card.favorite` | dark | `rgb(38, 62, 88)` | `rgb(242, 247, 252)` | `rgb(102, 168, 255)` | `rgba(47, 115, 217, 0.12) 0px 0px 0px 1px` |
+| Media stage (camera frame) | `.video-frame-wrap` | light | `rgb(232, 234, 237)` | `rgb(16, 35, 63)` | `rgb(16, 35, 63)` | `none` |
+| Media stage (camera frame) | `.video-frame-wrap` | dark | `rgb(17, 27, 39)` | `rgb(243, 247, 251)` | `rgb(38, 53, 71)` | `none` |
+| Telemetry chart container | `.telemetry-chart-container` | light | `rgb(240, 242, 245)` | `rgb(16, 35, 63)` | `rgb(229, 232, 236)` | `none` |
+| Telemetry chart container | `.telemetry-chart-container` | dark | `rgb(26, 37, 53)` | `rgb(242, 247, 252)` | `rgb(38, 60, 82)` | `none` |

--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -1,0 +1,8797 @@
+[
+  {
+    "value": "000000",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2739"
+    ]
+  },
+  {
+    "value": "0369A1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:656"
+    ]
+  },
+  {
+    "value": "080D13",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1869"
+    ]
+  },
+  {
+    "value": "09111A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2060"
+    ]
+  },
+  {
+    "value": "0A1119",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1764"
+    ]
+  },
+  {
+    "value": "0A121C",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1801",
+      "static/ui-kit.css:2895",
+      "static/ui-kit.css:2904"
+    ]
+  },
+  {
+    "value": "0B1520",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3219"
+    ]
+  },
+  {
+    "value": "0D1723",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3200"
+    ]
+  },
+  {
+    "value": "0E1B28",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:615"
+    ]
+  },
+  {
+    "value": "0E1C2A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2555"
+    ]
+  },
+  {
+    "value": "0F172A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part2.css:423",
+      "static/style-part2.css:474",
+      "static/style-part2.css:532",
+      "static/style-part2.css:604"
+    ]
+  },
+  {
+    "value": "0F1823",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1763"
+    ]
+  },
+  {
+    "value": "0F1A26",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:2061",
+      "static/style-part4.css:2476",
+      "static/ui-kit.css:1677"
+    ]
+  },
+  {
+    "value": "0F1C2A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3424"
+    ]
+  },
+  {
+    "value": "0F1D2B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2932"
+    ]
+  },
+  {
+    "value": "101820",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2166"
+    ]
+  },
+  {
+    "value": "101923",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3205"
+    ]
+  },
+  {
+    "value": "101B27",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:694"
+    ]
+  },
+  {
+    "value": "101C29",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2431"
+    ]
+  },
+  {
+    "value": "101D2B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1972"
+    ]
+  },
+  {
+    "value": "10233C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2232"
+    ]
+  },
+  {
+    "value": "10233F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:985",
+      "static/ui-kit.css:3086"
+    ]
+  },
+  {
+    "value": "102F5C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3129"
+    ]
+  },
+  {
+    "value": "111821",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1050"
+    ]
+  },
+  {
+    "value": "111A24",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1105"
+    ]
+  },
+  {
+    "value": "111B27",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1864"
+    ]
+  },
+  {
+    "value": "111C29",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:3201",
+      "static/ui-kit.css:3275"
+    ]
+  },
+  {
+    "value": "112F4D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2982"
+    ]
+  },
+  {
+    "value": "121C28",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3255"
+    ]
+  },
+  {
+    "value": "122F4A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3060"
+    ]
+  },
+  {
+    "value": "1265D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:2290",
+      "static/style-part1.css:2305",
+      "static/style-part2.css:1063"
+    ]
+  },
+  {
+    "value": "132334",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3220",
+      "static/style-part4.css:3399",
+      "static/style-part4.css:4000"
+    ]
+  },
+  {
+    "value": "142130",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1946"
+    ]
+  },
+  {
+    "value": "142434",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:595",
+      "static/style-part4.css:851"
+    ]
+  },
+  {
+    "value": "14243A",
+    "verdict": "ui-normalization-candidate",
+    "count": 10,
+    "locations": [
+      "static/style-part4.css:2038",
+      "static/style-part4.css:2347",
+      "static/style-part4.css:2358",
+      "static/style-part4.css:2372",
+      "static/style-part4.css:2380",
+      "static/style-part4.css:2410",
+      "static/style-part4.css:2753",
+      "static/style-part4.css:2832",
+      "static/style-part4.css:2884",
+      "static/style-part4.css:2933"
+    ]
+  },
+  {
+    "value": "145FC6",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:823",
+      "static/style-part2.css:2736",
+      "static/style-part2.css:2810"
+    ]
+  },
+  {
+    "value": "151E29",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1111"
+    ]
+  },
+  {
+    "value": "15314F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2879"
+    ]
+  },
+  {
+    "value": "1557B0",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:350",
+      "static/style-part1.css:423",
+      "static/style-part1.css:2330",
+      "static/style-part4.css:103",
+      "static/style-part4.css:263"
+    ]
+  },
+  {
+    "value": "155FAE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3486"
+    ]
+  },
+  {
+    "value": "162231",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:3203",
+      "static/ui-kit.css:3264"
+    ]
+  },
+  {
+    "value": "162331",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1731",
+      "static/ui-kit.css:2727"
+    ]
+  },
+  {
+    "value": "162433",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:2062",
+      "static/style-part4.css:3334 [comment]",
+      "static/ui-kit.css:3213"
+    ]
+  },
+  {
+    "value": "16243A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2685"
+    ]
+  },
+  {
+    "value": "162534",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2659"
+    ]
+  },
+  {
+    "value": "16283A",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3421",
+      "static/style-part4.css:3428",
+      "static/style-part4.css:4009"
+    ]
+  },
+  {
+    "value": "16324C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2520"
+    ]
+  },
+  {
+    "value": "163E72",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:423"
+    ]
+  },
+  {
+    "value": "165CBA",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part2.css:2936",
+      "static/style-part2.css:2946",
+      "static/style-part2.css:3368",
+      "static/style-part3.css:30",
+      "static/style-part3.css:311",
+      "static/ui-kit.css:2714"
+    ]
+  },
+  {
+    "value": "166534",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1624"
+    ]
+  },
+  {
+    "value": "16803C",
+    "verdict": "semantic-status-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1766",
+      "static/style-part4.css:1767"
+    ]
+  },
+  {
+    "value": "168447",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1300"
+    ]
+  },
+  {
+    "value": "168846",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1231"
+    ]
+  },
+  {
+    "value": "16A34A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:3468",
+      "static/style-part2.css:554",
+      "static/style-part2.css:1467",
+      "static/style-part2.css:1506"
+    ]
+  },
+  {
+    "value": "172033",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part4.css:1263",
+      "static/style-part4.css:1329",
+      "static/style-part4.css:1358",
+      "static/style-part4.css:1398",
+      "static/style-part4.css:1493",
+      "static/style-part4.css:1671",
+      "static/style-part4.css:1937"
+    ]
+  },
+  {
+    "value": "172432",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1685",
+      "static/ui-kit.css:2641"
+    ]
+  },
+  {
+    "value": "17243A",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/ui-kit.css:1220",
+      "static/ui-kit.css:1224",
+      "static/ui-kit.css:1226",
+      "static/ui-kit.css:1227",
+      "static/ui-kit.css:1228",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1231",
+      "static/ui-kit.css:1232"
+    ]
+  },
+  {
+    "value": "172535",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3212"
+    ]
+  },
+  {
+    "value": "172638",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part3.css:2353",
+      "static/style-part3.css:3734",
+      "static/style-part4.css:3251 [comment]",
+      "static/style-part4.css:3254",
+      "static/style-part4.css:3269 [comment]",
+      "static/style-part4.css:3972 [comment]",
+      "static/style-part4.css:3978",
+      "static/style-part4.css:4025 [comment]",
+      "static/style-part4.css:4031"
+    ]
+  },
+  {
+    "value": "17283A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:3460",
+      "static/style-part3.css:3551",
+      "static/style-part3.css:3732",
+      "static/style-part4.css:841"
+    ]
+  },
+  {
+    "value": "17293A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:577",
+      "static/style-part4.css:631"
+    ]
+  },
+  {
+    "value": "172A3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:616"
+    ]
+  },
+  {
+    "value": "17344F",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:2457",
+      "static/style-part3.css:2489",
+      "static/style-part3.css:2688"
+    ]
+  },
+  {
+    "value": "17365F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2589"
+    ]
+  },
+  {
+    "value": "17392D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2215"
+    ]
+  },
+  {
+    "value": "173A5E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:80"
+    ]
+  },
+  {
+    "value": "173C2A",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3239"
+    ]
+  },
+  {
+    "value": "173F73",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2507"
+    ]
+  },
+  {
+    "value": "175FC0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3101"
+    ]
+  },
+  {
+    "value": "1769C2",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:2128",
+      "static/style-part4.css:3435",
+      "static/style-part4.css:3436"
+    ]
+  },
+  {
+    "value": "1769D2",
+    "verdict": "ui-normalization-candidate",
+    "count": 10,
+    "locations": [
+      "static/style-part4.css:3109",
+      "static/ui-kit.css:1213",
+      "static/ui-kit.css:1214",
+      "static/ui-kit.css:1214",
+      "static/ui-kit.css:1226",
+      "static/ui-kit.css:1227",
+      "static/ui-kit.css:1229",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1231"
+    ]
+  },
+  {
+    "value": "1769E0",
+    "verdict": "ui-normalization-candidate",
+    "count": 13,
+    "locations": [
+      "static/style-part4.css:1392",
+      "static/style-part4.css:1393",
+      "static/style-part4.css:1713",
+      "static/style-part4.css:1803",
+      "static/style-part4.css:1804",
+      "static/style-part4.css:1821",
+      "static/style-part4.css:1833",
+      "static/style-part4.css:1874",
+      "static/style-part4.css:1875",
+      "static/style-part4.css:2041",
+      "static/style-part4.css:2414",
+      "static/style-part4.css:2415",
+      "static/style-part4.css:2540"
+    ]
+  },
+  {
+    "value": "176B3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1165"
+    ]
+  },
+  {
+    "value": "18212C",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/ui-kit.css:1066",
+      "static/ui-kit.css:1156",
+      "static/ui-kit.css:1175",
+      "static/ui-kit.css:1492",
+      "static/ui-kit.css:1497",
+      "static/ui-kit.css:2894",
+      "static/ui-kit.css:3005",
+      "static/ui-kit.css:3011"
+    ]
+  },
+  {
+    "value": "182533",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2181"
+    ]
+  },
+  {
+    "value": "182535",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3256"
+    ]
+  },
+  {
+    "value": "182636",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3276"
+    ]
+  },
+  {
+    "value": "183048",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:643",
+      "static/style-part4.css:644"
+    ]
+  },
+  {
+    "value": "1A2535",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3272"
+    ]
+  },
+  {
+    "value": "1A2736",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2070",
+      "static/ui-kit.css:3294"
+    ]
+  },
+  {
+    "value": "1A2A4A",
+    "verdict": "ui-normalization-candidate",
+    "count": 24,
+    "locations": [
+      "static/style-part1.css:36",
+      "static/style-part1.css:126",
+      "static/style-part1.css:176",
+      "static/style-part1.css:238",
+      "static/style-part1.css:357",
+      "static/style-part1.css:493",
+      "static/style-part1.css:1722",
+      "static/style-part1.css:1866",
+      "static/style-part1.css:2135",
+      "static/style-part1.css:2643",
+      "static/style-part2.css:3423",
+      "static/style-part2.css:3538",
+      "static/style-part2.css:3589",
+      "static/style-part2.css:3609",
+      "static/style-part2.css:3674",
+      "static/style-part2.css:3750",
+      "static/style-part2.css:3809",
+      "static/style-part2.css:3834",
+      "static/style-part2.css:3903",
+      "static/style-part2.css:3915",
+      "static/style-part2.css:3933",
+      "static/style-part2.css:3980",
+      "static/style-part3.css:353",
+      "static/style-part3.css:1905"
+    ]
+  },
+  {
+    "value": "1A2C3F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3024"
+    ]
+  },
+  {
+    "value": "1A3A2A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:625"
+    ]
+  },
+  {
+    "value": "1A3A5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:580"
+    ]
+  },
+  {
+    "value": "1A5A7A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1743"
+    ]
+  },
+  {
+    "value": "1A5FA8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3391"
+    ]
+  },
+  {
+    "value": "1A73E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 24,
+    "locations": [
+      "static/style-part1.css:350",
+      "static/style-part1.css:412",
+      "static/style-part1.css:423",
+      "static/style-part1.css:1956",
+      "static/style-part1.css:1958",
+      "static/style-part1.css:1988",
+      "static/style-part1.css:2249",
+      "static/style-part1.css:2272",
+      "static/style-part1.css:2280",
+      "static/style-part1.css:2325",
+      "static/style-part1.css:3291",
+      "static/style-part1.css:3292",
+      "static/style-part1.css:3496",
+      "static/style-part2.css:3543",
+      "static/style-part2.css:3544",
+      "static/style-part2.css:3597",
+      "static/style-part2.css:3787",
+      "static/style-part2.css:3789",
+      "static/style-part2.css:3846",
+      "static/style-part2.css:3848",
+      "static/style-part3.css:360",
+      "static/style-part3.css:363",
+      "static/style-part4.css:255",
+      "static/style-part4.css:302"
+    ]
+  },
+  {
+    "value": "1A7F4B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1924"
+    ]
+  },
+  {
+    "value": "1B2837",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1851",
+      "static/ui-kit.css:3202",
+      "static/ui-kit.css:3263"
+    ]
+  },
+  {
+    "value": "1B2938",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2136"
+    ]
+  },
+  {
+    "value": "1B2B3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3279"
+    ]
+  },
+  {
+    "value": "1B2D40",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part4.css:3170",
+      "static/style-part4.css:3292",
+      "static/style-part4.css:3361",
+      "static/style-part4.css:3368",
+      "static/style-part4.css:3432"
+    ]
+  },
+  {
+    "value": "1C2C3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2063"
+    ]
+  },
+  {
+    "value": "1C2E41",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2533",
+      "static/style-part3.css:2771"
+    ]
+  },
+  {
+    "value": "1D2B3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1879"
+    ]
+  },
+  {
+    "value": "1D2B3B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3257"
+    ]
+  },
+  {
+    "value": "1D2D3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2646"
+    ]
+  },
+  {
+    "value": "1D3043",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3117"
+    ]
+  },
+  {
+    "value": "1D344B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1704"
+    ]
+  },
+  {
+    "value": "1D3557",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1771",
+      "static/style-part2.css:1821"
+    ]
+  },
+  {
+    "value": "1D4ED8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:437"
+    ]
+  },
+  {
+    "value": "1D5DA8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:909"
+    ]
+  },
+  {
+    "value": "1E293B",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:452",
+      "static/style-part2.css:1532",
+      "static/style-part3.css:1500",
+      "static/style-part3.css:3640",
+      "static/ui-kit.css:2420"
+    ]
+  },
+  {
+    "value": "1E3145",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:932"
+    ]
+  },
+  {
+    "value": "1E3A8A",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:512",
+      "static/style-part2.css:584",
+      "static/style-part2.css:634"
+    ]
+  },
+  {
+    "value": "1E3C72",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part1.css:256",
+      "static/style-part1.css:674",
+      "static/style-part1.css:675",
+      "static/style-part1.css:1152",
+      "static/style-part1.css:1189",
+      "static/style-part1.css:2096",
+      "static/style-part1.css:2097",
+      "static/style-part3.css:209"
+    ]
+  },
+  {
+    "value": "1E4F8F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:425"
+    ]
+  },
+  {
+    "value": "1F2937",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:2844",
+      "static/style-part1.css:2880",
+      "static/style-part1.css:3116",
+      "static/style-part1.css:3160",
+      "static/style-part2.css:2786"
+    ]
+  },
+  {
+    "value": "1F2D3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:163"
+    ]
+  },
+  {
+    "value": "1F3347",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3520"
+    ]
+  },
+  {
+    "value": "1F6FD1",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1048",
+      "static/style-part4.css:1048"
+    ]
+  },
+  {
+    "value": "1F6FDB",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:1815",
+      "static/style-part3.css:1869",
+      "static/style-part4.css:837",
+      "static/ui-kit.css:3100"
+    ]
+  },
+  {
+    "value": "1F6FE5",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:2956",
+      "static/style-part1.css:2958",
+      "static/style-part1.css:2997",
+      "static/style-part1.css:2999"
+    ]
+  },
+  {
+    "value": "1F6FEB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3097"
+    ]
+  },
+  {
+    "value": "202936",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3298"
+    ]
+  },
+  {
+    "value": "202A36",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/ui-kit.css:1079",
+      "static/ui-kit.css:1144",
+      "static/ui-kit.css:1151",
+      "static/ui-kit.css:1504",
+      "static/ui-kit.css:1510",
+      "static/ui-kit.css:3004"
+    ]
+  },
+  {
+    "value": "202E3E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3294"
+    ]
+  },
+  {
+    "value": "202F40",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2168",
+      "static/ui-kit.css:3204"
+    ]
+  },
+  {
+    "value": "203044",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3277"
+    ]
+  },
+  {
+    "value": "203247",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1965"
+    ]
+  },
+  {
+    "value": "203449",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3735",
+      "static/style-part4.css:3122"
+    ]
+  },
+  {
+    "value": "20354A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2734"
+    ]
+  },
+  {
+    "value": "20364B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3126"
+    ]
+  },
+  {
+    "value": "20384E",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:586",
+      "static/style-part4.css:852",
+      "static/style-part4.css:943"
+    ]
+  },
+  {
+    "value": "203A52",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:617"
+    ]
+  },
+  {
+    "value": "203B53",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:638",
+      "static/style-part4.css:889"
+    ]
+  },
+  {
+    "value": "203D5D",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:3232",
+      "static/ui-kit.css:3245"
+    ]
+  },
+  {
+    "value": "205B9E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1717"
+    ]
+  },
+  {
+    "value": "21364B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3733"
+    ]
+  },
+  {
+    "value": "21364D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1510"
+    ]
+  },
+  {
+    "value": "213B57",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1704"
+    ]
+  },
+  {
+    "value": "214469",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3510"
+    ]
+  },
+  {
+    "value": "214D35",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2348"
+    ]
+  },
+  {
+    "value": "214F91",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:48",
+      "static/ui-kit.css:3104",
+      "static/ui-kit.css:3130"
+    ]
+  },
+  {
+    "value": "2168D7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:2249",
+      "static/style-part4.css:2510"
+    ]
+  },
+  {
+    "value": "216B36",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2286"
+    ]
+  },
+  {
+    "value": "216B3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2513",
+      "static/style-part4.css:3341 [comment]"
+    ]
+  },
+  {
+    "value": "217648",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3723"
+    ]
+  },
+  {
+    "value": "218653",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1296",
+      "static/style-part4.css:949"
+    ]
+  },
+  {
+    "value": "222D3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1119"
+    ]
+  },
+  {
+    "value": "223245",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2190"
+    ]
+  },
+  {
+    "value": "22324A",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:93",
+      "static/style-part4.css:152",
+      "static/style-part4.css:293"
+    ]
+  },
+  {
+    "value": "223349",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/ui-kit.css:1983",
+      "static/ui-kit.css:2202",
+      "static/ui-kit.css:2221",
+      "static/ui-kit.css:3248",
+      "static/ui-kit.css:3265",
+      "static/ui-kit.css:3270",
+      "static/ui-kit.css:3284"
+    ]
+  },
+  {
+    "value": "22364A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2626"
+    ]
+  },
+  {
+    "value": "22364B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2932"
+    ]
+  },
+  {
+    "value": "22A447",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1381"
+    ]
+  },
+  {
+    "value": "22A559",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:19"
+    ]
+  },
+  {
+    "value": "22C55E",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:1330",
+      "static/style-part1.css:3459",
+      "static/style-part2.css:1507",
+      "static/style-part4.css:3038"
+    ]
+  },
+  {
+    "value": "233346",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1664"
+    ]
+  },
+  {
+    "value": "23415F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1712"
+    ]
+  },
+  {
+    "value": "236337",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1732",
+      "static/style-part2.css:1895"
+    ]
+  },
+  {
+    "value": "23663A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2583"
+    ]
+  },
+  {
+    "value": "23699F",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3726"
+    ]
+  },
+  {
+    "value": "239B62",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2838",
+      "static/style-part2.css:2891"
+    ]
+  },
+  {
+    "value": "243243",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3225"
+    ]
+  },
+  {
+    "value": "243247",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:649"
+    ]
+  },
+  {
+    "value": "243447",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:1802",
+      "static/style-part2.css:1871",
+      "static/style-part3.css:1599"
+    ]
+  },
+  {
+    "value": "24374B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2064"
+    ]
+  },
+  {
+    "value": "243A2B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1714"
+    ]
+  },
+  {
+    "value": "243B5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:517"
+    ]
+  },
+  {
+    "value": "243C54",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3146"
+    ]
+  },
+  {
+    "value": "24415F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:3492",
+      "static/style-part2.css:163"
+    ]
+  },
+  {
+    "value": "24425E",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:892",
+      "static/style-part4.css:1047"
+    ]
+  },
+  {
+    "value": "24456F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:230",
+      "static/style-part3.css:418"
+    ]
+  },
+  {
+    "value": "24457B",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1966",
+      "static/ui-kit.css:803"
+    ]
+  },
+  {
+    "value": "244D82",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1007"
+    ]
+  },
+  {
+    "value": "2470D8",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:2662",
+      "static/style-part2.css:2684",
+      "static/style-part2.css:2685"
+    ]
+  },
+  {
+    "value": "25394D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2065"
+    ]
+  },
+  {
+    "value": "255984",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3918"
+    ]
+  },
+  {
+    "value": "2563EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1471"
+    ]
+  },
+  {
+    "value": "25C66B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1222"
+    ]
+  },
+  {
+    "value": "263547",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1771",
+      "static/ui-kit.css:1865"
+    ]
+  },
+  {
+    "value": "26364B",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:839",
+      "static/ui-kit.css:3138"
+    ]
+  },
+  {
+    "value": "26394D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3455"
+    ]
+  },
+  {
+    "value": "263B50",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:3227",
+      "static/style-part4.css:3310 [comment]",
+      "static/style-part4.css:3315",
+      "static/style-part4.css:3361"
+    ]
+  },
+  {
+    "value": "263B52",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part3.css:958",
+      "static/style-part3.css:1100",
+      "static/style-part3.css:1201",
+      "static/style-part4.css:3769",
+      "static/style-part4.css:3803",
+      "static/style-part4.css:3889"
+    ]
+  },
+  {
+    "value": "263C52",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part3.css:2352",
+      "static/style-part4.css:3251 [comment]",
+      "static/style-part4.css:3255",
+      "static/style-part4.css:3273",
+      "static/style-part4.css:3972 [comment]",
+      "static/style-part4.css:3977",
+      "static/style-part4.css:4025 [comment]",
+      "static/style-part4.css:4030"
+    ]
+  },
+  {
+    "value": "263D52",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3024"
+    ]
+  },
+  {
+    "value": "263E58",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1671"
+    ]
+  },
+  {
+    "value": "263F5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1704"
+    ]
+  },
+  {
+    "value": "267340",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2453",
+      "static/style-part4.css:3342 [comment]"
+    ]
+  },
+  {
+    "value": "273140",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1934"
+    ]
+  },
+  {
+    "value": "273D53",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2631"
+    ]
+  },
+  {
+    "value": "27435C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:641"
+    ]
+  },
+  {
+    "value": "274766",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:665",
+      "static/ui-kit.css:395",
+      "static/ui-kit.css:3122"
+    ]
+  },
+  {
+    "value": "275F8D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2589"
+    ]
+  },
+  {
+    "value": "277B4B",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3600"
+    ]
+  },
+  {
+    "value": "27B96F",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3108"
+    ]
+  },
+  {
+    "value": "285071",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:639",
+      "static/style-part4.css:890"
+    ]
+  },
+  {
+    "value": "28663A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1669"
+    ]
+  },
+  {
+    "value": "286DA8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3603"
+    ]
+  },
+  {
+    "value": "294766",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2576"
+    ]
+  },
+  {
+    "value": "29485D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2300"
+    ]
+  },
+  {
+    "value": "294967",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3233"
+    ]
+  },
+  {
+    "value": "2A3A6A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:36",
+      "static/style-part3.css:1905"
+    ]
+  },
+  {
+    "value": "2A3E53",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2067"
+    ]
+  },
+  {
+    "value": "2A3F54",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:3987",
+      "static/style-part4.css:4010",
+      "static/style-part4.css:4012",
+      "static/style-part4.css:4020"
+    ]
+  },
+  {
+    "value": "2A4A6A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:587",
+      "static/style-part3.css:103"
+    ]
+  },
+  {
+    "value": "2A4A7A",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1178"
+    ]
+  },
+  {
+    "value": "2A5684",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3515"
+    ]
+  },
+  {
+    "value": "2A5A3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:605"
+    ]
+  },
+  {
+    "value": "2A5A8A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:764",
+      "static/style-part1.css:1789",
+      "static/style-part1.css:2149",
+      "static/style-part1.css:2737"
+    ]
+  },
+  {
+    "value": "2A6A3A",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1176"
+    ]
+  },
+  {
+    "value": "2A9A60",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2901"
+    ]
+  },
+  {
+    "value": "2B3949",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1127",
+      "static/ui-kit.css:3006",
+      "static/ui-kit.css:3012"
+    ]
+  },
+  {
+    "value": "2B3A4C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1870"
+    ]
+  },
+  {
+    "value": "2B3B50",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:701"
+    ]
+  },
+  {
+    "value": "2B4059",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/ui-kit.css:1990",
+      "static/ui-kit.css:2209",
+      "static/ui-kit.css:3249",
+      "static/ui-kit.css:3271",
+      "static/ui-kit.css:3285"
+    ]
+  },
+  {
+    "value": "2B405B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1181"
+    ]
+  },
+  {
+    "value": "2B72DC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2941"
+    ]
+  },
+  {
+    "value": "2C3E50",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:14"
+    ]
+  },
+  {
+    "value": "2C6B52",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2216"
+    ]
+  },
+  {
+    "value": "2CA56C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1136"
+    ]
+  },
+  {
+    "value": "2D3D50",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2072"
+    ]
+  },
+  {
+    "value": "2D4057",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part3.css:934",
+      "static/style-part3.css:966",
+      "static/style-part3.css:1040",
+      "static/style-part3.css:1167",
+      "static/style-part3.css:2113",
+      "static/style-part4.css:3721",
+      "static/style-part4.css:3946"
+    ]
+  },
+  {
+    "value": "2D6CA3",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:3917",
+      "static/style-part4.css:3956"
+    ]
+  },
+  {
+    "value": "2E4258",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3278"
+    ]
+  },
+  {
+    "value": "2ECC71",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1897"
+    ]
+  },
+  {
+    "value": "2F3B4D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:214"
+    ]
+  },
+  {
+    "value": "2F3E50",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:3224",
+      "static/ui-kit.css:3266"
+    ]
+  },
+  {
+    "value": "2F4053",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2430"
+    ]
+  },
+  {
+    "value": "2F4357",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2640"
+    ]
+  },
+  {
+    "value": "2F73D9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3096"
+    ]
+  },
+  {
+    "value": "2F7DF6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1385"
+    ]
+  },
+  {
+    "value": "2F80ED",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3114"
+    ]
+  },
+  {
+    "value": "304A62",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3234",
+      "static/style-part4.css:3310 [comment]",
+      "static/style-part4.css:3320"
+    ]
+  },
+  {
+    "value": "304A63",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:616"
+    ]
+  },
+  {
+    "value": "31465C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2361"
+    ]
+  },
+  {
+    "value": "31475F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1856"
+    ]
+  },
+  {
+    "value": "31485E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3212"
+    ]
+  },
+  {
+    "value": "314A62",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part4.css:576",
+      "static/style-part4.css:594",
+      "static/style-part4.css:851",
+      "static/style-part4.css:856",
+      "static/style-part4.css:856"
+    ]
+  },
+  {
+    "value": "315B3D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2280"
+    ]
+  },
+  {
+    "value": "32445B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2111"
+    ]
+  },
+  {
+    "value": "33404F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2414"
+    ]
+  },
+  {
+    "value": "334155",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part1.css:2943",
+      "static/style-part2.css:53",
+      "static/style-part2.css:1016",
+      "static/style-part2.css:1643",
+      "static/style-part2.css:2497",
+      "static/ui-kit.css:897",
+      "static/ui-kit.css:924",
+      "static/ui-kit.css:2398",
+      "static/ui-kit.css:2498"
+    ]
+  },
+  {
+    "value": "334456",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1874"
+    ]
+  },
+  {
+    "value": "33465C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1785"
+    ]
+  },
+  {
+    "value": "33475B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2958"
+    ]
+  },
+  {
+    "value": "334A61",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:2532",
+      "static/style-part3.css:2554",
+      "static/style-part3.css:2770",
+      "static/style-part3.css:2778"
+    ]
+  },
+  {
+    "value": "334B68",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3128"
+    ]
+  },
+  {
+    "value": "344050",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1112"
+    ]
+  },
+  {
+    "value": "344359",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:810",
+      "static/style-part3.css:870"
+    ]
+  },
+  {
+    "value": "34445F",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:815",
+      "static/style-part2.css:892",
+      "static/style-part2.css:2729",
+      "static/style-part2.css:2791",
+      "static/style-part2.css:2803"
+    ]
+  },
+  {
+    "value": "34475B",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/ui-kit.css:2137",
+      "static/ui-kit.css:2162",
+      "static/ui-kit.css:2163",
+      "static/ui-kit.css:2164",
+      "static/ui-kit.css:2182"
+    ]
+  },
+  {
+    "value": "34475D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2931"
+    ]
+  },
+  {
+    "value": "34485A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2783"
+    ]
+  },
+  {
+    "value": "34485E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3734"
+    ]
+  },
+  {
+    "value": "34495E",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1784",
+      "static/style-part2.css:1856"
+    ]
+  },
+  {
+    "value": "344A60",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3550",
+      "static/style-part3.css:3732"
+    ]
+  },
+  {
+    "value": "344A61",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2066"
+    ]
+  },
+  {
+    "value": "344A62",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1379"
+    ]
+  },
+  {
+    "value": "344B61",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part4.css:3161",
+      "static/style-part4.css:3177",
+      "static/style-part4.css:3373",
+      "static/style-part4.css:3429",
+      "static/style-part4.css:4019"
+    ]
+  },
+  {
+    "value": "35475A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1845",
+      "static/ui-kit.css:1852"
+    ]
+  },
+  {
+    "value": "364253",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/ui-kit.css:1080",
+      "static/ui-kit.css:1157",
+      "static/ui-kit.css:1167",
+      "static/ui-kit.css:1493",
+      "static/ui-kit.css:1505",
+      "static/ui-kit.css:1511",
+      "static/ui-kit.css:3008",
+      "static/ui-kit.css:3295"
+    ]
+  },
+  {
+    "value": "36506A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1954"
+    ]
+  },
+  {
+    "value": "36516B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:632"
+    ]
+  },
+  {
+    "value": "36516C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2625"
+    ]
+  },
+  {
+    "value": "365A7A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2576"
+    ]
+  },
+  {
+    "value": "374151",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:2931",
+      "static/style-part1.css:3149",
+      "static/style-part1.css:3248",
+      "static/style-part1.css:3287",
+      "static/style-part2.css:1954"
+    ]
+  },
+  {
+    "value": "385068",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:3208",
+      "static/style-part4.css:3221",
+      "static/style-part4.css:3400",
+      "static/style-part4.css:4001"
+    ]
+  },
+  {
+    "value": "385069",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3118"
+    ]
+  },
+  {
+    "value": "38516A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:944"
+    ]
+  },
+  {
+    "value": "386445",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1276"
+    ]
+  },
+  {
+    "value": "38D68A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:612",
+      "static/style-part4.css:629"
+    ]
+  },
+  {
+    "value": "3A4A5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:1029",
+      "static/style-part1.css:1051",
+      "static/style-part1.css:1415",
+      "static/style-part2.css:3480",
+      "static/style-part2.css:3634"
+    ]
+  },
+  {
+    "value": "3A4A6A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:794"
+    ]
+  },
+  {
+    "value": "3A4E64",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2191"
+    ]
+  },
+  {
+    "value": "3A5269",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2645",
+      "static/ui-kit.css:2658"
+    ]
+  },
+  {
+    "value": "3A526A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:3136",
+      "static/style-part4.css:3171",
+      "static/style-part4.css:3361",
+      "static/style-part4.css:3369"
+    ]
+  },
+  {
+    "value": "3A526D",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/ui-kit.css:1974",
+      "static/ui-kit.css:1985",
+      "static/ui-kit.css:2203",
+      "static/ui-kit.css:2222",
+      "static/ui-kit.css:3250",
+      "static/ui-kit.css:3267",
+      "static/ui-kit.css:3286"
+    ]
+  },
+  {
+    "value": "3A5973",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:638",
+      "static/style-part4.css:889"
+    ]
+  },
+  {
+    "value": "3A5A7A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:86",
+      "static/style-part1.css:1642"
+    ]
+  },
+  {
+    "value": "3A6A3A",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1089"
+    ]
+  },
+  {
+    "value": "3B4858",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1936"
+    ]
+  },
+  {
+    "value": "3B4859",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1106",
+      "static/ui-kit.css:1120",
+      "static/ui-kit.css:1176"
+    ]
+  },
+  {
+    "value": "3B526A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3519"
+    ]
+  },
+  {
+    "value": "3B5670",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3127"
+    ]
+  },
+  {
+    "value": "3B82F6",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3043",
+      "static/style-part4.css:3049",
+      "static/ui-kit.css:2414"
+    ]
+  },
+  {
+    "value": "3D242B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:823"
+    ]
+  },
+  {
+    "value": "3DDC84",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3377"
+    ]
+  },
+  {
+    "value": "3F5065",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1226"
+    ]
+  },
+  {
+    "value": "3F6FAE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:968"
+    ]
+  },
+  {
+    "value": "405067",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2726"
+    ]
+  },
+  {
+    "value": "405268",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1337"
+    ]
+  },
+  {
+    "value": "405369",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1896"
+    ]
+  },
+  {
+    "value": "40556B",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2366",
+      "static/style-part3.css:2931"
+    ]
+  },
+  {
+    "value": "405875",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1183"
+    ]
+  },
+  {
+    "value": "41536A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1240"
+    ]
+  },
+  {
+    "value": "41576D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2577"
+    ]
+  },
+  {
+    "value": "415A72",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part4.css:3229",
+      "static/style-part4.css:3310 [comment]",
+      "static/style-part4.css:3317",
+      "static/style-part4.css:3322",
+      "static/style-part4.css:4005"
+    ]
+  },
+  {
+    "value": "415D78",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:126"
+    ]
+  },
+  {
+    "value": "433719",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3241"
+    ]
+  },
+  {
+    "value": "43566B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2077"
+    ]
+  },
+  {
+    "value": "43566D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:837"
+    ]
+  },
+  {
+    "value": "43A047",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2764"
+    ]
+  },
+  {
+    "value": "445164",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1145",
+      "static/ui-kit.css:1152",
+      "static/ui-kit.css:3007"
+    ]
+  },
+  {
+    "value": "445366",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3778",
+      "static/style-part4.css:3836",
+      "static/style-part4.css:3861"
+    ]
+  },
+  {
+    "value": "45272B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2227"
+    ]
+  },
+  {
+    "value": "46617C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1705"
+    ]
+  },
+  {
+    "value": "475569",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:628",
+      "static/style-part2.css:1029"
+    ]
+  },
+  {
+    "value": "48617E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2614"
+    ]
+  },
+  {
+    "value": "486B54",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2002"
+    ]
+  },
+  {
+    "value": "49252B",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3243"
+    ]
+  },
+  {
+    "value": "493B20",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2233"
+    ]
+  },
+  {
+    "value": "496274",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1988"
+    ]
+  },
+  {
+    "value": "49689F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1978",
+      "static/style-part3.css:1979"
+    ]
+  },
+  {
+    "value": "4A5A6A",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:877",
+      "static/style-part2.css:3472",
+      "static/style-part2.css:3688",
+      "static/style-part2.css:3945"
+    ]
+  },
+  {
+    "value": "4A5A7A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:173",
+      "static/style-part1.css:794"
+    ]
+  },
+  {
+    "value": "4A7AAA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:375"
+    ]
+  },
+  {
+    "value": "4A9EFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:1881",
+      "static/style-part1.css:1896"
+    ]
+  },
+  {
+    "value": "4AA3FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:613",
+      "static/style-part4.css:625"
+    ]
+  },
+  {
+    "value": "4B5563",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2820"
+    ]
+  },
+  {
+    "value": "4B6685",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3251"
+    ]
+  },
+  {
+    "value": "4C647B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3025"
+    ]
+  },
+  {
+    "value": "4CAF50",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:644",
+      "static/style-part1.css:2364",
+      "static/style-part1.css:2754",
+      "static/style-part4.css:335"
+    ]
+  },
+  {
+    "value": "4D6F9F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1133"
+    ]
+  },
+  {
+    "value": "4D7FB5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3509"
+    ]
+  },
+  {
+    "value": "4EA1FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1966"
+    ]
+  },
+  {
+    "value": "4F5F73",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:271"
+    ]
+  },
+  {
+    "value": "4F8CFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part4.css:2042",
+      "static/style-part4.css:2391",
+      "static/style-part4.css:2392",
+      "static/style-part4.css:2409",
+      "static/style-part4.css:2793",
+      "static/style-part4.css:2840",
+      "static/style-part4.css:2897",
+      "static/style-part4.css:2940"
+    ]
+  },
+  {
+    "value": "4F8FFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:2250",
+      "static/style-part4.css:2511"
+    ]
+  },
+  {
+    "value": "4F9CFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3260"
+    ]
+  },
+  {
+    "value": "4FD18B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:957"
+    ]
+  },
+  {
+    "value": "506983",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part4.css:2039",
+      "static/style-part4.css:2364",
+      "static/style-part4.css:2368",
+      "static/style-part4.css:2398",
+      "static/style-part4.css:2404",
+      "static/style-part4.css:2804"
+    ]
+  },
+  {
+    "value": "51627B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2113"
+    ]
+  },
+  {
+    "value": "526174",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3299"
+    ]
+  },
+  {
+    "value": "526177",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1221",
+      "static/ui-kit.css:1222"
+    ]
+  },
+  {
+    "value": "526178",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part2.css:1056",
+      "static/style-part2.css:2486",
+      "static/style-part3.css:502",
+      "static/style-part3.css:1640",
+      "static/style-part3.css:1641",
+      "static/style-part3.css:3620"
+    ]
+  },
+  {
+    "value": "52627A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1959",
+      "static/ui-kit.css:793"
+    ]
+  },
+  {
+    "value": "52657A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2280"
+    ]
+  },
+  {
+    "value": "52657C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1128"
+    ]
+  },
+  {
+    "value": "53657B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2675"
+    ]
+  },
+  {
+    "value": "536A83",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1900"
+    ]
+  },
+  {
+    "value": "53A66E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2388"
+    ]
+  },
+  {
+    "value": "55A9F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:586"
+    ]
+  },
+  {
+    "value": "55B870",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3283"
+    ]
+  },
+  {
+    "value": "58677B",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1226",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1231"
+    ]
+  },
+  {
+    "value": "58708F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:39",
+      "static/ui-kit.css:3087"
+    ]
+  },
+  {
+    "value": "58B76C",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part2.css:3320",
+      "static/style-part2.css:3350",
+      "static/style-part4.css:3582 [comment]",
+      "static/style-part4.css:3591"
+    ]
+  },
+  {
+    "value": "596675",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2357"
+    ]
+  },
+  {
+    "value": "5A6A7A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3458"
+    ]
+  },
+  {
+    "value": "5AA7FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2733"
+    ]
+  },
+  {
+    "value": "5B82AA",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/ui-kit.css:1991",
+      "static/ui-kit.css:2066",
+      "static/ui-kit.css:2101",
+      "static/ui-kit.css:2210"
+    ]
+  },
+  {
+    "value": "5C6B7E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:998"
+    ]
+  },
+  {
+    "value": "5C7082",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:640"
+    ]
+  },
+  {
+    "value": "5D7286",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:977"
+    ]
+  },
+  {
+    "value": "5D9B72",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2522"
+    ]
+  },
+  {
+    "value": "5DA4EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2915",
+      "static/style-part3.css:2920"
+    ]
+  },
+  {
+    "value": "5E7388",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2415"
+    ]
+  },
+  {
+    "value": "60748B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3249"
+    ]
+  },
+  {
+    "value": "60758A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2496"
+    ]
+  },
+  {
+    "value": "607A92",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3042"
+    ]
+  },
+  {
+    "value": "617184",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2338"
+    ]
+  },
+  {
+    "value": "617386",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3106"
+    ]
+  },
+  {
+    "value": "64748B",
+    "verdict": "ui-normalization-candidate",
+    "count": 26,
+    "locations": [
+      "static/style-part1.css:3452",
+      "static/style-part1.css:3474",
+      "static/style-part2.css:429",
+      "static/style-part2.css:470",
+      "static/style-part2.css:542",
+      "static/style-part2.css:571",
+      "static/style-part2.css:610",
+      "static/style-part2.css:1476",
+      "static/style-part2.css:1631",
+      "static/style-part3.css:406",
+      "static/style-part3.css:1988",
+      "static/style-part3.css:2402",
+      "static/style-part3.css:3185",
+      "static/style-part3.css:3527",
+      "static/style-part4.css:1215",
+      "static/style-part4.css:1251",
+      "static/style-part4.css:1277",
+      "static/style-part4.css:1349",
+      "static/style-part4.css:1538",
+      "static/style-part4.css:1677",
+      "static/style-part4.css:1688",
+      "static/style-part4.css:1748",
+      "static/style-part4.css:1761",
+      "static/style-part4.css:1797",
+      "static/style-part4.css:1815",
+      "static/ui-kit.css:2401"
+    ]
+  },
+  {
+    "value": "64798D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2484"
+    ]
+  },
+  {
+    "value": "647B91",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2672"
+    ]
+  },
+  {
+    "value": "654B18",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3502"
+    ]
+  },
+  {
+    "value": "65A3FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2071"
+    ]
+  },
+  {
+    "value": "667085",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:39",
+      "static/style-part3.css:281",
+      "static/style-part3.css:348",
+      "static/style-part4.css:439"
+    ]
+  },
+  {
+    "value": "667487",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:721"
+    ]
+  },
+  {
+    "value": "66756B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1918"
+    ]
+  },
+  {
+    "value": "66758A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1357"
+    ]
+  },
+  {
+    "value": "66788A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2989"
+    ]
+  },
+  {
+    "value": "66788F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1045",
+      "static/style-part4.css:1096"
+    ]
+  },
+  {
+    "value": "6688B7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1134",
+      "static/ui-kit.css:1182"
+    ]
+  },
+  {
+    "value": "66A8FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1672",
+      "static/ui-kit.css:3230"
+    ]
+  },
+  {
+    "value": "66B2FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2929"
+    ]
+  },
+  {
+    "value": "67788D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3300"
+    ]
+  },
+  {
+    "value": "687585",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2319"
+    ]
+  },
+  {
+    "value": "68758A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1212"
+    ]
+  },
+  {
+    "value": "68788B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3494"
+    ]
+  },
+  {
+    "value": "68A77A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1743",
+      "static/style-part2.css:1904"
+    ]
+  },
+  {
+    "value": "69A87F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2458"
+    ]
+  },
+  {
+    "value": "6A5A3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2341"
+    ]
+  },
+  {
+    "value": "6A7A8A",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part1.css:1073",
+      "static/style-part2.css:3444",
+      "static/style-part2.css:3497",
+      "static/style-part2.css:3603",
+      "static/style-part2.css:3668",
+      "static/style-part2.css:3744",
+      "static/style-part2.css:3775",
+      "static/style-part2.css:3828",
+      "static/style-part2.css:3897"
+    ]
+  },
+  {
+    "value": "6A97A6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3254"
+    ]
+  },
+  {
+    "value": "6A9AB8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1739"
+    ]
+  },
+  {
+    "value": "6AA7FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3226"
+    ]
+  },
+  {
+    "value": "6B5200",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:255"
+    ]
+  },
+  {
+    "value": "6B7280",
+    "verdict": "ui-normalization-candidate",
+    "count": 11,
+    "locations": [
+      "static/style-part1.css:2850",
+      "static/style-part1.css:2886",
+      "static/style-part1.css:3122",
+      "static/style-part1.css:3178",
+      "static/style-part1.css:3225",
+      "static/style-part2.css:143",
+      "static/style-part2.css:1968",
+      "static/style-part2.css:2780",
+      "static/style-part2.css:2840",
+      "static/style-part2.css:2841",
+      "static/style-part4.css:1169"
+    ]
+  },
+  {
+    "value": "6B778C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:147"
+    ]
+  },
+  {
+    "value": "6B7A8D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1107"
+    ]
+  },
+  {
+    "value": "6B8976",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2372"
+    ]
+  },
+  {
+    "value": "6C8195",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2448"
+    ]
+  },
+  {
+    "value": "6D7C8F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1300"
+    ]
+  },
+  {
+    "value": "6E9FE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1972",
+      "static/ui-kit.css:811"
+    ]
+  },
+  {
+    "value": "6F7D73",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1704"
+    ]
+  },
+  {
+    "value": "6F7E90",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1333"
+    ]
+  },
+  {
+    "value": "6F94C6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1005"
+    ]
+  },
+  {
+    "value": "6FA67C",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:3067",
+      "static/style-part2.css:3068"
+    ]
+  },
+  {
+    "value": "6FAC88",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2313"
+    ]
+  },
+  {
+    "value": "6FDC8C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2125"
+    ]
+  },
+  {
+    "value": "708399",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:882"
+    ]
+  },
+  {
+    "value": "718095",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1182"
+    ]
+  },
+  {
+    "value": "718096",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:889"
+    ]
+  },
+  {
+    "value": "718198",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part2.css:2210",
+      "static/style-part2.css:2362",
+      "static/style-part3.css:131",
+      "static/ui-kit.css:2596"
+    ]
+  },
+  {
+    "value": "718399",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2071"
+    ]
+  },
+  {
+    "value": "71879B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2788"
+    ]
+  },
+  {
+    "value": "72B8FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:619"
+    ]
+  },
+  {
+    "value": "72D69A",
+    "verdict": "semantic-status-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3736",
+      "static/ui-kit.css:3238"
+    ]
+  },
+  {
+    "value": "738096",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/ui-kit.css:1226",
+      "static/ui-kit.css:1227",
+      "static/ui-kit.css:1228",
+      "static/ui-kit.css:1228",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1232"
+    ]
+  },
+  {
+    "value": "738191",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:3018",
+      "static/style-part2.css:3084"
+    ]
+  },
+  {
+    "value": "73ADFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2072"
+    ]
+  },
+  {
+    "value": "73B2FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3227"
+    ]
+  },
+  {
+    "value": "744047",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2228"
+    ]
+  },
+  {
+    "value": "748278",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1675"
+    ]
+  },
+  {
+    "value": "75869C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1041"
+    ]
+  },
+  {
+    "value": "76602F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2234"
+    ]
+  },
+  {
+    "value": "77869A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3020"
+    ]
+  },
+  {
+    "value": "788596",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1328"
+    ]
+  },
+  {
+    "value": "78899E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1048"
+    ]
+  },
+  {
+    "value": "7890AA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3515"
+    ]
+  },
+  {
+    "value": "78B6FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3244"
+    ]
+  },
+  {
+    "value": "79879A",
+    "verdict": "ui-normalization-candidate",
+    "count": 12,
+    "locations": [
+      "static/style-part3.css:972",
+      "static/style-part3.css:995",
+      "static/style-part3.css:1094",
+      "static/style-part3.css:1125",
+      "static/style-part3.css:1135",
+      "static/style-part3.css:1142",
+      "static/style-part3.css:1174",
+      "static/style-part3.css:2122",
+      "static/style-part4.css:3727",
+      "static/style-part4.css:3755",
+      "static/style-part4.css:3878",
+      "static/style-part4.css:3896"
+    ]
+  },
+  {
+    "value": "7A6A2A",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:925",
+      "static/style-part1.css:1090",
+      "static/style-part1.css:1757"
+    ]
+  },
+  {
+    "value": "7A6A5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:364"
+    ]
+  },
+  {
+    "value": "7A6B5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:739"
+    ]
+  },
+  {
+    "value": "7A8391",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:865"
+    ]
+  },
+  {
+    "value": "7A8595",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:172"
+    ]
+  },
+  {
+    "value": "7A8794",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:1791",
+      "static/style-part2.css:1829",
+      "static/style-part2.css:1911"
+    ]
+  },
+  {
+    "value": "7A8798",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:286",
+      "static/ui-kit.css:878",
+      "static/ui-kit.css:3139"
+    ]
+  },
+  {
+    "value": "7A8AA0",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:3431",
+      "static/style-part2.css:3488",
+      "static/style-part2.css:3531",
+      "static/style-part2.css:3927",
+      "static/style-part3.css:3377"
+    ]
+  },
+  {
+    "value": "7A8AAA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:987"
+    ]
+  },
+  {
+    "value": "7A8BA0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1048"
+    ]
+  },
+  {
+    "value": "7A8CA5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:992"
+    ]
+  },
+  {
+    "value": "7B5D16",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2595"
+    ]
+  },
+  {
+    "value": "7B8492",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:949"
+    ]
+  },
+  {
+    "value": "7B8796",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part2.css:220",
+      "static/style-part3.css:656",
+      "static/style-part3.css:706",
+      "static/style-part3.css:859",
+      "static/style-part3.css:3661",
+      "static/style-part3.css:3729",
+      "static/style-part3.css:3730"
+    ]
+  },
+  {
+    "value": "7C641D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:925"
+    ]
+  },
+  {
+    "value": "7C8999",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1209"
+    ]
+  },
+  {
+    "value": "7D8FA1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2732"
+    ]
+  },
+  {
+    "value": "7D91A7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:2040",
+      "static/style-part4.css:2385"
+    ]
+  },
+  {
+    "value": "7E2530",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:808"
+    ]
+  },
+  {
+    "value": "7EB28D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1880"
+    ]
+  },
+  {
+    "value": "7EB391",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2510"
+    ]
+  },
+  {
+    "value": "7F8D9D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3603"
+    ]
+  },
+  {
+    "value": "7F8FA2",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:527",
+      "static/ui-kit.css:611"
+    ]
+  },
+  {
+    "value": "7FB0DC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:4022"
+    ]
+  },
+  {
+    "value": "806A25",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1270"
+    ]
+  },
+  {
+    "value": "813842",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3239"
+    ]
+  },
+  {
+    "value": "8293A5",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2423",
+      "static/style-part3.css:2503"
+    ]
+  },
+  {
+    "value": "8297AB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1682"
+    ]
+  },
+  {
+    "value": "829BB5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3169"
+    ]
+  },
+  {
+    "value": "8390A0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1234"
+    ]
+  },
+  {
+    "value": "8492A6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1042"
+    ]
+  },
+  {
+    "value": "8592A3",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:2710",
+      "static/style-part2.css:2750",
+      "static/style-part2.css:2771"
+    ]
+  },
+  {
+    "value": "86EFAC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1181"
+    ]
+  },
+  {
+    "value": "8793A2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1249"
+    ]
+  },
+  {
+    "value": "8794A4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1366"
+    ]
+  },
+  {
+    "value": "8795A8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2532"
+    ]
+  },
+  {
+    "value": "8798AD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3088"
+    ]
+  },
+  {
+    "value": "87BCE7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:265"
+    ]
+  },
+  {
+    "value": "8995A2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3043"
+    ]
+  },
+  {
+    "value": "8995A5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:911"
+    ]
+  },
+  {
+    "value": "8A3A2A",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:942",
+      "static/style-part1.css:1457"
+    ]
+  },
+  {
+    "value": "8A3A3A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2515"
+    ]
+  },
+  {
+    "value": "8A5A00",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1589"
+    ]
+  },
+  {
+    "value": "8A6A5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1121"
+    ]
+  },
+  {
+    "value": "8A7A4A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:915"
+    ]
+  },
+  {
+    "value": "8A94A3",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:153",
+      "static/style-part3.css:785"
+    ]
+  },
+  {
+    "value": "8A95A4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:817"
+    ]
+  },
+  {
+    "value": "8A96A5",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:1388",
+      "static/style-part3.css:1397",
+      "static/style-part3.css:2130"
+    ]
+  },
+  {
+    "value": "8A96A6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:933"
+    ]
+  },
+  {
+    "value": "8A9AA8",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:3581",
+      "static/style-part2.css:3615",
+      "static/style-part2.css:3694",
+      "static/style-part2.css:3781",
+      "static/style-part2.css:3838"
+    ]
+  },
+  {
+    "value": "8A9BB5",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:728",
+      "static/style-part1.css:1781"
+    ]
+  },
+  {
+    "value": "8AB4D8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1733"
+    ]
+  },
+  {
+    "value": "8ABEFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3231"
+    ]
+  },
+  {
+    "value": "8ABF99",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1729",
+      "static/style-part2.css:1892"
+    ]
+  },
+  {
+    "value": "8AC39A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2581"
+    ]
+  },
+  {
+    "value": "8B3D34",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2601"
+    ]
+  },
+  {
+    "value": "8B94A3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:854"
+    ]
+  },
+  {
+    "value": "8BA0B7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2538"
+    ]
+  },
+  {
+    "value": "8BB7EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3484"
+    ]
+  },
+  {
+    "value": "8BC0FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:3984",
+      "static/ui-kit.css:1723",
+      "static/ui-kit.css:1726"
+    ]
+  },
+  {
+    "value": "8BC34A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:644"
+    ]
+  },
+  {
+    "value": "8CE2B5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2217"
+    ]
+  },
+  {
+    "value": "8D4650",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3526"
+    ]
+  },
+  {
+    "value": "8EA6BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2540"
+    ]
+  },
+  {
+    "value": "8EB8DD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2587"
+    ]
+  },
+  {
+    "value": "8F1D14",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:113"
+    ]
+  },
+  {
+    "value": "8FA3B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1960"
+    ]
+  },
+  {
+    "value": "8FA7C2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2928"
+    ]
+  },
+  {
+    "value": "8FB8FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3397"
+    ]
+  },
+  {
+    "value": "8FC4FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3456"
+    ]
+  },
+  {
+    "value": "8FC5FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1930"
+    ]
+  },
+  {
+    "value": "8FC7F0",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3739"
+    ]
+  },
+  {
+    "value": "90A5BA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3218"
+    ]
+  },
+  {
+    "value": "90A6BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2636"
+    ]
+  },
+  {
+    "value": "90B080",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:1013",
+      "static/style-part1.css:1138"
+    ]
+  },
+  {
+    "value": "914343",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:729"
+    ]
+  },
+  {
+    "value": "91A2B6",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1140",
+      "static/ui-kit.css:1163",
+      "static/ui-kit.css:3010"
+    ]
+  },
+  {
+    "value": "91A4B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2172"
+    ]
+  },
+  {
+    "value": "91A6BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1838"
+    ]
+  },
+  {
+    "value": "91A7BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2070"
+    ]
+  },
+  {
+    "value": "91A8BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:636"
+    ]
+  },
+  {
+    "value": "927FB2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3640"
+    ]
+  },
+  {
+    "value": "93463C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1282"
+    ]
+  },
+  {
+    "value": "93A2B3",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part4.css:3693",
+      "static/style-part4.css:3779",
+      "static/style-part4.css:3794",
+      "static/style-part4.css:3810",
+      "static/style-part4.css:3817",
+      "static/style-part4.css:3927"
+    ]
+  },
+  {
+    "value": "946316",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:3013",
+      "static/style-part3.css:3724"
+    ]
+  },
+  {
+    "value": "94A3B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:1499",
+      "static/style-part2.css:1525",
+      "static/style-part2.css:1541",
+      "static/style-part2.css:1573",
+      "static/style-part2.css:1600"
+    ]
+  },
+  {
+    "value": "94A8BD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2432"
+    ]
+  },
+  {
+    "value": "94C7A5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2451"
+    ]
+  },
+  {
+    "value": "96A6B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1098"
+    ]
+  },
+  {
+    "value": "986500",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1768"
+    ]
+  },
+  {
+    "value": "99434E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3246"
+    ]
+  },
+  {
+    "value": "9A3434",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:931",
+      "static/style-part3.css:1121"
+    ]
+  },
+  {
+    "value": "9A5A4A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:932"
+    ]
+  },
+  {
+    "value": "9A5B00",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1166"
+    ]
+  },
+  {
+    "value": "9AA0A6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:331"
+    ]
+  },
+  {
+    "value": "9AA4B2",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:17",
+      "static/style-part3.css:22"
+    ]
+  },
+  {
+    "value": "9AA4B7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3393"
+    ]
+  },
+  {
+    "value": "9AA5B4",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:2887",
+      "static/style-part3.css:3218",
+      "static/style-part3.css:3320",
+      "static/style-part3.css:3326",
+      "static/style-part3.css:3819"
+    ]
+  },
+  {
+    "value": "9AA5B5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1058"
+    ]
+  },
+  {
+    "value": "9AA7B5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3261"
+    ]
+  },
+  {
+    "value": "9AA8B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:477",
+      "static/ui-kit.css:522",
+      "static/ui-kit.css:606"
+    ]
+  },
+  {
+    "value": "9AA8BA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:439",
+      "static/style-part3.css:1117"
+    ]
+  },
+  {
+    "value": "9B6B18",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3601"
+    ]
+  },
+  {
+    "value": "9B7421",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1312",
+      "static/style-part4.css:953"
+    ]
+  },
+  {
+    "value": "9B78C4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1137"
+    ]
+  },
+  {
+    "value": "9BC7FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3128"
+    ]
+  },
+  {
+    "value": "9DB0C1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:596"
+    ]
+  },
+  {
+    "value": "9E7BC7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1996",
+      "static/style-part4.css:1998"
+    ]
+  },
+  {
+    "value": "9EB1C6",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2034",
+      "static/ui-kit.css:2083"
+    ]
+  },
+  {
+    "value": "9EB3C8",
+    "verdict": "ui-normalization-candidate",
+    "count": 16,
+    "locations": [
+      "static/style-part4.css:3198",
+      "static/style-part4.css:3252 [comment]",
+      "static/style-part4.css:3259",
+      "static/style-part4.css:3325",
+      "static/style-part4.css:3380",
+      "static/style-part4.css:3404",
+      "static/style-part4.css:3407",
+      "static/style-part4.css:3974 [comment]",
+      "static/style-part4.css:3983",
+      "static/style-part4.css:3985",
+      "static/style-part4.css:3996",
+      "static/style-part4.css:4023",
+      "static/style-part4.css:4027 [comment]",
+      "static/style-part4.css:4036",
+      "static/style-part4.css:4038",
+      "static/style-part4.css:4039"
+    ]
+  },
+  {
+    "value": "9EB5C9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3068"
+    ]
+  },
+  {
+    "value": "9ECBB0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2301"
+    ]
+  },
+  {
+    "value": "9FB0C2",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2157",
+      "static/ui-kit.css:2475"
+    ]
+  },
+  {
+    "value": "9FB0C3",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:2276",
+      "static/ui-kit.css:3269",
+      "static/ui-kit.css:3281"
+    ]
+  },
+  {
+    "value": "9FB0C5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1198"
+    ]
+  },
+  {
+    "value": "9FB1C4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1887"
+    ]
+  },
+  {
+    "value": "9FB1C5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2654"
+    ]
+  },
+  {
+    "value": "9FB3C8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3168"
+    ]
+  },
+  {
+    "value": "9FB4CC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1978"
+    ]
+  },
+  {
+    "value": "A12B2B",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1168",
+      "static/style-part4.css:1175"
+    ]
+  },
+  {
+    "value": "A16207",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1305"
+    ]
+  },
+  {
+    "value": "A23E48",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:322"
+    ]
+  },
+  {
+    "value": "A32929",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2433",
+      "static/style-part4.css:3341 [comment]"
+    ]
+  },
+  {
+    "value": "A33F3F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:848"
+    ]
+  },
+  {
+    "value": "A43D45",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:317",
+      "static/style-part3.css:3725",
+      "static/style-part4.css:3906"
+    ]
+  },
+  {
+    "value": "A5AFBA",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:3007",
+      "static/style-part2.css:3013",
+      "static/style-part2.css:3240"
+    ]
+  },
+  {
+    "value": "A784CE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1146"
+    ]
+  },
+  {
+    "value": "A8B0BA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1242"
+    ]
+  },
+  {
+    "value": "A93E46",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3602"
+    ]
+  },
+  {
+    "value": "A985D3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2297"
+    ]
+  },
+  {
+    "value": "A9BAC9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:618"
+    ]
+  },
+  {
+    "value": "A9BED1",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:3185",
+      "static/style-part4.css:3383"
+    ]
+  },
+  {
+    "value": "A9CBB3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1274"
+    ]
+  },
+  {
+    "value": "AAB5C0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3699"
+    ]
+  },
+  {
+    "value": "AD5360",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3241"
+    ]
+  },
+  {
+    "value": "AEB7C1",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:3297",
+      "static/style-part2.css:3362",
+      "static/style-part4.css:3585 [comment]"
+    ]
+  },
+  {
+    "value": "AEB9C8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1036"
+    ]
+  },
+  {
+    "value": "AEBDCD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1177"
+    ]
+  },
+  {
+    "value": "AEBDCE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1653"
+    ]
+  },
+  {
+    "value": "AEBED0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2464"
+    ]
+  },
+  {
+    "value": "AFC2D5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3521"
+    ]
+  },
+  {
+    "value": "B04A4A",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1472"
+    ]
+  },
+  {
+    "value": "B0A090",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1376"
+    ]
+  },
+  {
+    "value": "B0B0B0",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:969",
+      "static/style-part1.css:1271"
+    ]
+  },
+  {
+    "value": "B0B8C5",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:984",
+      "static/style-part1.css:1952",
+      "static/style-part2.css:3639"
+    ]
+  },
+  {
+    "value": "B0C8A0",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:1000",
+      "static/style-part1.css:1126"
+    ]
+  },
+  {
+    "value": "B0C8F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1987"
+    ]
+  },
+  {
+    "value": "B0D0B0",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1089"
+    ]
+  },
+  {
+    "value": "B14B4B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1306"
+    ]
+  },
+  {
+    "value": "B17A00",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3538"
+    ]
+  },
+  {
+    "value": "B42318",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:107",
+      "static/style-part4.css:1310",
+      "static/style-part4.css:3503"
+    ]
+  },
+  {
+    "value": "B43842",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3544"
+    ]
+  },
+  {
+    "value": "B79AD9",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:1129",
+      "static/style-part4.css:1150",
+      "static/style-part4.css:1997"
+    ]
+  },
+  {
+    "value": "B7C1D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3342"
+    ]
+  },
+  {
+    "value": "B7C6D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:2186",
+      "static/ui-kit.css:3258"
+    ]
+  },
+  {
+    "value": "B7D8C0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1658"
+    ]
+  },
+  {
+    "value": "B82736",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:978"
+    ]
+  },
+  {
+    "value": "B83B47",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1045",
+      "static/style-part4.css:1125"
+    ]
+  },
+  {
+    "value": "B8C6D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1121"
+    ]
+  },
+  {
+    "value": "B8C9D8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:976"
+    ]
+  },
+  {
+    "value": "B8CBE0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2660"
+    ]
+  },
+  {
+    "value": "B8CCE2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:403"
+    ]
+  },
+  {
+    "value": "B91C1C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:664"
+    ]
+  },
+  {
+    "value": "B97870",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:3077",
+      "static/style-part2.css:3078"
+    ]
+  },
+  {
+    "value": "B9C6D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1180"
+    ]
+  },
+  {
+    "value": "B9C7D6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2575"
+    ]
+  },
+  {
+    "value": "B9C7DB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1967",
+      "static/ui-kit.css:804"
+    ]
+  },
+  {
+    "value": "B9C8D8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:259",
+      "static/ui-kit.css:308"
+    ]
+  },
+  {
+    "value": "B9C9DA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1290",
+      "static/ui-kit.css:2223"
+    ]
+  },
+  {
+    "value": "B9DFC9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1294"
+    ]
+  },
+  {
+    "value": "BDCADA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1831"
+    ]
+  },
+  {
+    "value": "BDCCDC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3121"
+    ]
+  },
+  {
+    "value": "BDD0E4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3732"
+    ]
+  },
+  {
+    "value": "BFD0DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:892"
+    ]
+  },
+  {
+    "value": "BFD0E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:906"
+    ]
+  },
+  {
+    "value": "C0392B",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1928",
+      "static/style-part3.css:1058"
+    ]
+  },
+  {
+    "value": "C08880",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1381"
+    ]
+  },
+  {
+    "value": "C0A040",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:1382",
+      "static/style-part1.css:1753"
+    ]
+  },
+  {
+    "value": "C0A84A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:997"
+    ]
+  },
+  {
+    "value": "C0C8D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3468"
+    ]
+  },
+  {
+    "value": "C0D4E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:767",
+      "static/style-part1.css:1799",
+      "static/style-part1.css:2156",
+      "static/style-part1.css:2746"
+    ]
+  },
+  {
+    "value": "C2CEDA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2325"
+    ]
+  },
+  {
+    "value": "C3D1DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:3336 [comment]",
+      "static/ui-kit.css:3217"
+    ]
+  },
+  {
+    "value": "C3D3E2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3418"
+    ]
+  },
+  {
+    "value": "C3D3E3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2069"
+    ]
+  },
+  {
+    "value": "C4D3DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:641"
+    ]
+  },
+  {
+    "value": "C5D2DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1892"
+    ]
+  },
+  {
+    "value": "C62828",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:2583",
+      "static/style-part2.css:3513",
+      "static/style-part2.css:3988",
+      "static/style-part4.css:183"
+    ]
+  },
+  {
+    "value": "C6D7E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3193"
+    ]
+  },
+  {
+    "value": "C78616",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2893"
+    ]
+  },
+  {
+    "value": "C7A84D",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:3072",
+      "static/style-part2.css:3073"
+    ]
+  },
+  {
+    "value": "C7CED6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3060"
+    ]
+  },
+  {
+    "value": "C7D0DC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:950"
+    ]
+  },
+  {
+    "value": "C7D4E1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2899"
+    ]
+  },
+  {
+    "value": "C87D7D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2447"
+    ]
+  },
+  {
+    "value": "C8D3DE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:929"
+    ]
+  },
+  {
+    "value": "C8D3DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1048"
+    ]
+  },
+  {
+    "value": "C8D5E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2576"
+    ]
+  },
+  {
+    "value": "C9D5E1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2517"
+    ]
+  },
+  {
+    "value": "C9D7E6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2471"
+    ]
+  },
+  {
+    "value": "C9D8EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2505"
+    ]
+  },
+  {
+    "value": "C9E3FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3511"
+    ]
+  },
+  {
+    "value": "CAD4E0",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:1799",
+      "static/style-part2.css:1868",
+      "static/style-part3.css:1596"
+    ]
+  },
+  {
+    "value": "CAD5E2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1048"
+    ]
+  },
+  {
+    "value": "CBD4DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1213"
+    ]
+  },
+  {
+    "value": "CBD5DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:61"
+    ]
+  },
+  {
+    "value": "CBD5E1",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part2.css:617",
+      "static/style-part2.css:632",
+      "static/style-part2.css:1026",
+      "static/style-part2.css:1565",
+      "static/style-part3.css:2229",
+      "static/style-part4.css:3766",
+      "static/style-part4.css:3800",
+      "static/style-part4.css:3833"
+    ]
+  },
+  {
+    "value": "CBD6E1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2643"
+    ]
+  },
+  {
+    "value": "CBD7E4",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:758",
+      "static/ui-kit.css:1113"
+    ]
+  },
+  {
+    "value": "CBD7E6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1011"
+    ]
+  },
+  {
+    "value": "CBD7E7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:231"
+    ]
+  },
+  {
+    "value": "CBD8CF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2265"
+    ]
+  },
+  {
+    "value": "CBD8E6",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part3.css:662",
+      "static/style-part4.css:2881",
+      "static/style-part4.css:2930",
+      "static/ui-kit.css:2040",
+      "static/ui-kit.css:3120"
+    ]
+  },
+  {
+    "value": "CBDFF7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:918"
+    ]
+  },
+  {
+    "value": "CCD3DC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2320"
+    ]
+  },
+  {
+    "value": "CCD5DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1261"
+    ]
+  },
+  {
+    "value": "CCD6E2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2250"
+    ]
+  },
+  {
+    "value": "CFD8E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:514"
+    ]
+  },
+  {
+    "value": "CFDAE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2611"
+    ]
+  },
+  {
+    "value": "D0D0D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:964",
+      "static/style-part1.css:1266",
+      "static/style-part1.css:1357"
+    ]
+  },
+  {
+    "value": "D0D8EC",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1179"
+    ]
+  },
+  {
+    "value": "D0E8D0",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1177"
+    ]
+  },
+  {
+    "value": "D2DEEA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1179"
+    ]
+  },
+  {
+    "value": "D34F5D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2905"
+    ]
+  },
+  {
+    "value": "D3D3D3",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part4.css:3659",
+      "static/style-part4.css:3660",
+      "static/style-part4.css:3661",
+      "static/style-part4.css:3662",
+      "static/style-part4.css:3668",
+      "static/style-part4.css:3669",
+      "static/style-part4.css:3670",
+      "static/style-part4.css:3671"
+    ]
+  },
+  {
+    "value": "D3DCE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:424"
+    ]
+  },
+  {
+    "value": "D3EBDA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1744",
+      "static/style-part2.css:1905"
+    ]
+  },
+  {
+    "value": "D4A31F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3558"
+    ]
+  },
+  {
+    "value": "D4B85A",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:926",
+      "static/style-part1.css:1747"
+    ]
+  },
+  {
+    "value": "D4C06A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:993"
+    ]
+  },
+  {
+    "value": "D4DBE5",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:201",
+      "static/style-part3.css:355"
+    ]
+  },
+  {
+    "value": "D4DDE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2285"
+    ]
+  },
+  {
+    "value": "D4E0F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:227"
+    ]
+  },
+  {
+    "value": "D5A4A4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2430"
+    ]
+  },
+  {
+    "value": "D5C8A8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:916"
+    ]
+  },
+  {
+    "value": "D5CBB8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:746"
+    ]
+  },
+  {
+    "value": "D5D0C0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2345"
+    ]
+  },
+  {
+    "value": "D5D0C8",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:779",
+      "static/style-part1.css:1195",
+      "static/style-part1.css:1667"
+    ]
+  },
+  {
+    "value": "D5D5D5",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:1091",
+      "static/style-part1.css:1456",
+      "static/style-part1.css:1475"
+    ]
+  },
+  {
+    "value": "D5D8DD",
+    "verdict": "ui-normalization-candidate",
+    "count": 20,
+    "locations": [
+      "static/style-part1.css:81",
+      "static/style-part1.css:402",
+      "static/style-part1.css:447",
+      "static/style-part1.css:573",
+      "static/style-part1.css:598",
+      "static/style-part1.css:631",
+      "static/style-part1.css:637",
+      "static/style-part1.css:720",
+      "static/style-part1.css:1631",
+      "static/style-part1.css:1772",
+      "static/style-part1.css:1940",
+      "static/style-part1.css:1975",
+      "static/style-part1.css:2239",
+      "static/style-part1.css:2262",
+      "static/style-part2.css:2256",
+      "static/style-part2.css:3627",
+      "static/style-part2.css:3711",
+      "static/style-part2.css:3761",
+      "static/style-part2.css:3861",
+      "static/style-part2.css:3958"
+    ]
+  },
+  {
+    "value": "D5DBE3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2411"
+    ]
+  },
+  {
+    "value": "D5DCE6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2673"
+    ]
+  },
+  {
+    "value": "D5DCE7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:1956",
+      "static/ui-kit.css:790"
+    ]
+  },
+  {
+    "value": "D5DDE5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1909"
+    ]
+  },
+  {
+    "value": "D5DEE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2440"
+    ]
+  },
+  {
+    "value": "D5DFEB",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part4.css:2036",
+      "static/style-part4.css:2346",
+      "static/style-part4.css:2379",
+      "static/style-part4.css:2403",
+      "static/style-part4.css:2752",
+      "static/style-part4.css:2829"
+    ]
+  },
+  {
+    "value": "D5E0EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:571",
+      "static/style-part3.css:60"
+    ]
+  },
+  {
+    "value": "D5E2EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1713"
+    ]
+  },
+  {
+    "value": "D5E9FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3499"
+    ]
+  },
+  {
+    "value": "D6E0EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1117"
+    ]
+  },
+  {
+    "value": "D74343",
+    "verdict": "semantic-status-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2839",
+      "static/style-part2.css:2895"
+    ]
+  },
+  {
+    "value": "D74755",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:994"
+    ]
+  },
+  {
+    "value": "D7DCE5",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part1.css:2941",
+      "static/style-part1.css:3185",
+      "static/style-part1.css:3219",
+      "static/style-part1.css:3232",
+      "static/style-part1.css:3260",
+      "static/style-part1.css:3285"
+    ]
+  },
+  {
+    "value": "D7DEE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part3.css:402",
+      "static/ui-kit.css:836",
+      "static/ui-kit.css:851",
+      "static/ui-kit.css:852",
+      "static/ui-kit.css:3137"
+    ]
+  },
+  {
+    "value": "D7E0E9",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:3008",
+      "static/style-part4.css:3492"
+    ]
+  },
+  {
+    "value": "D7E0EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/ui-kit.css:36",
+      "static/ui-kit.css:2682",
+      "static/ui-kit.css:3094",
+      "static/ui-kit.css:3164"
+    ]
+  },
+  {
+    "value": "D7E2EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1844"
+    ]
+  },
+  {
+    "value": "D7E4F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2093"
+    ]
+  },
+  {
+    "value": "D8A51D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3540"
+    ]
+  },
+  {
+    "value": "D8C788",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1268"
+    ]
+  },
+  {
+    "value": "D8DEE6",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part3.css:42",
+      "static/style-part3.css:294",
+      "static/style-part3.css:3425",
+      "static/style-part3.css:3437",
+      "static/style-part3.css:3515",
+      "static/style-part3.css:3617",
+      "static/style-part3.css:3637"
+    ]
+  },
+  {
+    "value": "D8DEE7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:208",
+      "static/style-part3.css:362"
+    ]
+  },
+  {
+    "value": "D8DEE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1007",
+      "static/style-part2.css:1103"
+    ]
+  },
+  {
+    "value": "D8E0E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:840",
+      "static/style-part4.css:846",
+      "static/style-part4.css:3106"
+    ]
+  },
+  {
+    "value": "D8E0EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:431",
+      "static/style-part4.css:999"
+    ]
+  },
+  {
+    "value": "D8E1EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2663",
+      "static/style-part3.css:2667"
+    ]
+  },
+  {
+    "value": "D8E1EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 11,
+    "locations": [
+      "static/style-part4.css:1221",
+      "static/style-part4.css:1381",
+      "static/style-part4.css:1459",
+      "static/style-part4.css:1595",
+      "static/style-part4.css:1610",
+      "static/style-part4.css:1656",
+      "static/style-part4.css:1705",
+      "static/style-part4.css:1713",
+      "static/style-part4.css:1794",
+      "static/style-part4.css:1874",
+      "static/ui-kit.css:2556"
+    ]
+  },
+  {
+    "value": "D8E2ED",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1935"
+    ]
+  },
+  {
+    "value": "D8E4F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:763",
+      "static/style-part1.css:1788",
+      "static/style-part1.css:2148",
+      "static/style-part1.css:2736",
+      "static/style-part2.css:172"
+    ]
+  },
+  {
+    "value": "D94B57",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:885"
+    ]
+  },
+  {
+    "value": "D9545F",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3546",
+      "static/style-part3.css:3564"
+    ]
+  },
+  {
+    "value": "D9606B",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:805",
+      "static/style-part4.css:818"
+    ]
+  },
+  {
+    "value": "D9988A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:943"
+    ]
+  },
+  {
+    "value": "D99B91",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2599"
+    ]
+  },
+  {
+    "value": "D9B437",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3324"
+    ]
+  },
+  {
+    "value": "D9BD72",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2593"
+    ]
+  },
+  {
+    "value": "D9E0E7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2718"
+    ]
+  },
+  {
+    "value": "D9E1EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/ui-kit.css:1211",
+      "static/ui-kit.css:1218",
+      "static/ui-kit.css:1222",
+      "static/ui-kit.css:1224",
+      "static/ui-kit.css:1228",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:1231",
+      "static/ui-kit.css:1232"
+    ]
+  },
+  {
+    "value": "D9E3EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:248"
+    ]
+  },
+  {
+    "value": "D9E7F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part4.css:3141",
+      "static/style-part4.css:3172",
+      "static/style-part4.css:3361",
+      "static/style-part4.css:3392",
+      "static/style-part4.css:3414"
+    ]
+  },
+  {
+    "value": "DB5A63",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:21"
+    ]
+  },
+  {
+    "value": "DBE2EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:995"
+    ]
+  },
+  {
+    "value": "DBE3EE",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:510",
+      "static/style-part2.css:582"
+    ]
+  },
+  {
+    "value": "DBE4EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1618",
+      "static/style-part4.css:1031"
+    ]
+  },
+  {
+    "value": "DBE5F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1197"
+    ]
+  },
+  {
+    "value": "DBE5F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/ui-kit.css:1051",
+      "static/ui-kit.css:1067",
+      "static/ui-kit.css:1081",
+      "static/ui-kit.css:1171",
+      "static/ui-kit.css:1506"
+    ]
+  },
+  {
+    "value": "DBE7F4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3517"
+    ]
+  },
+  {
+    "value": "DBE8F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part4.css:3228",
+      "static/style-part4.css:3310 [comment]",
+      "static/style-part4.css:3316",
+      "static/style-part4.css:3321",
+      "static/style-part4.css:3982",
+      "static/style-part4.css:4006",
+      "static/style-part4.css:4014",
+      "static/style-part4.css:4026 [comment]",
+      "static/style-part4.css:4037"
+    ]
+  },
+  {
+    "value": "DBE8F7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2725"
+    ]
+  },
+  {
+    "value": "DBEAFD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3103"
+    ]
+  },
+  {
+    "value": "DBEAFE",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:436",
+      "static/style-part2.css:593",
+      "static/style-part2.css:642"
+    ]
+  },
+  {
+    "value": "DC2626",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1512"
+    ]
+  },
+  {
+    "value": "DCCFAD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:922"
+    ]
+  },
+  {
+    "value": "DCE3EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1764",
+      "static/style-part2.css:1814"
+    ]
+  },
+  {
+    "value": "DCE4ED",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:915",
+      "static/style-part3.css:1021",
+      "static/style-part3.css:1152"
+    ]
+  },
+  {
+    "value": "DCE6F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1875"
+    ]
+  },
+  {
+    "value": "DCE7F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1046"
+    ]
+  },
+  {
+    "value": "DCE8F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2204"
+    ]
+  },
+  {
+    "value": "DCE8F6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2620"
+    ]
+  },
+  {
+    "value": "DCEAFB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:908"
+    ]
+  },
+  {
+    "value": "DDE6EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1219"
+    ]
+  },
+  {
+    "value": "DDE8F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1738"
+    ]
+  },
+  {
+    "value": "DF4B5A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3292"
+    ]
+  },
+  {
+    "value": "DF5B64",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part2.css:3328",
+      "static/style-part2.css:3358",
+      "static/style-part4.css:3584 [comment]",
+      "static/style-part4.css:3599"
+    ]
+  },
+  {
+    "value": "DF5D68",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:614",
+      "static/style-part4.css:628",
+      "static/style-part4.css:763"
+    ]
+  },
+  {
+    "value": "DF6B76",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:822",
+      "static/style-part4.css:829"
+    ]
+  },
+  {
+    "value": "DFB3B3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:929"
+    ]
+  },
+  {
+    "value": "DFB5AF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1280"
+    ]
+  },
+  {
+    "value": "DFE3EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:3027",
+      "static/style-part2.css:52",
+      "static/style-part2.css:145"
+    ]
+  },
+  {
+    "value": "DFE4EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part2.css:2642",
+      "static/style-part2.css:2718",
+      "static/style-part2.css:2753",
+      "static/style-part3.css:191",
+      "static/style-part3.css:337",
+      "static/style-part3.css:344"
+    ]
+  },
+  {
+    "value": "DFE5EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part3.css:632",
+      "static/style-part3.css:718",
+      "static/style-part3.css:749",
+      "static/style-part3.css:1799",
+      "static/style-part3.css:1827",
+      "static/style-part3.css:1853",
+      "static/style-part3.css:1881",
+      "static/style-part4.css:67"
+    ]
+  },
+  {
+    "value": "DFE5EE",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:408",
+      "static/style-part2.css:736"
+    ]
+  },
+  {
+    "value": "DFE7F2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:229"
+    ]
+  },
+  {
+    "value": "DFE8F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:843"
+    ]
+  },
+  {
+    "value": "DFE9F4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3626"
+    ]
+  },
+  {
+    "value": "DFF2E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2521"
+    ]
+  },
+  {
+    "value": "E05D68",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2954"
+    ]
+  },
+  {
+    "value": "E0B667",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:961"
+    ]
+  },
+  {
+    "value": "E0C8B8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1096"
+    ]
+  },
+  {
+    "value": "E0C8C0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:933"
+    ]
+  },
+  {
+    "value": "E0C98B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:923"
+    ]
+  },
+  {
+    "value": "E0E0E0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1502"
+    ]
+  },
+  {
+    "value": "E0E6EE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3949"
+    ]
+  },
+  {
+    "value": "E0E7EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:1217",
+      "static/style-part3.css:1218",
+      "static/style-part3.css:1326"
+    ]
+  },
+  {
+    "value": "E0F2FE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:655"
+    ]
+  },
+  {
+    "value": "E0F3E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2457"
+    ]
+  },
+  {
+    "value": "E14D68",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:1990",
+      "static/style-part4.css:1991",
+      "static/style-part4.css:1992",
+      "static/style-part4.css:2293"
+    ]
+  },
+  {
+    "value": "E1E6ED",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3651",
+      "static/style-part3.css:3704"
+    ]
+  },
+  {
+    "value": "E1E9F2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3141"
+    ]
+  },
+  {
+    "value": "E2BD45",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:271"
+    ]
+  },
+  {
+    "value": "E2E8F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:444",
+      "static/style-part2.css:524"
+    ]
+  },
+  {
+    "value": "E2EBF5",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:674",
+      "static/ui-kit.css:3119"
+    ]
+  },
+  {
+    "value": "E2F3E7",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:1731",
+      "static/style-part2.css:1894",
+      "static/style-part2.css:2314"
+    ]
+  },
+  {
+    "value": "E3E8EE",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:129",
+      "static/style-part4.css:160"
+    ]
+  },
+  {
+    "value": "E4EAF1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3095"
+    ]
+  },
+  {
+    "value": "E4EBF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:47"
+    ]
+  },
+  {
+    "value": "E4EDF7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1146",
+      "static/ui-kit.css:3009"
+    ]
+  },
+  {
+    "value": "E5E5E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:975"
+    ]
+  },
+  {
+    "value": "E5E7EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:461",
+      "static/style-part2.css:1440"
+    ]
+  },
+  {
+    "value": "E5E8EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 32,
+    "locations": [
+      "static/style-part1.css:112",
+      "static/style-part1.css:358",
+      "static/style-part1.css:388",
+      "static/style-part1.css:477",
+      "static/style-part1.css:562",
+      "static/style-part1.css:654",
+      "static/style-part1.css:1907",
+      "static/style-part1.css:2071",
+      "static/style-part1.css:2116",
+      "static/style-part1.css:2128",
+      "static/style-part1.css:2188",
+      "static/style-part1.css:2213",
+      "static/style-part1.css:2387",
+      "static/style-part1.css:2472",
+      "static/style-part1.css:2534",
+      "static/style-part1.css:2624",
+      "static/style-part1.css:2636",
+      "static/style-part1.css:2703",
+      "static/style-part1.css:2722",
+      "static/style-part1.css:3102",
+      "static/style-part2.css:2055",
+      "static/style-part2.css:2069",
+      "static/style-part2.css:2135",
+      "static/style-part2.css:2143",
+      "static/style-part2.css:3520",
+      "static/style-part2.css:3575",
+      "static/style-part2.css:3664",
+      "static/style-part2.css:3740",
+      "static/style-part2.css:3824",
+      "static/style-part2.css:3893",
+      "static/style-part2.css:3989",
+      "static/style-part3.css:643"
+    ]
+  },
+  {
+    "value": "E5EAF0",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:863",
+      "static/ui-kit.css:3136"
+    ]
+  },
+  {
+    "value": "E5EFF8",
+    "verdict": "ui-normalization-candidate",
+    "count": 16,
+    "locations": [
+      "static/style-part4.css:3216",
+      "static/style-part4.css:3222",
+      "static/style-part4.css:3252 [comment]",
+      "static/style-part4.css:3262",
+      "static/style-part4.css:3401",
+      "static/style-part4.css:3410",
+      "static/style-part4.css:3425",
+      "static/style-part4.css:3974 [comment]",
+      "static/style-part4.css:3981",
+      "static/style-part4.css:3988",
+      "static/style-part4.css:4002",
+      "static/style-part4.css:4013",
+      "static/style-part4.css:4021",
+      "static/style-part4.css:4026 [comment]",
+      "static/style-part4.css:4034",
+      "static/style-part4.css:4035"
+    ]
+  },
+  {
+    "value": "E6505D",
+    "verdict": "semantic-status-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:60",
+      "static/ui-kit.css:61",
+      "static/ui-kit.css:3112"
+    ]
+  },
+  {
+    "value": "E6AD22",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3110"
+    ]
+  },
+  {
+    "value": "E6C765",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:256"
+    ]
+  },
+  {
+    "value": "E6E9EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:2837",
+      "static/style-part1.css:2873",
+      "static/style-part2.css:1946"
+    ]
+  },
+  {
+    "value": "E6ECF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part3.css:1078",
+      "static/style-part4.css:3704",
+      "static/style-part4.css:3844",
+      "static/style-part4.css:3873",
+      "static/style-part4.css:3938"
+    ]
+  },
+  {
+    "value": "E6EEF8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2517"
+    ]
+  },
+  {
+    "value": "E6F1FA",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3726"
+    ]
+  },
+  {
+    "value": "E6F7EC",
+    "verdict": "semantic-status-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1766",
+      "static/style-part4.css:1767"
+    ]
+  },
+  {
+    "value": "E7AF27",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:20"
+    ]
+  },
+  {
+    "value": "E7E7E7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:482"
+    ]
+  },
+  {
+    "value": "E7EBEF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1250"
+    ]
+  },
+  {
+    "value": "E7EBF0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:119"
+    ]
+  },
+  {
+    "value": "E7EDF4",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:2037",
+      "static/style-part4.css:2353"
+    ]
+  },
+  {
+    "value": "E7EDF5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3390"
+    ]
+  },
+  {
+    "value": "E7EEF7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1107"
+    ]
+  },
+  {
+    "value": "E7EEF8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:292"
+    ]
+  },
+  {
+    "value": "E7F1FD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3485"
+    ]
+  },
+  {
+    "value": "E7F5EC",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3723"
+    ]
+  },
+  {
+    "value": "E8A89E",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:945",
+      "static/style-part1.css:1458"
+    ]
+  },
+  {
+    "value": "E8B437",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:3354",
+      "static/style-part4.css:3583 [comment]",
+      "static/style-part4.css:3595"
+    ]
+  },
+  {
+    "value": "E8B9BD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:319"
+    ]
+  },
+  {
+    "value": "E8C86A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1378"
+    ]
+  },
+  {
+    "value": "E8D0CC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:939"
+    ]
+  },
+  {
+    "value": "E8D5D5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:990"
+    ]
+  },
+  {
+    "value": "E8D8A0",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1090"
+    ]
+  },
+  {
+    "value": "E8DCC8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:738"
+    ]
+  },
+  {
+    "value": "E8DDC0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:914"
+    ]
+  },
+  {
+    "value": "E8DDC8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3501"
+    ]
+  },
+  {
+    "value": "E8E0D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2340"
+    ]
+  },
+  {
+    "value": "E8E0D5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:365"
+    ]
+  },
+  {
+    "value": "E8E0F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:228"
+    ]
+  },
+  {
+    "value": "E8E5E0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:986"
+    ]
+  },
+  {
+    "value": "E8E8E8",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:1409",
+      "static/style-part1.css:1455",
+      "static/style-part1.css:1474",
+      "static/style-part4.css:3914"
+    ]
+  },
+  {
+    "value": "E8EAED",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part1.css:77",
+      "static/style-part1.css:672",
+      "static/style-part1.css:1846",
+      "static/style-part1.css:2090",
+      "static/style-part1.css:2495",
+      "static/style-part1.css:2506",
+      "static/style-part1.css:2658",
+      "static/style-part2.css:3391"
+    ]
+  },
+  {
+    "value": "E8ECF0",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:224",
+      "static/style-part1.css:463",
+      "static/style-part1.css:529"
+    ]
+  },
+  {
+    "value": "E8ECF5",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1178"
+    ]
+  },
+  {
+    "value": "E8EDF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:691"
+    ]
+  },
+  {
+    "value": "E8EDF4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:896"
+    ]
+  },
+  {
+    "value": "E8EEF5",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1182",
+      "static/ui-kit.css:1883"
+    ]
+  },
+  {
+    "value": "E8EEF7",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:3491",
+      "static/style-part2.css:162",
+      "static/ui-kit.css:2124"
+    ]
+  },
+  {
+    "value": "E8F0E8",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1176"
+    ]
+  },
+  {
+    "value": "E8F0F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:571",
+      "static/style-part3.css:60"
+    ]
+  },
+  {
+    "value": "E8F0FE",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:3788",
+      "static/style-part2.css:3847"
+    ]
+  },
+  {
+    "value": "E8F2FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:893"
+    ]
+  },
+  {
+    "value": "E8F6EC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2582"
+    ]
+  },
+  {
+    "value": "E9B53C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3287"
+    ]
+  },
+  {
+    "value": "E9EDF2",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:769",
+      "static/ui-kit.css:3075"
+    ]
+  },
+  {
+    "value": "E9EDF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:948"
+    ]
+  },
+  {
+    "value": "E9F7ED",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2512",
+      "static/style-part4.css:3341 [comment]"
+    ]
+  },
+  {
+    "value": "E9F8F0",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3109"
+    ]
+  },
+  {
+    "value": "EAD0D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:726"
+    ]
+  },
+  {
+    "value": "EAD8AE",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1310"
+    ]
+  },
+  {
+    "value": "EAF1F7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2901"
+    ]
+  },
+  {
+    "value": "EAF2FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:2138",
+      "static/ui-kit.css:2269",
+      "static/ui-kit.css:2270"
+    ]
+  },
+  {
+    "value": "EAF2FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1006"
+    ]
+  },
+  {
+    "value": "EAF2FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2112"
+    ]
+  },
+  {
+    "value": "EAF3FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:2588",
+      "static/style-part4.css:578",
+      "static/style-part4.css:616"
+    ]
+  },
+  {
+    "value": "EAF3FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:1814",
+      "static/style-part3.css:1868",
+      "static/ui-kit.css:3102",
+      "static/ui-kit.css:3115"
+    ]
+  },
+  {
+    "value": "EAF4FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:624",
+      "static/style-part4.css:753"
+    ]
+  },
+  {
+    "value": "EBC5C9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:276"
+    ]
+  },
+  {
+    "value": "ECD0D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:2523"
+    ]
+  },
+  {
+    "value": "ECD5D5",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1473"
+    ]
+  },
+  {
+    "value": "ECEFF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:203"
+    ]
+  },
+  {
+    "value": "EDC5C5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1304"
+    ]
+  },
+  {
+    "value": "EDCC6A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:928"
+    ]
+  },
+  {
+    "value": "EDEBE7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:778"
+    ]
+  },
+  {
+    "value": "EDF0F3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:139"
+    ]
+  },
+  {
+    "value": "EDF0F4",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:3110",
+      "static/style-part1.css:3272",
+      "static/style-part2.css:2758",
+      "static/ui-kit.css:902"
+    ]
+  },
+  {
+    "value": "EDF1F6",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1341",
+      "static/ui-kit.css:1227"
+    ]
+  },
+  {
+    "value": "EDF2F7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:836",
+      "static/style-part4.css:3007"
+    ]
+  },
+  {
+    "value": "EDF3F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1238",
+      "static/style-part4.css:931"
+    ]
+  },
+  {
+    "value": "EDF3F9",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:664",
+      "static/ui-kit.css:3118"
+    ]
+  },
+  {
+    "value": "EDF3FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part1.css:2952",
+      "static/style-part2.css:2682",
+      "static/style-part3.css:1968",
+      "static/ui-kit.css:805"
+    ]
+  },
+  {
+    "value": "EDF4FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 8,
+    "locations": [
+      "static/style-part4.css:2035",
+      "static/style-part4.css:2397",
+      "static/style-part4.css:2803",
+      "static/style-part4.css:2831",
+      "static/ui-kit.css:1090",
+      "static/ui-kit.css:1129",
+      "static/ui-kit.css:2176",
+      "static/ui-kit.css:2197"
+    ]
+  },
+  {
+    "value": "EDF4FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:102"
+    ]
+  },
+  {
+    "value": "EDF5FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/ui-kit.css:1213",
+      "static/ui-kit.css:1225",
+      "static/ui-kit.css:1226",
+      "static/ui-kit.css:1230",
+      "static/ui-kit.css:2029",
+      "static/ui-kit.css:2087"
+    ]
+  },
+  {
+    "value": "EEF0F4",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:3040",
+      "static/style-part1.css:3060"
+    ]
+  },
+  {
+    "value": "EEF1F6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2855"
+    ]
+  },
+  {
+    "value": "EEF2F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part2.css:3449",
+      "static/style-part2.css:3638",
+      "static/style-part2.css:3720",
+      "static/style-part2.css:3770",
+      "static/style-part2.css:3870",
+      "static/style-part2.css:3923",
+      "static/style-part2.css:3941"
+    ]
+  },
+  {
+    "value": "EEF2F7",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:144",
+      "static/style-part3.css:3619",
+      "static/ui-kit.css:3070"
+    ]
+  },
+  {
+    "value": "EEF3F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 10,
+    "locations": [
+      "static/style-part2.css:1035",
+      "static/style-part2.css:1642",
+      "static/style-part2.css:2576",
+      "static/style-part4.css:2030",
+      "static/style-part4.css:3108",
+      "static/style-part4.css:3493",
+      "static/ui-kit.css:38",
+      "static/ui-kit.css:3074",
+      "static/ui-kit.css:3135",
+      "static/ui-kit.css:3140"
+    ]
+  },
+  {
+    "value": "EEF4F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1734"
+    ]
+  },
+  {
+    "value": "EEF4FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part3.css:917",
+      "static/style-part3.css:1023",
+      "static/style-part3.css:1154",
+      "static/style-part4.css:849"
+    ]
+  },
+  {
+    "value": "EEF4FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part4.css:1242",
+      "static/style-part4.css:1276",
+      "static/style-part4.css:1539",
+      "static/style-part4.css:1553",
+      "static/style-part4.css:1658",
+      "static/style-part4.css:1687",
+      "static/style-part4.css:1729",
+      "static/style-part4.css:1760",
+      "static/style-part4.css:1789"
+    ]
+  },
+  {
+    "value": "EEF4FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1986"
+    ]
+  },
+  {
+    "value": "EEF5FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1183"
+    ]
+  },
+  {
+    "value": "EEF5FD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2506"
+    ]
+  },
+  {
+    "value": "EEF5FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:511",
+      "static/style-part2.css:583",
+      "static/ui-kit.css:2436"
+    ]
+  },
+  {
+    "value": "EEF6FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part4.css:631",
+      "static/style-part4.css:851",
+      "static/style-part4.css:945"
+    ]
+  },
+  {
+    "value": "EEF6FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/ui-kit.css:1218",
+      "static/ui-kit.css:1973",
+      "static/ui-kit.css:1984",
+      "static/ui-kit.css:3252",
+      "static/ui-kit.css:3268",
+      "static/ui-kit.css:3280",
+      "static/ui-kit.css:3287"
+    ]
+  },
+  {
+    "value": "EEF8F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2302"
+    ]
+  },
+  {
+    "value": "EEF9F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2452",
+      "static/style-part4.css:3342 [comment]"
+    ]
+  },
+  {
+    "value": "EEFAF3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1295"
+    ]
+  },
+  {
+    "value": "EF4444",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:1329",
+      "static/style-part2.css:1513",
+      "static/style-part4.css:3060"
+    ]
+  },
+  {
+    "value": "EF4F5F",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:966",
+      "static/style-part4.css:967",
+      "static/style-part4.css:972",
+      "static/style-part4.css:1037"
+    ]
+  },
+  {
+    "value": "EFB6B1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3505"
+    ]
+  },
+  {
+    "value": "EFC8CC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:321"
+    ]
+  },
+  {
+    "value": "F0B8B0",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:941",
+      "static/style-part1.css:1457"
+    ]
+  },
+  {
+    "value": "F0C75E",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2126"
+    ]
+  },
+  {
+    "value": "F0C86A",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:3018",
+      "static/style-part3.css:3737",
+      "static/ui-kit.css:3240"
+    ]
+  },
+  {
+    "value": "F0DDDA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:931"
+    ]
+  },
+  {
+    "value": "F0E8D0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1752"
+    ]
+  },
+  {
+    "value": "F0EEEA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:986"
+    ]
+  },
+  {
+    "value": "F0F0F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 13,
+    "locations": [
+      "static/style-part1.css:161",
+      "static/style-part1.css:296",
+      "static/style-part1.css:489",
+      "static/style-part1.css:510",
+      "static/style-part1.css:528",
+      "static/style-part1.css:554",
+      "static/style-part1.css:1144",
+      "static/style-part1.css:1186",
+      "static/style-part1.css:1217",
+      "static/style-part1.css:1231",
+      "static/style-part1.css:1234",
+      "static/style-part1.css:1927",
+      "static/style-part1.css:2550"
+    ]
+  },
+  {
+    "value": "F0F2F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 10,
+    "locations": [
+      "static/style-part1.css:13",
+      "static/style-part1.css:655",
+      "static/style-part1.css:1842",
+      "static/style-part1.css:1904",
+      "static/style-part1.css:1951",
+      "static/style-part1.css:2070",
+      "static/style-part1.css:2469",
+      "static/style-part1.css:2700",
+      "static/style-part2.css:3432",
+      "static/style-part4.css:3268 [comment]"
+    ]
+  },
+  {
+    "value": "F0F4F0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:596"
+    ]
+  },
+  {
+    "value": "F0F4F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:204",
+      "static/style-part2.css:3984"
+    ]
+  },
+  {
+    "value": "F1F3F6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3077"
+    ]
+  },
+  {
+    "value": "F1F8F3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1275"
+    ]
+  },
+  {
+    "value": "F2385A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3629"
+    ]
+  },
+  {
+    "value": "F2D17A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2235"
+    ]
+  },
+  {
+    "value": "F2D38C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1586"
+    ]
+  },
+  {
+    "value": "F2DDDD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:737"
+    ]
+  },
+  {
+    "value": "F2F4F7",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1910",
+      "static/style-part2.css:2321"
+    ]
+  },
+  {
+    "value": "F2F7FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2549",
+      "static/style-part3.css:2556"
+    ]
+  },
+  {
+    "value": "F2F7FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:3335 [comment]",
+      "static/ui-kit.css:3216"
+    ]
+  },
+  {
+    "value": "F2F7FD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2148"
+    ]
+  },
+  {
+    "value": "F3B63F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3381"
+    ]
+  },
+  {
+    "value": "F3F6F9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:720"
+    ]
+  },
+  {
+    "value": "F3F6FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:402",
+      "static/style-part2.css:726"
+    ]
+  },
+  {
+    "value": "F3F6FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3055"
+    ]
+  },
+  {
+    "value": "F3F7FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:2926",
+      "static/style-part4.css:2068"
+    ]
+  },
+  {
+    "value": "F3F8FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2650"
+    ]
+  },
+  {
+    "value": "F4F7FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3712",
+      "static/style-part4.css:3099"
+    ]
+  },
+  {
+    "value": "F4F7FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:1399",
+      "static/ui-kit.css:3163"
+    ]
+  },
+  {
+    "value": "F4F8FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/style-part4.css:640",
+      "static/style-part4.css:3181",
+      "static/style-part4.css:3376",
+      "static/ui-kit.css:1708",
+      "static/ui-kit.css:1716",
+      "static/ui-kit.css:1822",
+      "static/ui-kit.css:3259"
+    ]
+  },
+  {
+    "value": "F4F8FD",
+    "verdict": "ui-normalization-candidate",
+    "count": 4,
+    "locations": [
+      "static/style-part4.css:2034",
+      "static/style-part4.css:2408",
+      "static/style-part4.css:2794",
+      "static/style-part4.css:2841"
+    ]
+  },
+  {
+    "value": "F4F8FF",
+    "verdict": "ui-normalization-candidate",
+    "count": 7,
+    "locations": [
+      "static/ui-kit.css:2244",
+      "static/ui-kit.css:2252",
+      "static/ui-kit.css:2262",
+      "static/ui-kit.css:2263",
+      "static/ui-kit.css:2457",
+      "static/ui-kit.css:2927",
+      "static/ui-kit.css:2933"
+    ]
+  },
+  {
+    "value": "F4FBF6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1660"
+    ]
+  },
+  {
+    "value": "F59B2F",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:1221"
+    ]
+  },
+  {
+    "value": "F59E0B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3055"
+    ]
+  },
+  {
+    "value": "F5A623",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:341"
+    ]
+  },
+  {
+    "value": "F5C542",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part2.css:2930",
+      "static/style-part2.css:2941",
+      "static/style-part2.css:3413",
+      "static/style-part3.css:34",
+      "static/style-part3.css:304"
+    ]
+  },
+  {
+    "value": "F5D980",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:924"
+    ]
+  },
+  {
+    "value": "F5DDDD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:930"
+    ]
+  },
+  {
+    "value": "F5E8E8",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:1472",
+      "static/style-part1.css:2514",
+      "static/style-part1.css:2582"
+    ]
+  },
+  {
+    "value": "F5EDCF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:924"
+    ]
+  },
+  {
+    "value": "F5EDE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1095"
+    ]
+  },
+  {
+    "value": "F5F0E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:363"
+    ]
+  },
+  {
+    "value": "F5F3EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:778"
+    ]
+  },
+  {
+    "value": "F5F5F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part1.css:974",
+      "static/style-part1.css:1240",
+      "static/style-part1.css:1276"
+    ]
+  },
+  {
+    "value": "F5F7FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 16,
+    "locations": [
+      "static/style-part1.css:406",
+      "static/style-part1.css:449",
+      "static/style-part1.css:1633",
+      "static/style-part1.css:2127",
+      "static/style-part1.css:2187",
+      "static/style-part1.css:2212",
+      "static/style-part1.css:2635",
+      "static/style-part1.css:2721",
+      "static/style-part2.css:3477",
+      "static/style-part2.css:3539",
+      "static/style-part3.css:293",
+      "static/style-part3.css:621",
+      "static/style-part3.css:3427",
+      "static/style-part3.css:3517",
+      "static/style-part4.css:1585",
+      "static/ui-kit.css:3071"
+    ]
+  },
+  {
+    "value": "F5F7FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:2822",
+      "static/style-part2.css:2834"
+    ]
+  },
+  {
+    "value": "F5F8FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:2252"
+    ]
+  },
+  {
+    "value": "F5F8FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:3594"
+    ]
+  },
+  {
+    "value": "F5F9FD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:892"
+    ]
+  },
+  {
+    "value": "F5FFE8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:213"
+    ]
+  },
+  {
+    "value": "F6F8FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1263"
+    ]
+  },
+  {
+    "value": "F6F8FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:51",
+      "static/style-part2.css:2674",
+      "static/ui-kit.css:1207"
+    ]
+  },
+  {
+    "value": "F6F9FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:2932"
+    ]
+  },
+  {
+    "value": "F7E5E5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:847"
+    ]
+  },
+  {
+    "value": "F7F9FB",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:41",
+      "static/style-part3.css:347"
+    ]
+  },
+  {
+    "value": "F7F9FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 10,
+    "locations": [
+      "static/style-part3.css:405",
+      "static/style-part3.css:1801",
+      "static/style-part3.css:1855",
+      "static/style-part4.css:2031",
+      "static/style-part4.css:2378",
+      "static/ui-kit.css:864",
+      "static/ui-kit.css:2558",
+      "static/ui-kit.css:3073",
+      "static/ui-kit.css:3125",
+      "static/ui-kit.css:3134"
+    ]
+  },
+  {
+    "value": "F7FAFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:250"
+    ]
+  },
+  {
+    "value": "F7FBFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3075"
+    ]
+  },
+  {
+    "value": "F8EDED",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:728"
+    ]
+  },
+  {
+    "value": "F8F0D8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:995"
+    ]
+  },
+  {
+    "value": "F8F4E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1748"
+    ]
+  },
+  {
+    "value": "F8F5F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:990"
+    ]
+  },
+  {
+    "value": "F8F6F2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1669"
+    ]
+  },
+  {
+    "value": "F8F8F8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:723"
+    ]
+  },
+  {
+    "value": "F8F9FA",
+    "verdict": "ui-normalization-candidate",
+    "count": 9,
+    "locations": [
+      "static/style-part1.css:27",
+      "static/style-part1.css:561",
+      "static/style-part1.css:1503",
+      "static/style-part1.css:2412",
+      "static/style-part1.css:2561",
+      "static/style-part2.css:2054",
+      "static/style-part2.css:2068",
+      "static/style-part2.css:2134",
+      "static/style-part2.css:2142"
+    ]
+  },
+  {
+    "value": "F8F9FC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:1842"
+    ]
+  },
+  {
+    "value": "F8FAFC",
+    "verdict": "ui-normalization-candidate",
+    "count": 17,
+    "locations": [
+      "static/style-part1.css:2942",
+      "static/style-part2.css:443",
+      "static/style-part2.css:633",
+      "static/style-part2.css:1028",
+      "static/style-part2.css:1364",
+      "static/style-part2.css:1599",
+      "static/style-part2.css:1801",
+      "static/style-part2.css:1870",
+      "static/style-part2.css:3571",
+      "static/style-part2.css:3678",
+      "static/style-part2.css:3802",
+      "static/style-part2.css:3884",
+      "static/style-part2.css:3907",
+      "static/style-part3.css:200",
+      "static/style-part3.css:1598",
+      "static/style-part4.css:162",
+      "static/ui-kit.css:2400"
+    ]
+  },
+  {
+    "value": "F8FBFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 6,
+    "locations": [
+      "static/style-part2.css:1620",
+      "static/style-part3.css:917",
+      "static/style-part3.css:1023",
+      "static/style-part3.css:1154",
+      "static/style-part4.css:3846",
+      "static/ui-kit.css:1711"
+    ]
+  },
+  {
+    "value": "FAFBFC",
+    "verdict": "ui-normalization-candidate",
+    "count": 5,
+    "locations": [
+      "static/style-part1.css:315",
+      "static/style-part1.css:2104",
+      "static/style-part1.css:2612",
+      "static/style-part1.css:3273",
+      "static/style-part2.css:95"
+    ]
+  },
+  {
+    "value": "FAFBFD",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:997"
+    ]
+  },
+  {
+    "value": "FAFFF5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:209"
+    ]
+  },
+  {
+    "value": "FBE8A6",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:254"
+    ]
+  },
+  {
+    "value": "FBF5DF",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2594"
+    ]
+  },
+  {
+    "value": "FBFCFE",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part3.css:644",
+      "static/style-part3.css:1460",
+      "static/style-part4.css:1611"
+    ]
+  },
+  {
+    "value": "FCA5A5",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1189"
+    ]
+  },
+  {
+    "value": "FCD34D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1183"
+    ]
+  },
+  {
+    "value": "FCECEA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:2600"
+    ]
+  },
+  {
+    "value": "FDE9EB",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3725",
+      "static/style-part4.css:3905"
+    ]
+  },
+  {
+    "value": "FDECEE",
+    "verdict": "semantic-status-candidate",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:62",
+      "static/ui-kit.css:3113"
+    ]
+  },
+  {
+    "value": "FDF8E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:995"
+    ]
+  },
+  {
+    "value": "FECACA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:662"
+    ]
+  },
+  {
+    "value": "FEE2E2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:672"
+    ]
+  },
+  {
+    "value": "FF5722",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:210",
+      "static/style-part1.css:275"
+    ]
+  },
+  {
+    "value": "FF6262",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part1.css:3389"
+    ]
+  },
+  {
+    "value": "FF6B35",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part1.css:1886",
+      "static/style-part1.css:1895"
+    ]
+  },
+  {
+    "value": "FF6B6B",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:345"
+    ]
+  },
+  {
+    "value": "FF7B85",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3242"
+    ]
+  },
+  {
+    "value": "FF7D7D",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2127"
+    ]
+  },
+  {
+    "value": "FF858C",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3562"
+    ]
+  },
+  {
+    "value": "FF8A80",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3204"
+    ]
+  },
+  {
+    "value": "FF9299",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part3.css:3738",
+      "static/style-part4.css:4017"
+    ]
+  },
+  {
+    "value": "FF9DA4",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3151"
+    ]
+  },
+  {
+    "value": "FFB3BA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:2229"
+    ]
+  },
+  {
+    "value": "FFB4BA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3527"
+    ]
+  },
+  {
+    "value": "FFB5BC",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:975"
+    ]
+  },
+  {
+    "value": "FFBBC0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3157"
+    ]
+  },
+  {
+    "value": "FFD35A",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3556"
+    ]
+  },
+  {
+    "value": "FFE7E9",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3545"
+    ]
+  },
+  {
+    "value": "FFE8E8",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:2446",
+      "static/style-part2.css:3994"
+    ]
+  },
+  {
+    "value": "FFE8EB",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:824"
+    ]
+  },
+  {
+    "value": "FFF0EF",
+    "verdict": "ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part4.css:112",
+      "static/style-part4.css:3504"
+    ]
+  },
+  {
+    "value": "FFF0F1",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:318"
+    ]
+  },
+  {
+    "value": "FFF2C7",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3539"
+    ]
+  },
+  {
+    "value": "FFF2F3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:3240"
+    ]
+  },
+  {
+    "value": "FFF3D8",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:3724"
+    ]
+  },
+  {
+    "value": "FFF3F3",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1305"
+    ]
+  },
+  {
+    "value": "FFF4D8",
+    "verdict": "semantic-status-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:1768"
+    ]
+  },
+  {
+    "value": "FFF4F2",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1281"
+    ]
+  },
+  {
+    "value": "FFF4F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part4.css:807"
+    ]
+  },
+  {
+    "value": "FFF5F5",
+    "verdict": "ui-normalization-candidate",
+    "count": 3,
+    "locations": [
+      "static/style-part2.css:663",
+      "static/style-part2.css:2432",
+      "static/style-part4.css:3341 [comment]"
+    ]
+  },
+  {
+    "value": "FFF7DF",
+    "verdict": "mixed:semantic-status-candidate+ui-normalization-candidate",
+    "count": 2,
+    "locations": [
+      "static/style-part2.css:1588",
+      "static/ui-kit.css:3111"
+    ]
+  },
+  {
+    "value": "FFF9EA",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part3.css:1311"
+    ]
+  },
+  {
+    "value": "FFFAF0",
+    "verdict": "ui-normalization-candidate",
+    "count": 1,
+    "locations": [
+      "static/style-part2.css:1269"
+    ]
+  },
+  {
+    "value": "FFFFFF",
+    "verdict": "ui-normalization-candidate",
+    "count": 46,
+    "locations": [
+      "static/style-part1.css:1824",
+      "static/style-part1.css:2833",
+      "static/style-part1.css:2957",
+      "static/style-part1.css:3026",
+      "static/style-part1.css:3098",
+      "static/style-part2.css:407",
+      "static/style-part2.css:526",
+      "static/style-part2.css:735",
+      "static/style-part2.css:1215",
+      "static/style-part2.css:1766",
+      "static/style-part2.css:1816",
+      "static/style-part2.css:3387",
+      "static/style-part3.css:207",
+      "static/style-part3.css:354",
+      "static/style-part3.css:361",
+      "static/style-part3.css:417",
+      "static/style-part3.css:422",
+      "static/style-part3.css:516",
+      "static/style-part3.css:1289",
+      "static/style-part3.css:1460",
+      "static/style-part3.css:1958",
+      "static/style-part3.css:1977",
+      "static/style-part3.css:3018",
+      "static/style-part4.css:1222",
+      "static/style-part4.css:2032",
+      "static/style-part4.css:2033",
+      "static/style-part4.css:2251",
+      "static/style-part4.css:2345",
+      "static/style-part4.css:2352",
+      "static/style-part4.css:2416",
+      "static/style-part4.css:2512",
+      "static/style-part4.css:2751",
+      "static/style-part4.css:2883",
+      "static/style-part4.css:3147",
+      "static/style-part4.css:3189",
+      "static/style-part4.css:3277 [comment]",
+      "static/style-part4.css:3386",
+      "static/ui-kit.css:2065",
+      "static/ui-kit.css:2100",
+      "static/ui-kit.css:2211",
+      "static/ui-kit.css:2732",
+      "static/ui-kit.css:3072",
+      "static/ui-kit.css:3089",
+      "static/ui-kit.css:3126",
+      "static/ui-kit.css:3127",
+      "static/ui-kit.css:3133"
+    ]
+  }
+]

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1,0 +1,1023 @@
+# Raw-HEX color audit — Stage 0 baseline
+
+_Generated 2026-09-03 for the theme-registry Stage 0 preparatory task._
+
+Inventory of every unique 6-digit HEX literal across the 5 theming-relevant CSS files (`static/style-part1.css`–`style-part4.css`, `static/ui-kit.css`), classified for later token-normalization stages. **No values were changed and no components were touched** — this is a read-only inventory.
+
+- Files scanned: `static/style-part1.css`, `static/style-part2.css`, `static/style-part3.css`, `static/style-part4.css`, `static/ui-kit.css` (18,707 lines total)
+- Total HEX occurrences: **2019**
+- Unique HEX values: **968**
+
+## Classification method
+
+Each occurrence was checked for (1) whether it sits inside a `/* ... */` comment rather than a live declaration, and (2) whether its selector/property context matches a semantic-status vocabulary (success/warning/danger/info, online/offline/medium, `.confirm-danger`, `notification-*`, `*-profile-badge`, etc.) versus general UI surface/text/border/shadow/gradient usage.
+
+**Finding: no legitimate non-UI/vendor colors were found in these 5 files.** Before writing the classifier, two specific hypotheses for category (a) ("legitimate non-UI color") were checked directly against the codebase and both came back negative:
+
+- **Chart/telemetry colors are not in CSS at all.** `chat-telemetry.js` sets Chart.js colors in JS (only 6 HEX literals there, out of scope for this CSS audit); the CSS side just themes the chart's *container* (`.telemetry-chart-container`), and the `<canvas>` itself is forced transparent (`style-part4.css:3265-3266`).
+- **No per-node/avatar hash-color palette or Leaflet marker-color override exists in *our own* CSS.** `.base-node-avatar` / `.node-manager-avatar` rules are plain container chrome (border/background/hover), not a distinct-color-per-entity palette; the "EMBEDDED MAP WORKSPACE (Leaflet)" section (`style-part4.css:558`) only themes MeshCenter's own map toolbar/popup chrome, not Leaflet's own default marker icons.
+
+So every live declaration found in the 5 files is a **product UI color** — either a general surface/text/border/gradient color, or (the one subtype worth distinguishing now) a **semantic status color** that later stages should map to a semantic token (e.g. `--mc-success`) rather than a plain surface token. A future stage that adds a real data-viz/vendor-override CSS section should re-run this audit rather than assume the same holds.
+
+**Scope caveat — read before treating this as "no vendor colors exist anywhere":** this audit only grepped the 5 files listed above. Leaflet's own stylesheet (`https://unpkg.com/leaflet@1.9.4/dist/leaflet.css`, loaded via `<link>` straight from the CDN in `templates/index.html:15`) is a separate, external file and was **not** part of this grep at all — its absence from the registry below means "out of scope," not "checked and found clean." Leaflet's own default marker-icon colors (its classic blue pin, etc.) are real vendor colors; they just live outside the 5 files this Stage 0 task was scoped to. If a later stage wants to theme or override Leaflet's own chrome, that stylesheet needs its own separate look, not an assumption based on this document.
+
+## Summary by category
+
+| Category | Unique values | Description |
+|---|---|---|
+| `semantic-status-candidate` | 41 | Semantic status color (success/warning/danger/info) — normalization candidate, maps to a semantic token |
+| `mixed:semantic-status-candidate+ui-normalization-candidate` | 16 | Mixed — same HEX reused as both a semantic-status color and a general surface color at different sites |
+| `ui-normalization-candidate` | 911 | General product UI color (surface/text/border/shadow/gradient) — normalization candidate |
+
+## Full registry (grouped by HEX value)
+
+Each row lists every `file:line` occurrence of that HEX value across the 5 files. Comment-only occurrences (design-review notes) are marked `[comment]` inline and were excluded from the category verdict.
+
+### Semantic status color (success/warning/danger/info) — normalization candidate, maps to a semantic token
+
+_41 unique values_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#16803C` | 2 | static/style-part4.css:1766, static/style-part4.css:1767 |
+| `#173C2A` | 1 | static/ui-kit.css:3239 |
+| `#217648` | 1 | static/style-part3.css:3723 |
+| `#22A559` | 1 | static/style-part3.css:19 |
+| `#23699F` | 1 | static/style-part3.css:3726 |
+| `#277B4B` | 1 | static/style-part3.css:3600 |
+| `#27B96F` | 1 | static/ui-kit.css:3108 |
+| `#2A4A7A` | 1 | static/style-part1.css:1178 |
+| `#2A6A3A` | 1 | static/style-part1.css:1176 |
+| `#3A6A3A` | 1 | static/style-part1.css:1089 |
+| `#433719` | 1 | static/ui-kit.css:3241 |
+| `#49252B` | 1 | static/ui-kit.css:3243 |
+| `#72D69A` | 2 | static/style-part3.css:3736, static/ui-kit.css:3238 |
+| `#8FC7F0` | 1 | static/style-part3.css:3739 |
+| `#986500` | 1 | static/style-part4.css:1768 |
+| `#9B6B18` | 1 | static/style-part3.css:3601 |
+| `#A93E46` | 1 | static/style-part3.css:3602 |
+| `#B04A4A` | 1 | static/style-part1.css:1472 |
+| `#B0D0B0` | 1 | static/style-part1.css:1089 |
+| `#C78616` | 1 | static/style-part2.css:2893 |
+| `#D0D8EC` | 1 | static/style-part1.css:1179 |
+| `#D0E8D0` | 1 | static/style-part1.css:1177 |
+| `#D74343` | 2 | static/style-part2.css:2839, static/style-part2.css:2895 |
+| `#D94B57` | 1 | static/style-part4.css:885 |
+| `#DB5A63` | 1 | static/style-part3.css:21 |
+| `#E6505D` | 3 | static/ui-kit.css:60, static/ui-kit.css:61, static/ui-kit.css:3112 |
+| `#E6AD22` | 1 | static/ui-kit.css:3110 |
+| `#E6F1FA` | 1 | static/style-part3.css:3726 |
+| `#E6F7EC` | 2 | static/style-part4.css:1766, static/style-part4.css:1767 |
+| `#E7AF27` | 1 | static/style-part3.css:20 |
+| `#E7F5EC` | 1 | static/style-part3.css:3723 |
+| `#E8D8A0` | 1 | static/style-part1.css:1090 |
+| `#E8ECF5` | 1 | static/style-part1.css:1178 |
+| `#E8F0E8` | 1 | static/style-part1.css:1176 |
+| `#E9F8F0` | 1 | static/ui-kit.css:3109 |
+| `#ECD5D5` | 1 | static/style-part1.css:1473 |
+| `#FCA5A5` | 1 | static/style-part4.css:1189 |
+| `#FDECEE` | 2 | static/ui-kit.css:62, static/ui-kit.css:3113 |
+| `#FF7B85` | 1 | static/ui-kit.css:3242 |
+| `#FFF3D8` | 1 | static/style-part3.css:3724 |
+| `#FFF4D8` | 1 | static/style-part4.css:1768 |
+
+### Mixed — same HEX reused as both a semantic-status color and a general surface color at different sites
+
+_16 unique values_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#239B62` | 2 | static/style-part2.css:2838, static/style-part2.css:2891 |
+| `#7A6A2A` | 3 | static/style-part1.css:925, static/style-part1.css:1090, static/style-part1.css:1757 |
+| `#8A3A2A` | 2 | static/style-part1.css:942, static/style-part1.css:1457 |
+| `#946316` | 2 | static/style-part1.css:3013, static/style-part3.css:3724 |
+| `#A12B2B` | 2 | static/style-part4.css:1168, static/style-part4.css:1175 |
+| `#A43D45` | 3 | static/style-part3.css:317, static/style-part3.css:3725, static/style-part4.css:3906 |
+| `#B83B47` | 2 | static/style-part4.css:1045, static/style-part4.css:1125 |
+| `#D5D5D5` | 3 | static/style-part1.css:1091, static/style-part1.css:1456, static/style-part1.css:1475 |
+| `#E8A89E` | 2 | static/style-part1.css:945, static/style-part1.css:1458 |
+| `#E8E8E8` | 4 | static/style-part1.css:1409, static/style-part1.css:1455, static/style-part1.css:1474, static/style-part4.css:3914 |
+| `#F0B8B0` | 2 | static/style-part1.css:941, static/style-part1.css:1457 |
+| `#F0C86A` | 3 | static/style-part1.css:3018, static/style-part3.css:3737, static/ui-kit.css:3240 |
+| `#F5E8E8` | 3 | static/style-part1.css:1472, static/style-part1.css:2514, static/style-part1.css:2582 |
+| `#FDE9EB` | 2 | static/style-part3.css:3725, static/style-part4.css:3905 |
+| `#FF9299` | 2 | static/style-part3.css:3738, static/style-part4.css:4017 |
+| `#FFF7DF` | 2 | static/style-part2.css:1588, static/ui-kit.css:3111 |
+
+### General product UI color (surface/text/border/shadow/gradient) — normalization candidate
+
+_911 unique values_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#000000` | 1 | static/style-part4.css:2739 |
+| `#0369A1` | 1 | static/style-part2.css:656 |
+| `#080D13` | 1 | static/ui-kit.css:1869 |
+| `#09111A` | 1 | static/style-part4.css:2060 |
+| `#0A1119` | 1 | static/ui-kit.css:1764 |
+| `#0A121C` | 3 | static/ui-kit.css:1801, static/ui-kit.css:2895, static/ui-kit.css:2904 |
+| `#0B1520` | 1 | static/ui-kit.css:3219 |
+| `#0D1723` | 1 | static/ui-kit.css:3200 |
+| `#0E1B28` | 1 | static/style-part4.css:615 |
+| `#0E1C2A` | 1 | static/style-part3.css:2555 |
+| `#0F172A` | 4 | static/style-part2.css:423, static/style-part2.css:474, static/style-part2.css:532, static/style-part2.css:604 |
+| `#0F1823` | 1 | static/ui-kit.css:1763 |
+| `#0F1A26` | 3 | static/style-part4.css:2061, static/style-part4.css:2476, static/ui-kit.css:1677 |
+| `#0F1C2A` | 1 | static/style-part4.css:3424 |
+| `#0F1D2B` | 1 | static/ui-kit.css:2932 |
+| `#101820` | 1 | static/style-part1.css:2166 |
+| `#101923` | 1 | static/ui-kit.css:3205 |
+| `#101B27` | 1 | static/style-part4.css:694 |
+| `#101C29` | 1 | static/ui-kit.css:2431 |
+| `#101D2B` | 1 | static/ui-kit.css:1972 |
+| `#10233C` | 1 | static/style-part3.css:2232 |
+| `#10233F` | 2 | static/style-part3.css:985, static/ui-kit.css:3086 |
+| `#102F5C` | 1 | static/ui-kit.css:3129 |
+| `#111821` | 1 | static/ui-kit.css:1050 |
+| `#111A24` | 1 | static/ui-kit.css:1105 |
+| `#111B27` | 1 | static/ui-kit.css:1864 |
+| `#111C29` | 2 | static/ui-kit.css:3201, static/ui-kit.css:3275 |
+| `#112F4D` | 1 | static/style-part3.css:2982 |
+| `#121C28` | 1 | static/ui-kit.css:3255 |
+| `#122F4A` | 1 | static/style-part3.css:3060 |
+| `#1265D6` | 3 | static/style-part1.css:2290, static/style-part1.css:2305, static/style-part2.css:1063 |
+| `#132334` | 3 | static/style-part4.css:3220, static/style-part4.css:3399, static/style-part4.css:4000 |
+| `#142130` | 1 | static/ui-kit.css:1946 |
+| `#142434` | 2 | static/style-part4.css:595, static/style-part4.css:851 |
+| `#14243A` | 10 | static/style-part4.css:2038, static/style-part4.css:2347, static/style-part4.css:2358, static/style-part4.css:2372, static/style-part4.css:2380, static/style-part4.css:2410, static/style-part4.css:2753, static/style-part4.css:2832, static/style-part4.css:2884, static/style-part4.css:2933 |
+| `#145FC6` | 3 | static/style-part2.css:823, static/style-part2.css:2736, static/style-part2.css:2810 |
+| `#151E29` | 1 | static/ui-kit.css:1111 |
+| `#15314F` | 1 | static/style-part3.css:2879 |
+| `#1557B0` | 5 | static/style-part1.css:350, static/style-part1.css:423, static/style-part1.css:2330, static/style-part4.css:103, static/style-part4.css:263 |
+| `#155FAE` | 1 | static/style-part4.css:3486 |
+| `#162231` | 2 | static/ui-kit.css:3203, static/ui-kit.css:3264 |
+| `#162331` | 2 | static/ui-kit.css:1731, static/ui-kit.css:2727 |
+| `#162433` | 3 | static/style-part4.css:2062, static/style-part4.css:3334 [comment], static/ui-kit.css:3213 |
+| `#16243A` | 1 | static/ui-kit.css:2685 |
+| `#162534` | 1 | static/ui-kit.css:2659 |
+| `#16283A` | 3 | static/style-part4.css:3421, static/style-part4.css:3428, static/style-part4.css:4009 |
+| `#16324C` | 1 | static/style-part3.css:2520 |
+| `#163E72` | 1 | static/style-part3.css:423 |
+| `#165CBA` | 6 | static/style-part2.css:2936, static/style-part2.css:2946, static/style-part2.css:3368, static/style-part3.css:30, static/style-part3.css:311, static/ui-kit.css:2714 |
+| `#166534` | 1 | static/style-part2.css:1624 |
+| `#168447` | 1 | static/style-part4.css:1300 |
+| `#168846` | 1 | static/ui-kit.css:1231 |
+| `#16A34A` | 4 | static/style-part1.css:3468, static/style-part2.css:554, static/style-part2.css:1467, static/style-part2.css:1506 |
+| `#172033` | 7 | static/style-part4.css:1263, static/style-part4.css:1329, static/style-part4.css:1358, static/style-part4.css:1398, static/style-part4.css:1493, static/style-part4.css:1671, static/style-part4.css:1937 |
+| `#172432` | 2 | static/ui-kit.css:1685, static/ui-kit.css:2641 |
+| `#17243A` | 8 | static/ui-kit.css:1220, static/ui-kit.css:1224, static/ui-kit.css:1226, static/ui-kit.css:1227, static/ui-kit.css:1228, static/ui-kit.css:1230, static/ui-kit.css:1231, static/ui-kit.css:1232 |
+| `#172535` | 1 | static/ui-kit.css:3212 |
+| `#172638` | 9 | static/style-part3.css:2353, static/style-part3.css:3734, static/style-part4.css:3251 [comment], static/style-part4.css:3254, static/style-part4.css:3269 [comment], static/style-part4.css:3972 [comment], static/style-part4.css:3978, static/style-part4.css:4025 [comment], static/style-part4.css:4031 |
+| `#17283A` | 4 | static/style-part3.css:3460, static/style-part3.css:3551, static/style-part3.css:3732, static/style-part4.css:841 |
+| `#17293A` | 2 | static/style-part4.css:577, static/style-part4.css:631 |
+| `#172A3D` | 1 | static/style-part4.css:616 |
+| `#17344F` | 3 | static/style-part3.css:2457, static/style-part3.css:2489, static/style-part3.css:2688 |
+| `#17365F` | 1 | static/ui-kit.css:2589 |
+| `#17392D` | 1 | static/ui-kit.css:2215 |
+| `#173A5E` | 1 | static/style-part3.css:80 |
+| `#173F73` | 1 | static/ui-kit.css:2507 |
+| `#175FC0` | 1 | static/ui-kit.css:3101 |
+| `#1769C2` | 3 | static/style-part3.css:2128, static/style-part4.css:3435, static/style-part4.css:3436 |
+| `#1769D2` | 10 | static/style-part4.css:3109, static/ui-kit.css:1213, static/ui-kit.css:1214, static/ui-kit.css:1214, static/ui-kit.css:1226, static/ui-kit.css:1227, static/ui-kit.css:1229, static/ui-kit.css:1230, static/ui-kit.css:1230, static/ui-kit.css:1231 |
+| `#1769E0` | 13 | static/style-part4.css:1392, static/style-part4.css:1393, static/style-part4.css:1713, static/style-part4.css:1803, static/style-part4.css:1804, static/style-part4.css:1821, static/style-part4.css:1833, static/style-part4.css:1874, static/style-part4.css:1875, static/style-part4.css:2041, static/style-part4.css:2414, static/style-part4.css:2415, static/style-part4.css:2540 |
+| `#176B3A` | 1 | static/style-part4.css:1165 |
+| `#18212C` | 8 | static/ui-kit.css:1066, static/ui-kit.css:1156, static/ui-kit.css:1175, static/ui-kit.css:1492, static/ui-kit.css:1497, static/ui-kit.css:2894, static/ui-kit.css:3005, static/ui-kit.css:3011 |
+| `#182533` | 1 | static/ui-kit.css:2181 |
+| `#182535` | 1 | static/ui-kit.css:3256 |
+| `#182636` | 1 | static/ui-kit.css:3276 |
+| `#183048` | 2 | static/style-part4.css:643, static/style-part4.css:644 |
+| `#1A2535` | 1 | static/style-part4.css:3272 |
+| `#1A2736` | 2 | static/ui-kit.css:2070, static/ui-kit.css:3294 |
+| `#1A2A4A` | 24 | static/style-part1.css:36, static/style-part1.css:126, static/style-part1.css:176, static/style-part1.css:238, static/style-part1.css:357, static/style-part1.css:493, static/style-part1.css:1722, static/style-part1.css:1866, static/style-part1.css:2135, static/style-part1.css:2643, static/style-part2.css:3423, static/style-part2.css:3538, static/style-part2.css:3589, static/style-part2.css:3609, static/style-part2.css:3674, static/style-part2.css:3750, static/style-part2.css:3809, static/style-part2.css:3834, static/style-part2.css:3903, static/style-part2.css:3915, static/style-part2.css:3933, static/style-part2.css:3980, static/style-part3.css:353, static/style-part3.css:1905 |
+| `#1A2C3F` | 1 | static/style-part3.css:3024 |
+| `#1A3A2A` | 1 | static/style-part1.css:625 |
+| `#1A3A5A` | 1 | static/style-part1.css:580 |
+| `#1A5A7A` | 1 | static/style-part1.css:1743 |
+| `#1A5FA8` | 1 | static/style-part3.css:3391 |
+| `#1A73E8` | 24 | static/style-part1.css:350, static/style-part1.css:412, static/style-part1.css:423, static/style-part1.css:1956, static/style-part1.css:1958, static/style-part1.css:1988, static/style-part1.css:2249, static/style-part1.css:2272, static/style-part1.css:2280, static/style-part1.css:2325, static/style-part1.css:3291, static/style-part1.css:3292, static/style-part1.css:3496, static/style-part2.css:3543, static/style-part2.css:3544, static/style-part2.css:3597, static/style-part2.css:3787, static/style-part2.css:3789, static/style-part2.css:3846, static/style-part2.css:3848, static/style-part3.css:360, static/style-part3.css:363, static/style-part4.css:255, static/style-part4.css:302 |
+| `#1A7F4B` | 1 | static/style-part2.css:1924 |
+| `#1B2837` | 3 | static/ui-kit.css:1851, static/ui-kit.css:3202, static/ui-kit.css:3263 |
+| `#1B2938` | 1 | static/ui-kit.css:2136 |
+| `#1B2B3D` | 1 | static/ui-kit.css:3279 |
+| `#1B2D40` | 5 | static/style-part4.css:3170, static/style-part4.css:3292, static/style-part4.css:3361, static/style-part4.css:3368, static/style-part4.css:3432 |
+| `#1C2C3D` | 1 | static/style-part4.css:2063 |
+| `#1C2E41` | 2 | static/style-part3.css:2533, static/style-part3.css:2771 |
+| `#1D2B3A` | 1 | static/ui-kit.css:1879 |
+| `#1D2B3B` | 1 | static/ui-kit.css:3257 |
+| `#1D2D3D` | 1 | static/ui-kit.css:2646 |
+| `#1D3043` | 1 | static/style-part4.css:3117 |
+| `#1D344B` | 1 | static/ui-kit.css:1704 |
+| `#1D3557` | 2 | static/style-part2.css:1771, static/style-part2.css:1821 |
+| `#1D4ED8` | 1 | static/style-part2.css:437 |
+| `#1D5DA8` | 1 | static/style-part2.css:909 |
+| `#1E293B` | 5 | static/style-part2.css:452, static/style-part2.css:1532, static/style-part3.css:1500, static/style-part3.css:3640, static/ui-kit.css:2420 |
+| `#1E3145` | 1 | static/style-part4.css:932 |
+| `#1E3A8A` | 3 | static/style-part2.css:512, static/style-part2.css:584, static/style-part2.css:634 |
+| `#1E3C72` | 8 | static/style-part1.css:256, static/style-part1.css:674, static/style-part1.css:675, static/style-part1.css:1152, static/style-part1.css:1189, static/style-part1.css:2096, static/style-part1.css:2097, static/style-part3.css:209 |
+| `#1E4F8F` | 1 | static/style-part3.css:425 |
+| `#1F2937` | 5 | static/style-part1.css:2844, static/style-part1.css:2880, static/style-part1.css:3116, static/style-part1.css:3160, static/style-part2.css:2786 |
+| `#1F2D3D` | 1 | static/style-part4.css:163 |
+| `#1F3347` | 1 | static/style-part4.css:3520 |
+| `#1F6FD1` | 2 | static/style-part4.css:1048, static/style-part4.css:1048 |
+| `#1F6FDB` | 4 | static/style-part3.css:1815, static/style-part3.css:1869, static/style-part4.css:837, static/ui-kit.css:3100 |
+| `#1F6FE5` | 4 | static/style-part1.css:2956, static/style-part1.css:2958, static/style-part1.css:2997, static/style-part1.css:2999 |
+| `#1F6FEB` | 1 | static/ui-kit.css:3097 |
+| `#202936` | 1 | static/ui-kit.css:3298 |
+| `#202A36` | 6 | static/ui-kit.css:1079, static/ui-kit.css:1144, static/ui-kit.css:1151, static/ui-kit.css:1504, static/ui-kit.css:1510, static/ui-kit.css:3004 |
+| `#202E3E` | 1 | static/ui-kit.css:3294 |
+| `#202F40` | 2 | static/ui-kit.css:2168, static/ui-kit.css:3204 |
+| `#203044` | 1 | static/ui-kit.css:3277 |
+| `#203247` | 1 | static/ui-kit.css:1965 |
+| `#203449` | 2 | static/style-part3.css:3735, static/style-part4.css:3122 |
+| `#20354A` | 1 | static/ui-kit.css:2734 |
+| `#20364B` | 1 | static/style-part4.css:3126 |
+| `#20384E` | 3 | static/style-part4.css:586, static/style-part4.css:852, static/style-part4.css:943 |
+| `#203A52` | 1 | static/style-part4.css:617 |
+| `#203B53` | 2 | static/style-part4.css:638, static/style-part4.css:889 |
+| `#203D5D` | 2 | static/ui-kit.css:3232, static/ui-kit.css:3245 |
+| `#205B9E` | 1 | static/ui-kit.css:1717 |
+| `#21364B` | 1 | static/style-part3.css:3733 |
+| `#21364D` | 1 | static/ui-kit.css:1510 |
+| `#213B57` | 1 | static/ui-kit.css:1704 |
+| `#214469` | 1 | static/style-part4.css:3510 |
+| `#214D35` | 1 | static/style-part2.css:2348 |
+| `#214F91` | 3 | static/ui-kit.css:48, static/ui-kit.css:3104, static/ui-kit.css:3130 |
+| `#2168D7` | 2 | static/style-part4.css:2249, static/style-part4.css:2510 |
+| `#216B36` | 1 | static/style-part2.css:2286 |
+| `#216B3A` | 2 | static/style-part2.css:2513, static/style-part4.css:3341 [comment] |
+| `#218653` | 2 | static/style-part3.css:1296, static/style-part4.css:949 |
+| `#222D3A` | 1 | static/ui-kit.css:1119 |
+| `#223245` | 1 | static/ui-kit.css:2190 |
+| `#22324A` | 3 | static/style-part4.css:93, static/style-part4.css:152, static/style-part4.css:293 |
+| `#223349` | 7 | static/ui-kit.css:1983, static/ui-kit.css:2202, static/ui-kit.css:2221, static/ui-kit.css:3248, static/ui-kit.css:3265, static/ui-kit.css:3270, static/ui-kit.css:3284 |
+| `#22364A` | 1 | static/ui-kit.css:2626 |
+| `#22364B` | 1 | static/style-part3.css:2932 |
+| `#22A447` | 1 | static/style-part2.css:1381 |
+| `#22C55E` | 4 | static/style-part1.css:1330, static/style-part1.css:3459, static/style-part2.css:1507, static/style-part4.css:3038 |
+| `#233346` | 1 | static/ui-kit.css:1664 |
+| `#23415F` | 1 | static/ui-kit.css:1712 |
+| `#236337` | 2 | static/style-part2.css:1732, static/style-part2.css:1895 |
+| `#23663A` | 1 | static/style-part2.css:2583 |
+| `#243243` | 1 | static/ui-kit.css:3225 |
+| `#243247` | 1 | static/style-part3.css:649 |
+| `#243447` | 3 | static/style-part2.css:1802, static/style-part2.css:1871, static/style-part3.css:1599 |
+| `#24374B` | 1 | static/style-part4.css:2064 |
+| `#243A2B` | 1 | static/style-part2.css:1714 |
+| `#243B5A` | 1 | static/style-part3.css:517 |
+| `#243C54` | 1 | static/style-part4.css:3146 |
+| `#24415F` | 2 | static/style-part1.css:3492, static/style-part2.css:163 |
+| `#24425E` | 2 | static/style-part4.css:892, static/style-part4.css:1047 |
+| `#24456F` | 2 | static/style-part3.css:230, static/style-part3.css:418 |
+| `#24457B` | 2 | static/style-part3.css:1966, static/ui-kit.css:803 |
+| `#244D82` | 1 | static/ui-kit.css:1007 |
+| `#2470D8` | 3 | static/style-part2.css:2662, static/style-part2.css:2684, static/style-part2.css:2685 |
+| `#25394D` | 1 | static/style-part4.css:2065 |
+| `#255984` | 1 | static/style-part4.css:3918 |
+| `#2563EB` | 1 | static/style-part2.css:1471 |
+| `#25C66B` | 1 | static/ui-kit.css:1222 |
+| `#263547` | 2 | static/ui-kit.css:1771, static/ui-kit.css:1865 |
+| `#26364B` | 2 | static/ui-kit.css:839, static/ui-kit.css:3138 |
+| `#26394D` | 1 | static/style-part3.css:3455 |
+| `#263B50` | 4 | static/style-part4.css:3227, static/style-part4.css:3310 [comment], static/style-part4.css:3315, static/style-part4.css:3361 |
+| `#263B52` | 6 | static/style-part3.css:958, static/style-part3.css:1100, static/style-part3.css:1201, static/style-part4.css:3769, static/style-part4.css:3803, static/style-part4.css:3889 |
+| `#263C52` | 8 | static/style-part3.css:2352, static/style-part4.css:3251 [comment], static/style-part4.css:3255, static/style-part4.css:3273, static/style-part4.css:3972 [comment], static/style-part4.css:3977, static/style-part4.css:4025 [comment], static/style-part4.css:4030 |
+| `#263D52` | 1 | static/style-part3.css:3024 |
+| `#263E58` | 1 | static/ui-kit.css:1671 |
+| `#263F5A` | 1 | static/ui-kit.css:1704 |
+| `#267340` | 2 | static/style-part2.css:2453, static/style-part4.css:3342 [comment] |
+| `#273140` | 1 | static/ui-kit.css:1934 |
+| `#273D53` | 1 | static/ui-kit.css:2631 |
+| `#27435C` | 1 | static/style-part4.css:641 |
+| `#274766` | 3 | static/style-part3.css:665, static/ui-kit.css:395, static/ui-kit.css:3122 |
+| `#275F8D` | 1 | static/style-part2.css:2589 |
+| `#285071` | 2 | static/style-part4.css:639, static/style-part4.css:890 |
+| `#28663A` | 1 | static/style-part2.css:1669 |
+| `#286DA8` | 1 | static/style-part3.css:3603 |
+| `#294766` | 1 | static/style-part3.css:2576 |
+| `#29485D` | 1 | static/style-part2.css:2300 |
+| `#294967` | 1 | static/ui-kit.css:3233 |
+| `#2A3A6A` | 2 | static/style-part1.css:36, static/style-part3.css:1905 |
+| `#2A3E53` | 1 | static/style-part4.css:2067 |
+| `#2A3F54` | 4 | static/style-part4.css:3987, static/style-part4.css:4010, static/style-part4.css:4012, static/style-part4.css:4020 |
+| `#2A4A6A` | 2 | static/style-part1.css:587, static/style-part3.css:103 |
+| `#2A5684` | 1 | static/style-part4.css:3515 |
+| `#2A5A3A` | 1 | static/style-part1.css:605 |
+| `#2A5A8A` | 4 | static/style-part1.css:764, static/style-part1.css:1789, static/style-part1.css:2149, static/style-part1.css:2737 |
+| `#2A9A60` | 1 | static/style-part4.css:2901 |
+| `#2B3949` | 3 | static/ui-kit.css:1127, static/ui-kit.css:3006, static/ui-kit.css:3012 |
+| `#2B3A4C` | 1 | static/ui-kit.css:1870 |
+| `#2B3B50` | 1 | static/style-part3.css:701 |
+| `#2B4059` | 5 | static/ui-kit.css:1990, static/ui-kit.css:2209, static/ui-kit.css:3249, static/ui-kit.css:3271, static/ui-kit.css:3285 |
+| `#2B405B` | 1 | static/ui-kit.css:1181 |
+| `#2B72DC` | 1 | static/style-part4.css:2941 |
+| `#2C3E50` | 1 | static/style-part1.css:14 |
+| `#2C6B52` | 1 | static/ui-kit.css:2216 |
+| `#2CA56C` | 1 | static/style-part4.css:1136 |
+| `#2D3D50` | 1 | static/ui-kit.css:2072 |
+| `#2D4057` | 7 | static/style-part3.css:934, static/style-part3.css:966, static/style-part3.css:1040, static/style-part3.css:1167, static/style-part3.css:2113, static/style-part4.css:3721, static/style-part4.css:3946 |
+| `#2D6CA3` | 2 | static/style-part4.css:3917, static/style-part4.css:3956 |
+| `#2E4258` | 1 | static/ui-kit.css:3278 |
+| `#2ECC71` | 1 | static/style-part1.css:1897 |
+| `#2F3B4D` | 1 | static/style-part2.css:214 |
+| `#2F3E50` | 2 | static/ui-kit.css:3224, static/ui-kit.css:3266 |
+| `#2F4053` | 1 | static/ui-kit.css:2430 |
+| `#2F4357` | 1 | static/ui-kit.css:2640 |
+| `#2F73D9` | 1 | static/ui-kit.css:3096 |
+| `#2F7DF6` | 1 | static/style-part2.css:1385 |
+| `#2F80ED` | 1 | static/ui-kit.css:3114 |
+| `#304A62` | 3 | static/style-part4.css:3234, static/style-part4.css:3310 [comment], static/style-part4.css:3320 |
+| `#304A63` | 1 | static/style-part4.css:616 |
+| `#31465C` | 1 | static/style-part3.css:2361 |
+| `#31475F` | 1 | static/ui-kit.css:1856 |
+| `#31485E` | 1 | static/style-part4.css:3212 |
+| `#314A62` | 5 | static/style-part4.css:576, static/style-part4.css:594, static/style-part4.css:851, static/style-part4.css:856, static/style-part4.css:856 |
+| `#315B3D` | 1 | static/style-part2.css:2280 |
+| `#32445B` | 1 | static/ui-kit.css:2111 |
+| `#33404F` | 1 | static/style-part2.css:2414 |
+| `#334155` | 9 | static/style-part1.css:2943, static/style-part2.css:53, static/style-part2.css:1016, static/style-part2.css:1643, static/style-part2.css:2497, static/ui-kit.css:897, static/ui-kit.css:924, static/ui-kit.css:2398, static/ui-kit.css:2498 |
+| `#334456` | 1 | static/ui-kit.css:1874 |
+| `#33465C` | 1 | static/ui-kit.css:1785 |
+| `#33475B` | 1 | static/style-part2.css:2958 |
+| `#334A61` | 4 | static/style-part3.css:2532, static/style-part3.css:2554, static/style-part3.css:2770, static/style-part3.css:2778 |
+| `#334B68` | 1 | static/ui-kit.css:3128 |
+| `#344050` | 1 | static/ui-kit.css:1112 |
+| `#344359` | 2 | static/style-part3.css:810, static/style-part3.css:870 |
+| `#34445F` | 5 | static/style-part2.css:815, static/style-part2.css:892, static/style-part2.css:2729, static/style-part2.css:2791, static/style-part2.css:2803 |
+| `#34475B` | 5 | static/ui-kit.css:2137, static/ui-kit.css:2162, static/ui-kit.css:2163, static/ui-kit.css:2164, static/ui-kit.css:2182 |
+| `#34475D` | 1 | static/ui-kit.css:2931 |
+| `#34485A` | 1 | static/style-part3.css:2783 |
+| `#34485E` | 1 | static/style-part3.css:3734 |
+| `#34495E` | 2 | static/style-part2.css:1784, static/style-part2.css:1856 |
+| `#344A60` | 2 | static/style-part3.css:3550, static/style-part3.css:3732 |
+| `#344A61` | 1 | static/style-part4.css:2066 |
+| `#344A62` | 1 | static/style-part3.css:1379 |
+| `#344B61` | 5 | static/style-part4.css:3161, static/style-part4.css:3177, static/style-part4.css:3373, static/style-part4.css:3429, static/style-part4.css:4019 |
+| `#35475A` | 2 | static/ui-kit.css:1845, static/ui-kit.css:1852 |
+| `#364253` | 8 | static/ui-kit.css:1080, static/ui-kit.css:1157, static/ui-kit.css:1167, static/ui-kit.css:1493, static/ui-kit.css:1505, static/ui-kit.css:1511, static/ui-kit.css:3008, static/ui-kit.css:3295 |
+| `#36506A` | 1 | static/ui-kit.css:1954 |
+| `#36516B` | 1 | static/style-part4.css:632 |
+| `#36516C` | 1 | static/ui-kit.css:2625 |
+| `#365A7A` | 1 | static/style-part3.css:2576 |
+| `#374151` | 5 | static/style-part1.css:2931, static/style-part1.css:3149, static/style-part1.css:3248, static/style-part1.css:3287, static/style-part2.css:1954 |
+| `#385068` | 4 | static/style-part4.css:3208, static/style-part4.css:3221, static/style-part4.css:3400, static/style-part4.css:4001 |
+| `#385069` | 1 | static/style-part4.css:3118 |
+| `#38516A` | 1 | static/style-part4.css:944 |
+| `#386445` | 1 | static/style-part2.css:1276 |
+| `#38D68A` | 2 | static/style-part4.css:612, static/style-part4.css:629 |
+| `#3A4A5A` | 5 | static/style-part1.css:1029, static/style-part1.css:1051, static/style-part1.css:1415, static/style-part2.css:3480, static/style-part2.css:3634 |
+| `#3A4A6A` | 1 | static/style-part1.css:794 |
+| `#3A4E64` | 1 | static/ui-kit.css:2191 |
+| `#3A5269` | 2 | static/ui-kit.css:2645, static/ui-kit.css:2658 |
+| `#3A526A` | 4 | static/style-part4.css:3136, static/style-part4.css:3171, static/style-part4.css:3361, static/style-part4.css:3369 |
+| `#3A526D` | 7 | static/ui-kit.css:1974, static/ui-kit.css:1985, static/ui-kit.css:2203, static/ui-kit.css:2222, static/ui-kit.css:3250, static/ui-kit.css:3267, static/ui-kit.css:3286 |
+| `#3A5973` | 2 | static/style-part4.css:638, static/style-part4.css:889 |
+| `#3A5A7A` | 2 | static/style-part1.css:86, static/style-part1.css:1642 |
+| `#3B4858` | 1 | static/ui-kit.css:1936 |
+| `#3B4859` | 3 | static/ui-kit.css:1106, static/ui-kit.css:1120, static/ui-kit.css:1176 |
+| `#3B526A` | 1 | static/style-part4.css:3519 |
+| `#3B5670` | 1 | static/style-part4.css:3127 |
+| `#3B82F6` | 3 | static/style-part4.css:3043, static/style-part4.css:3049, static/ui-kit.css:2414 |
+| `#3D242B` | 1 | static/style-part4.css:823 |
+| `#3DDC84` | 1 | static/style-part1.css:3377 |
+| `#3F5065` | 1 | static/style-part2.css:1226 |
+| `#3F6FAE` | 1 | static/ui-kit.css:968 |
+| `#405067` | 1 | static/ui-kit.css:2726 |
+| `#405268` | 1 | static/style-part2.css:1337 |
+| `#405369` | 1 | static/ui-kit.css:1896 |
+| `#40556B` | 2 | static/style-part3.css:2366, static/style-part3.css:2931 |
+| `#405875` | 1 | static/style-part2.css:1183 |
+| `#41536A` | 1 | static/style-part3.css:1240 |
+| `#41576D` | 1 | static/style-part2.css:2577 |
+| `#415A72` | 5 | static/style-part4.css:3229, static/style-part4.css:3310 [comment], static/style-part4.css:3317, static/style-part4.css:3322, static/style-part4.css:4005 |
+| `#415D78` | 1 | static/style-part3.css:126 |
+| `#43566B` | 1 | static/ui-kit.css:2077 |
+| `#43566D` | 1 | static/style-part3.css:837 |
+| `#43A047` | 1 | static/style-part1.css:2764 |
+| `#445164` | 3 | static/ui-kit.css:1145, static/ui-kit.css:1152, static/ui-kit.css:3007 |
+| `#445366` | 3 | static/style-part4.css:3778, static/style-part4.css:3836, static/style-part4.css:3861 |
+| `#45272B` | 1 | static/ui-kit.css:2227 |
+| `#46617C` | 1 | static/ui-kit.css:1705 |
+| `#475569` | 2 | static/style-part2.css:628, static/style-part2.css:1029 |
+| `#48617E` | 1 | static/ui-kit.css:2614 |
+| `#486B54` | 1 | static/style-part2.css:2002 |
+| `#493B20` | 1 | static/ui-kit.css:2233 |
+| `#496274` | 1 | static/style-part2.css:1988 |
+| `#49689F` | 2 | static/style-part3.css:1978, static/style-part3.css:1979 |
+| `#4A5A6A` | 4 | static/style-part1.css:877, static/style-part2.css:3472, static/style-part2.css:3688, static/style-part2.css:3945 |
+| `#4A5A7A` | 2 | static/style-part1.css:173, static/style-part1.css:794 |
+| `#4A7AAA` | 1 | static/style-part1.css:375 |
+| `#4A9EFF` | 2 | static/style-part1.css:1881, static/style-part1.css:1896 |
+| `#4AA3FF` | 2 | static/style-part4.css:613, static/style-part4.css:625 |
+| `#4B5563` | 1 | static/style-part2.css:2820 |
+| `#4B6685` | 1 | static/ui-kit.css:3251 |
+| `#4C647B` | 1 | static/style-part3.css:3025 |
+| `#4CAF50` | 4 | static/style-part1.css:644, static/style-part1.css:2364, static/style-part1.css:2754, static/style-part4.css:335 |
+| `#4D6F9F` | 1 | static/ui-kit.css:1133 |
+| `#4D7FB5` | 1 | static/style-part4.css:3509 |
+| `#4EA1FF` | 1 | static/ui-kit.css:1966 |
+| `#4F5F73` | 1 | static/style-part4.css:271 |
+| `#4F8CFF` | 8 | static/style-part4.css:2042, static/style-part4.css:2391, static/style-part4.css:2392, static/style-part4.css:2409, static/style-part4.css:2793, static/style-part4.css:2840, static/style-part4.css:2897, static/style-part4.css:2940 |
+| `#4F8FFF` | 2 | static/style-part4.css:2250, static/style-part4.css:2511 |
+| `#4F9CFF` | 1 | static/ui-kit.css:3260 |
+| `#4FD18B` | 1 | static/style-part4.css:957 |
+| `#506983` | 6 | static/style-part4.css:2039, static/style-part4.css:2364, static/style-part4.css:2368, static/style-part4.css:2398, static/style-part4.css:2404, static/style-part4.css:2804 |
+| `#51627B` | 1 | static/ui-kit.css:2113 |
+| `#526174` | 1 | static/ui-kit.css:3299 |
+| `#526177` | 2 | static/ui-kit.css:1221, static/ui-kit.css:1222 |
+| `#526178` | 6 | static/style-part2.css:1056, static/style-part2.css:2486, static/style-part3.css:502, static/style-part3.css:1640, static/style-part3.css:1641, static/style-part3.css:3620 |
+| `#52627A` | 2 | static/style-part3.css:1959, static/ui-kit.css:793 |
+| `#52657A` | 1 | static/ui-kit.css:2280 |
+| `#52657C` | 1 | static/ui-kit.css:1128 |
+| `#53657B` | 1 | static/style-part2.css:2675 |
+| `#536A83` | 1 | static/ui-kit.css:1900 |
+| `#53A66E` | 1 | static/style-part2.css:2388 |
+| `#55A9F5` | 1 | static/style-part4.css:586 |
+| `#55B870` | 1 | static/style-part2.css:3283 |
+| `#58677B` | 3 | static/ui-kit.css:1226, static/ui-kit.css:1230, static/ui-kit.css:1231 |
+| `#58708F` | 2 | static/ui-kit.css:39, static/ui-kit.css:3087 |
+| `#58B76C` | 4 | static/style-part2.css:3320, static/style-part2.css:3350, static/style-part4.css:3582 [comment], static/style-part4.css:3591 |
+| `#596675` | 1 | static/style-part2.css:2357 |
+| `#5A6A7A` | 1 | static/style-part2.css:3458 |
+| `#5AA7FF` | 1 | static/ui-kit.css:2733 |
+| `#5B82AA` | 4 | static/ui-kit.css:1991, static/ui-kit.css:2066, static/ui-kit.css:2101, static/ui-kit.css:2210 |
+| `#5C6B7E` | 1 | static/ui-kit.css:998 |
+| `#5C7082` | 1 | static/style-part4.css:640 |
+| `#5D7286` | 1 | static/style-part4.css:977 |
+| `#5D9B72` | 1 | static/style-part2.css:2522 |
+| `#5DA4EF` | 2 | static/style-part3.css:2915, static/style-part3.css:2920 |
+| `#5E7388` | 1 | static/style-part3.css:2415 |
+| `#60748B` | 1 | static/style-part2.css:3249 |
+| `#60758A` | 1 | static/style-part3.css:2496 |
+| `#607A92` | 1 | static/style-part3.css:3042 |
+| `#617184` | 1 | static/style-part2.css:2338 |
+| `#617386` | 1 | static/style-part2.css:3106 |
+| `#64748B` | 26 | static/style-part1.css:3452, static/style-part1.css:3474, static/style-part2.css:429, static/style-part2.css:470, static/style-part2.css:542, static/style-part2.css:571, static/style-part2.css:610, static/style-part2.css:1476, static/style-part2.css:1631, static/style-part3.css:406, static/style-part3.css:1988, static/style-part3.css:2402, static/style-part3.css:3185, static/style-part3.css:3527, static/style-part4.css:1215, static/style-part4.css:1251, static/style-part4.css:1277, static/style-part4.css:1349, static/style-part4.css:1538, static/style-part4.css:1677, static/style-part4.css:1688, static/style-part4.css:1748, static/style-part4.css:1761, static/style-part4.css:1797, static/style-part4.css:1815, static/ui-kit.css:2401 |
+| `#64798D` | 1 | static/style-part3.css:2484 |
+| `#647B91` | 1 | static/style-part3.css:2672 |
+| `#654B18` | 1 | static/style-part1.css:3502 |
+| `#65A3FF` | 1 | static/style-part4.css:2071 |
+| `#667085` | 4 | static/style-part3.css:39, static/style-part3.css:281, static/style-part3.css:348, static/style-part4.css:439 |
+| `#667487` | 1 | static/style-part3.css:721 |
+| `#66756B` | 1 | static/style-part2.css:1918 |
+| `#66758A` | 1 | static/style-part3.css:1357 |
+| `#66788A` | 1 | static/style-part2.css:2989 |
+| `#66788F` | 2 | static/style-part4.css:1045, static/style-part4.css:1096 |
+| `#6688B7` | 2 | static/ui-kit.css:1134, static/ui-kit.css:1182 |
+| `#66A8FF` | 2 | static/ui-kit.css:1672, static/ui-kit.css:3230 |
+| `#66B2FF` | 1 | static/ui-kit.css:2929 |
+| `#67788D` | 1 | static/ui-kit.css:3300 |
+| `#687585` | 1 | static/style-part2.css:2319 |
+| `#68758A` | 1 | static/ui-kit.css:1212 |
+| `#68788B` | 1 | static/style-part4.css:3494 |
+| `#68A77A` | 2 | static/style-part2.css:1743, static/style-part2.css:1904 |
+| `#69A87F` | 1 | static/style-part2.css:2458 |
+| `#6A5A3A` | 1 | static/style-part1.css:2341 |
+| `#6A7A8A` | 9 | static/style-part1.css:1073, static/style-part2.css:3444, static/style-part2.css:3497, static/style-part2.css:3603, static/style-part2.css:3668, static/style-part2.css:3744, static/style-part2.css:3775, static/style-part2.css:3828, static/style-part2.css:3897 |
+| `#6A97A6` | 1 | static/style-part2.css:3254 |
+| `#6A9AB8` | 1 | static/style-part1.css:1739 |
+| `#6AA7FF` | 1 | static/ui-kit.css:3226 |
+| `#6B5200` | 1 | static/style-part3.css:255 |
+| `#6B7280` | 11 | static/style-part1.css:2850, static/style-part1.css:2886, static/style-part1.css:3122, static/style-part1.css:3178, static/style-part1.css:3225, static/style-part2.css:143, static/style-part2.css:1968, static/style-part2.css:2780, static/style-part2.css:2840, static/style-part2.css:2841, static/style-part4.css:1169 |
+| `#6B778C` | 1 | static/style-part4.css:147 |
+| `#6B7A8D` | 1 | static/style-part3.css:1107 |
+| `#6B8976` | 1 | static/style-part2.css:2372 |
+| `#6C8195` | 1 | static/style-part3.css:2448 |
+| `#6D7C8F` | 1 | static/style-part3.css:1300 |
+| `#6E9FE8` | 2 | static/style-part3.css:1972, static/ui-kit.css:811 |
+| `#6F7D73` | 1 | static/style-part2.css:1704 |
+| `#6F7E90` | 1 | static/style-part3.css:1333 |
+| `#6F94C6` | 1 | static/ui-kit.css:1005 |
+| `#6FA67C` | 2 | static/style-part2.css:3067, static/style-part2.css:3068 |
+| `#6FAC88` | 1 | static/style-part2.css:2313 |
+| `#6FDC8C` | 1 | static/ui-kit.css:2125 |
+| `#708399` | 1 | static/style-part4.css:882 |
+| `#718095` | 1 | static/style-part3.css:1182 |
+| `#718096` | 1 | static/ui-kit.css:889 |
+| `#718198` | 4 | static/style-part2.css:2210, static/style-part2.css:2362, static/style-part3.css:131, static/ui-kit.css:2596 |
+| `#718399` | 1 | static/ui-kit.css:2071 |
+| `#71879B` | 1 | static/style-part3.css:2788 |
+| `#72B8FF` | 1 | static/style-part4.css:619 |
+| `#738096` | 6 | static/ui-kit.css:1226, static/ui-kit.css:1227, static/ui-kit.css:1228, static/ui-kit.css:1228, static/ui-kit.css:1230, static/ui-kit.css:1232 |
+| `#738191` | 2 | static/style-part2.css:3018, static/style-part2.css:3084 |
+| `#73ADFF` | 1 | static/style-part4.css:2072 |
+| `#73B2FF` | 1 | static/ui-kit.css:3227 |
+| `#744047` | 1 | static/ui-kit.css:2228 |
+| `#748278` | 1 | static/style-part2.css:1675 |
+| `#75869C` | 1 | static/style-part4.css:1041 |
+| `#76602F` | 1 | static/ui-kit.css:2234 |
+| `#77869A` | 1 | static/style-part4.css:3020 |
+| `#788596` | 1 | static/style-part2.css:1328 |
+| `#78899E` | 1 | static/style-part4.css:1048 |
+| `#7890AA` | 1 | static/style-part3.css:3515 |
+| `#78B6FF` | 1 | static/ui-kit.css:3244 |
+| `#79879A` | 12 | static/style-part3.css:972, static/style-part3.css:995, static/style-part3.css:1094, static/style-part3.css:1125, static/style-part3.css:1135, static/style-part3.css:1142, static/style-part3.css:1174, static/style-part3.css:2122, static/style-part4.css:3727, static/style-part4.css:3755, static/style-part4.css:3878, static/style-part4.css:3896 |
+| `#7A6A5A` | 1 | static/style-part1.css:364 |
+| `#7A6B5A` | 1 | static/style-part1.css:739 |
+| `#7A8391` | 1 | static/style-part2.css:865 |
+| `#7A8595` | 1 | static/style-part4.css:172 |
+| `#7A8794` | 3 | static/style-part2.css:1791, static/style-part2.css:1829, static/style-part2.css:1911 |
+| `#7A8798` | 3 | static/style-part4.css:286, static/ui-kit.css:878, static/ui-kit.css:3139 |
+| `#7A8AA0` | 5 | static/style-part2.css:3431, static/style-part2.css:3488, static/style-part2.css:3531, static/style-part2.css:3927, static/style-part3.css:3377 |
+| `#7A8AAA` | 1 | static/style-part1.css:987 |
+| `#7A8BA0` | 1 | static/style-part4.css:1048 |
+| `#7A8CA5` | 1 | static/style-part4.css:992 |
+| `#7B5D16` | 1 | static/style-part2.css:2595 |
+| `#7B8492` | 1 | static/style-part2.css:949 |
+| `#7B8796` | 7 | static/style-part2.css:220, static/style-part3.css:656, static/style-part3.css:706, static/style-part3.css:859, static/style-part3.css:3661, static/style-part3.css:3729, static/style-part3.css:3730 |
+| `#7C641D` | 1 | static/style-part2.css:925 |
+| `#7C8999` | 1 | static/style-part3.css:1209 |
+| `#7D8FA1` | 1 | static/style-part3.css:2732 |
+| `#7D91A7` | 2 | static/style-part4.css:2040, static/style-part4.css:2385 |
+| `#7E2530` | 1 | static/style-part4.css:808 |
+| `#7EB28D` | 1 | static/style-part2.css:1880 |
+| `#7EB391` | 1 | static/style-part2.css:2510 |
+| `#7F8D9D` | 1 | static/style-part4.css:3603 |
+| `#7F8FA2` | 2 | static/ui-kit.css:527, static/ui-kit.css:611 |
+| `#7FB0DC` | 1 | static/style-part4.css:4022 |
+| `#806A25` | 1 | static/style-part2.css:1270 |
+| `#813842` | 1 | static/style-part4.css:3239 |
+| `#8293A5` | 2 | static/style-part3.css:2423, static/style-part3.css:2503 |
+| `#8297AB` | 1 | static/ui-kit.css:1682 |
+| `#829BB5` | 1 | static/ui-kit.css:3169 |
+| `#8390A0` | 1 | static/style-part3.css:1234 |
+| `#8492A6` | 1 | static/style-part4.css:1042 |
+| `#8592A3` | 3 | static/style-part2.css:2710, static/style-part2.css:2750, static/style-part2.css:2771 |
+| `#86EFAC` | 1 | static/style-part4.css:1181 |
+| `#8793A2` | 1 | static/style-part3.css:1249 |
+| `#8794A4` | 1 | static/style-part3.css:1366 |
+| `#8795A8` | 1 | static/ui-kit.css:2532 |
+| `#8798AD` | 1 | static/ui-kit.css:3088 |
+| `#87BCE7` | 1 | static/ui-kit.css:265 |
+| `#8995A2` | 1 | static/style-part2.css:3043 |
+| `#8995A5` | 1 | static/ui-kit.css:911 |
+| `#8A3A3A` | 1 | static/style-part1.css:2515 |
+| `#8A5A00` | 1 | static/style-part2.css:1589 |
+| `#8A6A5A` | 1 | static/style-part1.css:1121 |
+| `#8A7A4A` | 1 | static/style-part1.css:915 |
+| `#8A94A3` | 2 | static/style-part2.css:153, static/style-part3.css:785 |
+| `#8A95A4` | 1 | static/style-part3.css:817 |
+| `#8A96A5` | 3 | static/style-part3.css:1388, static/style-part3.css:1397, static/style-part3.css:2130 |
+| `#8A96A6` | 1 | static/ui-kit.css:933 |
+| `#8A9AA8` | 5 | static/style-part2.css:3581, static/style-part2.css:3615, static/style-part2.css:3694, static/style-part2.css:3781, static/style-part2.css:3838 |
+| `#8A9BB5` | 2 | static/style-part1.css:728, static/style-part1.css:1781 |
+| `#8AB4D8` | 1 | static/style-part1.css:1733 |
+| `#8ABEFF` | 1 | static/ui-kit.css:3231 |
+| `#8ABF99` | 2 | static/style-part2.css:1729, static/style-part2.css:1892 |
+| `#8AC39A` | 1 | static/style-part2.css:2581 |
+| `#8B3D34` | 1 | static/style-part2.css:2601 |
+| `#8B94A3` | 1 | static/style-part2.css:854 |
+| `#8BA0B7` | 1 | static/ui-kit.css:2538 |
+| `#8BB7EB` | 1 | static/style-part4.css:3484 |
+| `#8BC0FF` | 3 | static/style-part4.css:3984, static/ui-kit.css:1723, static/ui-kit.css:1726 |
+| `#8BC34A` | 1 | static/style-part1.css:644 |
+| `#8CE2B5` | 1 | static/ui-kit.css:2217 |
+| `#8D4650` | 1 | static/style-part4.css:3526 |
+| `#8EA6BC` | 1 | static/style-part3.css:2540 |
+| `#8EB8DD` | 1 | static/style-part2.css:2587 |
+| `#8F1D14` | 1 | static/style-part4.css:113 |
+| `#8FA3B8` | 1 | static/ui-kit.css:1960 |
+| `#8FA7C2` | 1 | static/ui-kit.css:2928 |
+| `#8FB8FF` | 1 | static/style-part1.css:3397 |
+| `#8FC4FF` | 1 | static/style-part3.css:3456 |
+| `#8FC5FF` | 1 | static/ui-kit.css:1930 |
+| `#90A5BA` | 1 | static/ui-kit.css:3218 |
+| `#90A6BC` | 1 | static/ui-kit.css:2636 |
+| `#90B080` | 2 | static/style-part1.css:1013, static/style-part1.css:1138 |
+| `#914343` | 1 | static/style-part3.css:729 |
+| `#91A2B6` | 3 | static/ui-kit.css:1140, static/ui-kit.css:1163, static/ui-kit.css:3010 |
+| `#91A4B8` | 1 | static/ui-kit.css:2172 |
+| `#91A6BC` | 1 | static/ui-kit.css:1838 |
+| `#91A7BC` | 1 | static/style-part4.css:2070 |
+| `#91A8BC` | 1 | static/style-part4.css:636 |
+| `#927FB2` | 1 | static/style-part4.css:3640 |
+| `#93463C` | 1 | static/style-part2.css:1282 |
+| `#93A2B3` | 6 | static/style-part4.css:3693, static/style-part4.css:3779, static/style-part4.css:3794, static/style-part4.css:3810, static/style-part4.css:3817, static/style-part4.css:3927 |
+| `#94A3B8` | 5 | static/style-part2.css:1499, static/style-part2.css:1525, static/style-part2.css:1541, static/style-part2.css:1573, static/style-part2.css:1600 |
+| `#94A8BD` | 1 | static/ui-kit.css:2432 |
+| `#94C7A5` | 1 | static/style-part2.css:2451 |
+| `#96A6B8` | 1 | static/ui-kit.css:1098 |
+| `#99434E` | 1 | static/style-part4.css:3246 |
+| `#9A3434` | 2 | static/style-part2.css:931, static/style-part3.css:1121 |
+| `#9A5A4A` | 1 | static/style-part1.css:932 |
+| `#9A5B00` | 1 | static/style-part4.css:1166 |
+| `#9AA0A6` | 1 | static/style-part4.css:331 |
+| `#9AA4B2` | 2 | static/style-part3.css:17, static/style-part3.css:22 |
+| `#9AA4B7` | 1 | static/style-part1.css:3393 |
+| `#9AA5B4` | 5 | static/style-part2.css:2887, static/style-part3.css:3218, static/style-part3.css:3320, static/style-part3.css:3326, static/style-part3.css:3819 |
+| `#9AA5B5` | 1 | static/style-part1.css:1058 |
+| `#9AA7B5` | 1 | static/style-part2.css:3261 |
+| `#9AA8B8` | 3 | static/ui-kit.css:477, static/ui-kit.css:522, static/ui-kit.css:606 |
+| `#9AA8BA` | 2 | static/style-part3.css:439, static/style-part3.css:1117 |
+| `#9B7421` | 2 | static/style-part3.css:1312, static/style-part4.css:953 |
+| `#9B78C4` | 1 | static/style-part4.css:1137 |
+| `#9BC7FF` | 1 | static/style-part4.css:3128 |
+| `#9DB0C1` | 1 | static/style-part4.css:596 |
+| `#9E7BC7` | 2 | static/style-part4.css:1996, static/style-part4.css:1998 |
+| `#9EB1C6` | 2 | static/ui-kit.css:2034, static/ui-kit.css:2083 |
+| `#9EB3C8` | 16 | static/style-part4.css:3198, static/style-part4.css:3252 [comment], static/style-part4.css:3259, static/style-part4.css:3325, static/style-part4.css:3380, static/style-part4.css:3404, static/style-part4.css:3407, static/style-part4.css:3974 [comment], static/style-part4.css:3983, static/style-part4.css:3985, static/style-part4.css:3996, static/style-part4.css:4023, static/style-part4.css:4027 [comment], static/style-part4.css:4036, static/style-part4.css:4038, static/style-part4.css:4039 |
+| `#9EB5C9` | 1 | static/style-part3.css:3068 |
+| `#9ECBB0` | 1 | static/style-part2.css:2301 |
+| `#9FB0C2` | 2 | static/ui-kit.css:2157, static/ui-kit.css:2475 |
+| `#9FB0C3` | 3 | static/ui-kit.css:2276, static/ui-kit.css:3269, static/ui-kit.css:3281 |
+| `#9FB0C5` | 1 | static/style-part2.css:1198 |
+| `#9FB1C4` | 1 | static/ui-kit.css:1887 |
+| `#9FB1C5` | 1 | static/ui-kit.css:2654 |
+| `#9FB3C8` | 1 | static/ui-kit.css:3168 |
+| `#9FB4CC` | 1 | static/ui-kit.css:1978 |
+| `#A16207` | 1 | static/style-part4.css:1305 |
+| `#A23E48` | 1 | static/ui-kit.css:322 |
+| `#A32929` | 2 | static/style-part2.css:2433, static/style-part4.css:3341 [comment] |
+| `#A33F3F` | 1 | static/style-part3.css:848 |
+| `#A5AFBA` | 3 | static/style-part2.css:3007, static/style-part2.css:3013, static/style-part2.css:3240 |
+| `#A784CE` | 1 | static/style-part4.css:1146 |
+| `#A8B0BA` | 1 | static/style-part2.css:1242 |
+| `#A985D3` | 1 | static/style-part4.css:2297 |
+| `#A9BAC9` | 1 | static/style-part4.css:618 |
+| `#A9BED1` | 2 | static/style-part4.css:3185, static/style-part4.css:3383 |
+| `#A9CBB3` | 1 | static/style-part2.css:1274 |
+| `#AAB5C0` | 1 | static/style-part2.css:3699 |
+| `#AD5360` | 1 | static/style-part4.css:3241 |
+| `#AEB7C1` | 3 | static/style-part2.css:3297, static/style-part2.css:3362, static/style-part4.css:3585 [comment] |
+| `#AEB9C8` | 1 | static/style-part2.css:1036 |
+| `#AEBDCD` | 1 | static/ui-kit.css:1177 |
+| `#AEBDCE` | 1 | static/style-part3.css:1653 |
+| `#AEBED0` | 1 | static/ui-kit.css:2464 |
+| `#AFC2D5` | 1 | static/style-part4.css:3521 |
+| `#B0A090` | 1 | static/style-part1.css:1376 |
+| `#B0B0B0` | 2 | static/style-part1.css:969, static/style-part1.css:1271 |
+| `#B0B8C5` | 3 | static/style-part1.css:984, static/style-part1.css:1952, static/style-part2.css:3639 |
+| `#B0C8A0` | 2 | static/style-part1.css:1000, static/style-part1.css:1126 |
+| `#B0C8F0` | 1 | static/style-part1.css:1987 |
+| `#B14B4B` | 1 | static/style-part3.css:1306 |
+| `#B17A00` | 1 | static/style-part3.css:3538 |
+| `#B42318` | 3 | static/style-part4.css:107, static/style-part4.css:1310, static/style-part4.css:3503 |
+| `#B43842` | 1 | static/style-part3.css:3544 |
+| `#B79AD9` | 3 | static/style-part4.css:1129, static/style-part4.css:1150, static/style-part4.css:1997 |
+| `#B7C1D6` | 1 | static/style-part1.css:3342 |
+| `#B7C6D6` | 2 | static/ui-kit.css:2186, static/ui-kit.css:3258 |
+| `#B7D8C0` | 1 | static/style-part2.css:1658 |
+| `#B82736` | 1 | static/style-part4.css:978 |
+| `#B8C6D6` | 1 | static/ui-kit.css:1121 |
+| `#B8C9D8` | 1 | static/style-part4.css:976 |
+| `#B8CBE0` | 1 | static/ui-kit.css:2660 |
+| `#B8CCE2` | 1 | static/ui-kit.css:403 |
+| `#B91C1C` | 1 | static/style-part2.css:664 |
+| `#B97870` | 2 | static/style-part2.css:3077, static/style-part2.css:3078 |
+| `#B9C6D6` | 1 | static/style-part2.css:1180 |
+| `#B9C7D6` | 1 | static/style-part2.css:2575 |
+| `#B9C7DB` | 2 | static/style-part3.css:1967, static/ui-kit.css:804 |
+| `#B9C8D8` | 2 | static/ui-kit.css:259, static/ui-kit.css:308 |
+| `#B9C9DA` | 2 | static/style-part3.css:1290, static/ui-kit.css:2223 |
+| `#B9DFC9` | 1 | static/style-part3.css:1294 |
+| `#BDCADA` | 1 | static/ui-kit.css:1831 |
+| `#BDCCDC` | 1 | static/ui-kit.css:3121 |
+| `#BDD0E4` | 1 | static/style-part3.css:3732 |
+| `#BFD0DF` | 1 | static/style-part4.css:892 |
+| `#BFD0E8` | 1 | static/style-part2.css:906 |
+| `#C0392B` | 2 | static/style-part2.css:1928, static/style-part3.css:1058 |
+| `#C08880` | 1 | static/style-part1.css:1381 |
+| `#C0A040` | 2 | static/style-part1.css:1382, static/style-part1.css:1753 |
+| `#C0A84A` | 1 | static/style-part1.css:997 |
+| `#C0C8D0` | 1 | static/style-part2.css:3468 |
+| `#C0D4E8` | 4 | static/style-part1.css:767, static/style-part1.css:1799, static/style-part1.css:2156, static/style-part1.css:2746 |
+| `#C2CEDA` | 1 | static/style-part3.css:2325 |
+| `#C3D1DF` | 2 | static/style-part4.css:3336 [comment], static/ui-kit.css:3217 |
+| `#C3D3E2` | 1 | static/style-part4.css:3418 |
+| `#C3D3E3` | 1 | static/style-part4.css:2069 |
+| `#C4D3DF` | 1 | static/style-part4.css:641 |
+| `#C5D2DF` | 1 | static/ui-kit.css:1892 |
+| `#C62828` | 4 | static/style-part1.css:2583, static/style-part2.css:3513, static/style-part2.css:3988, static/style-part4.css:183 |
+| `#C6D7E8` | 1 | static/style-part4.css:3193 |
+| `#C7A84D` | 2 | static/style-part2.css:3072, static/style-part2.css:3073 |
+| `#C7CED6` | 1 | static/style-part2.css:3060 |
+| `#C7D0DC` | 1 | static/ui-kit.css:950 |
+| `#C7D4E1` | 1 | static/style-part3.css:2899 |
+| `#C87D7D` | 1 | static/style-part2.css:2447 |
+| `#C8D3DE` | 1 | static/style-part4.css:929 |
+| `#C8D3DF` | 1 | static/style-part4.css:1048 |
+| `#C8D5E5` | 1 | static/ui-kit.css:2576 |
+| `#C9D5E1` | 1 | static/style-part3.css:2517 |
+| `#C9D7E6` | 1 | static/ui-kit.css:2471 |
+| `#C9D8EA` | 1 | static/ui-kit.css:2505 |
+| `#C9E3FF` | 1 | static/style-part4.css:3511 |
+| `#CAD4E0` | 3 | static/style-part2.css:1799, static/style-part2.css:1868, static/style-part3.css:1596 |
+| `#CAD5E2` | 1 | static/style-part4.css:1048 |
+| `#CBD4DF` | 1 | static/style-part2.css:1213 |
+| `#CBD5DF` | 1 | static/style-part3.css:61 |
+| `#CBD5E1` | 8 | static/style-part2.css:617, static/style-part2.css:632, static/style-part2.css:1026, static/style-part2.css:1565, static/style-part3.css:2229, static/style-part4.css:3766, static/style-part4.css:3800, static/style-part4.css:3833 |
+| `#CBD6E1` | 1 | static/style-part3.css:2643 |
+| `#CBD7E4` | 2 | static/style-part3.css:758, static/ui-kit.css:1113 |
+| `#CBD7E6` | 1 | static/style-part4.css:1011 |
+| `#CBD7E7` | 1 | static/style-part3.css:231 |
+| `#CBD8CF` | 1 | static/style-part2.css:2265 |
+| `#CBD8E6` | 5 | static/style-part3.css:662, static/style-part4.css:2881, static/style-part4.css:2930, static/ui-kit.css:2040, static/ui-kit.css:3120 |
+| `#CBDFF7` | 1 | static/style-part2.css:918 |
+| `#CCD3DC` | 1 | static/style-part2.css:2320 |
+| `#CCD5DF` | 1 | static/style-part2.css:1261 |
+| `#CCD6E2` | 1 | static/style-part3.css:2250 |
+| `#CFD8E5` | 1 | static/style-part3.css:514 |
+| `#CFDAE8` | 1 | static/ui-kit.css:2611 |
+| `#D0D0D0` | 3 | static/style-part1.css:964, static/style-part1.css:1266, static/style-part1.css:1357 |
+| `#D2DEEA` | 1 | static/style-part3.css:1179 |
+| `#D34F5D` | 1 | static/style-part4.css:2905 |
+| `#D3D3D3` | 8 | static/style-part4.css:3659, static/style-part4.css:3660, static/style-part4.css:3661, static/style-part4.css:3662, static/style-part4.css:3668, static/style-part4.css:3669, static/style-part4.css:3670, static/style-part4.css:3671 |
+| `#D3DCE8` | 1 | static/style-part3.css:424 |
+| `#D3EBDA` | 2 | static/style-part2.css:1744, static/style-part2.css:1905 |
+| `#D4A31F` | 1 | static/style-part3.css:3558 |
+| `#D4B85A` | 2 | static/style-part1.css:926, static/style-part1.css:1747 |
+| `#D4C06A` | 1 | static/style-part1.css:993 |
+| `#D4DBE5` | 2 | static/style-part3.css:201, static/style-part3.css:355 |
+| `#D4DDE8` | 1 | static/style-part3.css:2285 |
+| `#D4E0F0` | 1 | static/style-part1.css:227 |
+| `#D5A4A4` | 1 | static/style-part2.css:2430 |
+| `#D5C8A8` | 1 | static/style-part1.css:916 |
+| `#D5CBB8` | 1 | static/style-part1.css:746 |
+| `#D5D0C0` | 1 | static/style-part1.css:2345 |
+| `#D5D0C8` | 3 | static/style-part1.css:779, static/style-part1.css:1195, static/style-part1.css:1667 |
+| `#D5D8DD` | 20 | static/style-part1.css:81, static/style-part1.css:402, static/style-part1.css:447, static/style-part1.css:573, static/style-part1.css:598, static/style-part1.css:631, static/style-part1.css:637, static/style-part1.css:720, static/style-part1.css:1631, static/style-part1.css:1772, static/style-part1.css:1940, static/style-part1.css:1975, static/style-part1.css:2239, static/style-part1.css:2262, static/style-part2.css:2256, static/style-part2.css:3627, static/style-part2.css:3711, static/style-part2.css:3761, static/style-part2.css:3861, static/style-part2.css:3958 |
+| `#D5DBE3` | 1 | static/style-part2.css:2411 |
+| `#D5DCE6` | 1 | static/style-part2.css:2673 |
+| `#D5DCE7` | 2 | static/style-part3.css:1956, static/ui-kit.css:790 |
+| `#D5DDE5` | 1 | static/style-part2.css:1909 |
+| `#D5DEE8` | 1 | static/style-part3.css:2440 |
+| `#D5DFEB` | 6 | static/style-part4.css:2036, static/style-part4.css:2346, static/style-part4.css:2379, static/style-part4.css:2403, static/style-part4.css:2752, static/style-part4.css:2829 |
+| `#D5E0EC` | 2 | static/style-part1.css:571, static/style-part3.css:60 |
+| `#D5E2EF` | 1 | static/ui-kit.css:1713 |
+| `#D5E9FC` | 1 | static/style-part4.css:3499 |
+| `#D6E0EB` | 1 | static/style-part4.css:1117 |
+| `#D74755` | 1 | static/style-part4.css:994 |
+| `#D7DCE5` | 6 | static/style-part1.css:2941, static/style-part1.css:3185, static/style-part1.css:3219, static/style-part1.css:3232, static/style-part1.css:3260, static/style-part1.css:3285 |
+| `#D7DEE8` | 5 | static/style-part3.css:402, static/ui-kit.css:836, static/ui-kit.css:851, static/ui-kit.css:852, static/ui-kit.css:3137 |
+| `#D7E0E9` | 2 | static/style-part4.css:3008, static/style-part4.css:3492 |
+| `#D7E0EA` | 4 | static/ui-kit.css:36, static/ui-kit.css:2682, static/ui-kit.css:3094, static/ui-kit.css:3164 |
+| `#D7E2EC` | 1 | static/ui-kit.css:1844 |
+| `#D7E4F1` | 1 | static/ui-kit.css:2093 |
+| `#D8A51D` | 1 | static/style-part3.css:3540 |
+| `#D8C788` | 1 | static/style-part2.css:1268 |
+| `#D8DEE6` | 7 | static/style-part3.css:42, static/style-part3.css:294, static/style-part3.css:3425, static/style-part3.css:3437, static/style-part3.css:3515, static/style-part3.css:3617, static/style-part3.css:3637 |
+| `#D8DEE7` | 2 | static/style-part3.css:208, static/style-part3.css:362 |
+| `#D8DEE8` | 2 | static/style-part2.css:1007, static/style-part2.css:1103 |
+| `#D8E0E8` | 3 | static/style-part4.css:840, static/style-part4.css:846, static/style-part4.css:3106 |
+| `#D8E0EA` | 2 | static/style-part4.css:431, static/style-part4.css:999 |
+| `#D8E1EA` | 2 | static/style-part3.css:2663, static/style-part3.css:2667 |
+| `#D8E1EC` | 11 | static/style-part4.css:1221, static/style-part4.css:1381, static/style-part4.css:1459, static/style-part4.css:1595, static/style-part4.css:1610, static/style-part4.css:1656, static/style-part4.css:1705, static/style-part4.css:1713, static/style-part4.css:1794, static/style-part4.css:1874, static/ui-kit.css:2556 |
+| `#D8E2ED` | 1 | static/ui-kit.css:1935 |
+| `#D8E4F0` | 5 | static/style-part1.css:763, static/style-part1.css:1788, static/style-part1.css:2148, static/style-part1.css:2736, static/style-part2.css:172 |
+| `#D9545F` | 2 | static/style-part3.css:3546, static/style-part3.css:3564 |
+| `#D9606B` | 2 | static/style-part4.css:805, static/style-part4.css:818 |
+| `#D9988A` | 1 | static/style-part1.css:943 |
+| `#D99B91` | 1 | static/style-part2.css:2599 |
+| `#D9B437` | 1 | static/style-part2.css:3324 |
+| `#D9BD72` | 1 | static/style-part2.css:2593 |
+| `#D9E0E7` | 1 | static/style-part3.css:2718 |
+| `#D9E1EC` | 8 | static/ui-kit.css:1211, static/ui-kit.css:1218, static/ui-kit.css:1222, static/ui-kit.css:1224, static/ui-kit.css:1228, static/ui-kit.css:1230, static/ui-kit.css:1231, static/ui-kit.css:1232 |
+| `#D9E3EF` | 1 | static/style-part4.css:248 |
+| `#D9E7F5` | 5 | static/style-part4.css:3141, static/style-part4.css:3172, static/style-part4.css:3361, static/style-part4.css:3392, static/style-part4.css:3414 |
+| `#DBE2EB` | 1 | static/ui-kit.css:995 |
+| `#DBE3EE` | 2 | static/style-part2.css:510, static/style-part2.css:582 |
+| `#DBE4EF` | 2 | static/style-part2.css:1618, static/style-part4.css:1031 |
+| `#DBE5F0` | 1 | static/style-part2.css:1197 |
+| `#DBE5F1` | 5 | static/ui-kit.css:1051, static/ui-kit.css:1067, static/ui-kit.css:1081, static/ui-kit.css:1171, static/ui-kit.css:1506 |
+| `#DBE7F4` | 1 | static/style-part3.css:3517 |
+| `#DBE8F5` | 9 | static/style-part4.css:3228, static/style-part4.css:3310 [comment], static/style-part4.css:3316, static/style-part4.css:3321, static/style-part4.css:3982, static/style-part4.css:4006, static/style-part4.css:4014, static/style-part4.css:4026 [comment], static/style-part4.css:4037 |
+| `#DBE8F7` | 1 | static/ui-kit.css:2725 |
+| `#DBEAFD` | 1 | static/ui-kit.css:3103 |
+| `#DBEAFE` | 3 | static/style-part2.css:436, static/style-part2.css:593, static/style-part2.css:642 |
+| `#DC2626` | 1 | static/style-part2.css:1512 |
+| `#DCCFAD` | 1 | static/style-part1.css:922 |
+| `#DCE3EC` | 2 | static/style-part2.css:1764, static/style-part2.css:1814 |
+| `#DCE4ED` | 3 | static/style-part3.css:915, static/style-part3.css:1021, static/style-part3.css:1152 |
+| `#DCE6F0` | 1 | static/ui-kit.css:1875 |
+| `#DCE7F1` | 1 | static/style-part4.css:1046 |
+| `#DCE8F5` | 1 | static/ui-kit.css:2204 |
+| `#DCE8F6` | 1 | static/ui-kit.css:2620 |
+| `#DCEAFB` | 1 | static/style-part2.css:908 |
+| `#DDE6EF` | 1 | static/style-part3.css:1219 |
+| `#DDE8F0` | 1 | static/style-part1.css:1738 |
+| `#DF4B5A` | 1 | static/style-part2.css:3292 |
+| `#DF5B64` | 4 | static/style-part2.css:3328, static/style-part2.css:3358, static/style-part4.css:3584 [comment], static/style-part4.css:3599 |
+| `#DF5D68` | 3 | static/style-part4.css:614, static/style-part4.css:628, static/style-part4.css:763 |
+| `#DF6B76` | 2 | static/style-part4.css:822, static/style-part4.css:829 |
+| `#DFB3B3` | 1 | static/style-part2.css:929 |
+| `#DFB5AF` | 1 | static/style-part2.css:1280 |
+| `#DFE3EA` | 3 | static/style-part1.css:3027, static/style-part2.css:52, static/style-part2.css:145 |
+| `#DFE4EB` | 6 | static/style-part2.css:2642, static/style-part2.css:2718, static/style-part2.css:2753, static/style-part3.css:191, static/style-part3.css:337, static/style-part3.css:344 |
+| `#DFE5EC` | 8 | static/style-part3.css:632, static/style-part3.css:718, static/style-part3.css:749, static/style-part3.css:1799, static/style-part3.css:1827, static/style-part3.css:1853, static/style-part3.css:1881, static/style-part4.css:67 |
+| `#DFE5EE` | 2 | static/style-part2.css:408, static/style-part2.css:736 |
+| `#DFE7F2` | 1 | static/style-part3.css:229 |
+| `#DFE8F1` | 1 | static/style-part3.css:843 |
+| `#DFE9F4` | 1 | static/style-part3.css:3626 |
+| `#DFF2E5` | 1 | static/style-part2.css:2521 |
+| `#E05D68` | 1 | static/style-part4.css:2954 |
+| `#E0B667` | 1 | static/style-part4.css:961 |
+| `#E0C8B8` | 1 | static/style-part1.css:1096 |
+| `#E0C8C0` | 1 | static/style-part1.css:933 |
+| `#E0C98B` | 1 | static/style-part2.css:923 |
+| `#E0E0E0` | 1 | static/style-part1.css:1502 |
+| `#E0E6EE` | 1 | static/style-part2.css:3949 |
+| `#E0E7EF` | 3 | static/style-part3.css:1217, static/style-part3.css:1218, static/style-part3.css:1326 |
+| `#E0F2FE` | 1 | static/style-part2.css:655 |
+| `#E0F3E5` | 1 | static/style-part2.css:2457 |
+| `#E14D68` | 4 | static/style-part4.css:1990, static/style-part4.css:1991, static/style-part4.css:1992, static/style-part4.css:2293 |
+| `#E1E6ED` | 2 | static/style-part3.css:3651, static/style-part3.css:3704 |
+| `#E1E9F2` | 1 | static/ui-kit.css:3141 |
+| `#E2BD45` | 1 | static/ui-kit.css:271 |
+| `#E2E8F0` | 2 | static/style-part2.css:444, static/style-part2.css:524 |
+| `#E2EBF5` | 2 | static/style-part3.css:674, static/ui-kit.css:3119 |
+| `#E2F3E7` | 3 | static/style-part2.css:1731, static/style-part2.css:1894, static/style-part2.css:2314 |
+| `#E3E8EE` | 2 | static/style-part4.css:129, static/style-part4.css:160 |
+| `#E4EAF1` | 1 | static/ui-kit.css:3095 |
+| `#E4EBF3` | 1 | static/ui-kit.css:47 |
+| `#E4EDF7` | 2 | static/ui-kit.css:1146, static/ui-kit.css:3009 |
+| `#E5E5E5` | 1 | static/style-part1.css:975 |
+| `#E5E7EB` | 2 | static/style-part2.css:461, static/style-part2.css:1440 |
+| `#E5E8EC` | 32 | static/style-part1.css:112, static/style-part1.css:358, static/style-part1.css:388, static/style-part1.css:477, static/style-part1.css:562, static/style-part1.css:654, static/style-part1.css:1907, static/style-part1.css:2071, static/style-part1.css:2116, static/style-part1.css:2128, static/style-part1.css:2188, static/style-part1.css:2213, static/style-part1.css:2387, static/style-part1.css:2472, static/style-part1.css:2534, static/style-part1.css:2624, static/style-part1.css:2636, static/style-part1.css:2703, static/style-part1.css:2722, static/style-part1.css:3102, static/style-part2.css:2055, static/style-part2.css:2069, static/style-part2.css:2135, static/style-part2.css:2143, static/style-part2.css:3520, static/style-part2.css:3575, static/style-part2.css:3664, static/style-part2.css:3740, static/style-part2.css:3824, static/style-part2.css:3893, static/style-part2.css:3989, static/style-part3.css:643 |
+| `#E5EAF0` | 2 | static/ui-kit.css:863, static/ui-kit.css:3136 |
+| `#E5EFF8` | 16 | static/style-part4.css:3216, static/style-part4.css:3222, static/style-part4.css:3252 [comment], static/style-part4.css:3262, static/style-part4.css:3401, static/style-part4.css:3410, static/style-part4.css:3425, static/style-part4.css:3974 [comment], static/style-part4.css:3981, static/style-part4.css:3988, static/style-part4.css:4002, static/style-part4.css:4013, static/style-part4.css:4021, static/style-part4.css:4026 [comment], static/style-part4.css:4034, static/style-part4.css:4035 |
+| `#E6C765` | 1 | static/style-part3.css:256 |
+| `#E6E9EF` | 3 | static/style-part1.css:2837, static/style-part1.css:2873, static/style-part2.css:1946 |
+| `#E6ECF3` | 5 | static/style-part3.css:1078, static/style-part4.css:3704, static/style-part4.css:3844, static/style-part4.css:3873, static/style-part4.css:3938 |
+| `#E6EEF8` | 1 | static/ui-kit.css:2517 |
+| `#E7E7E7` | 1 | static/style-part2.css:482 |
+| `#E7EBEF` | 1 | static/style-part2.css:1250 |
+| `#E7EBF0` | 1 | static/style-part4.css:119 |
+| `#E7EDF4` | 2 | static/style-part4.css:2037, static/style-part4.css:2353 |
+| `#E7EDF5` | 1 | static/style-part3.css:3390 |
+| `#E7EEF7` | 1 | static/ui-kit.css:1107 |
+| `#E7EEF8` | 1 | static/style-part4.css:292 |
+| `#E7F1FD` | 1 | static/style-part4.css:3485 |
+| `#E8B437` | 3 | static/style-part2.css:3354, static/style-part4.css:3583 [comment], static/style-part4.css:3595 |
+| `#E8B9BD` | 1 | static/style-part3.css:319 |
+| `#E8C86A` | 1 | static/style-part1.css:1378 |
+| `#E8D0CC` | 1 | static/style-part1.css:939 |
+| `#E8D5D5` | 1 | static/style-part1.css:990 |
+| `#E8DCC8` | 1 | static/style-part1.css:738 |
+| `#E8DDC0` | 1 | static/style-part1.css:914 |
+| `#E8DDC8` | 1 | static/style-part1.css:3501 |
+| `#E8E0D0` | 1 | static/style-part1.css:2340 |
+| `#E8E0D5` | 1 | static/style-part1.css:365 |
+| `#E8E0F0` | 1 | static/style-part1.css:228 |
+| `#E8E5E0` | 1 | static/style-part1.css:986 |
+| `#E8EAED` | 8 | static/style-part1.css:77, static/style-part1.css:672, static/style-part1.css:1846, static/style-part1.css:2090, static/style-part1.css:2495, static/style-part1.css:2506, static/style-part1.css:2658, static/style-part2.css:3391 |
+| `#E8ECF0` | 3 | static/style-part1.css:224, static/style-part1.css:463, static/style-part1.css:529 |
+| `#E8EDF3` | 1 | static/style-part3.css:691 |
+| `#E8EDF4` | 1 | static/ui-kit.css:896 |
+| `#E8EEF5` | 2 | static/style-part2.css:1182, static/ui-kit.css:1883 |
+| `#E8EEF7` | 3 | static/style-part1.css:3491, static/style-part2.css:162, static/ui-kit.css:2124 |
+| `#E8F0F8` | 2 | static/style-part1.css:571, static/style-part3.css:60 |
+| `#E8F0FE` | 2 | static/style-part2.css:3788, static/style-part2.css:3847 |
+| `#E8F2FB` | 1 | static/style-part4.css:893 |
+| `#E8F6EC` | 1 | static/style-part2.css:2582 |
+| `#E9B53C` | 1 | static/style-part2.css:3287 |
+| `#E9EDF2` | 2 | static/style-part3.css:769, static/ui-kit.css:3075 |
+| `#E9EDF3` | 1 | static/style-part2.css:948 |
+| `#E9F7ED` | 2 | static/style-part2.css:2512, static/style-part4.css:3341 [comment] |
+| `#EAD0D0` | 1 | static/style-part3.css:726 |
+| `#EAD8AE` | 1 | static/style-part3.css:1310 |
+| `#EAF1F7` | 1 | static/style-part3.css:2901 |
+| `#EAF2FB` | 3 | static/ui-kit.css:2138, static/ui-kit.css:2269, static/ui-kit.css:2270 |
+| `#EAF2FC` | 1 | static/ui-kit.css:1006 |
+| `#EAF2FF` | 1 | static/ui-kit.css:2112 |
+| `#EAF3FB` | 3 | static/style-part2.css:2588, static/style-part4.css:578, static/style-part4.css:616 |
+| `#EAF3FF` | 4 | static/style-part3.css:1814, static/style-part3.css:1868, static/ui-kit.css:3102, static/ui-kit.css:3115 |
+| `#EAF4FF` | 2 | static/style-part4.css:624, static/style-part4.css:753 |
+| `#EBC5C9` | 1 | static/ui-kit.css:276 |
+| `#ECD0D0` | 1 | static/style-part1.css:2523 |
+| `#ECEFF3` | 1 | static/style-part2.css:203 |
+| `#EDC5C5` | 1 | static/style-part3.css:1304 |
+| `#EDCC6A` | 1 | static/style-part1.css:928 |
+| `#EDEBE7` | 1 | static/style-part1.css:778 |
+| `#EDF0F3` | 1 | static/style-part4.css:139 |
+| `#EDF0F4` | 4 | static/style-part1.css:3110, static/style-part1.css:3272, static/style-part2.css:2758, static/ui-kit.css:902 |
+| `#EDF1F6` | 2 | static/style-part4.css:1341, static/ui-kit.css:1227 |
+| `#EDF2F7` | 2 | static/style-part3.css:836, static/style-part4.css:3007 |
+| `#EDF3F8` | 2 | static/style-part2.css:1238, static/style-part4.css:931 |
+| `#EDF3F9` | 2 | static/style-part3.css:664, static/ui-kit.css:3118 |
+| `#EDF3FB` | 4 | static/style-part1.css:2952, static/style-part2.css:2682, static/style-part3.css:1968, static/ui-kit.css:805 |
+| `#EDF4FB` | 8 | static/style-part4.css:2035, static/style-part4.css:2397, static/style-part4.css:2803, static/style-part4.css:2831, static/ui-kit.css:1090, static/ui-kit.css:1129, static/ui-kit.css:2176, static/ui-kit.css:2197 |
+| `#EDF4FF` | 1 | static/style-part4.css:102 |
+| `#EDF5FF` | 6 | static/ui-kit.css:1213, static/ui-kit.css:1225, static/ui-kit.css:1226, static/ui-kit.css:1230, static/ui-kit.css:2029, static/ui-kit.css:2087 |
+| `#EEF0F4` | 2 | static/style-part1.css:3040, static/style-part1.css:3060 |
+| `#EEF1F6` | 1 | static/style-part2.css:2855 |
+| `#EEF2F5` | 7 | static/style-part2.css:3449, static/style-part2.css:3638, static/style-part2.css:3720, static/style-part2.css:3770, static/style-part2.css:3870, static/style-part2.css:3923, static/style-part2.css:3941 |
+| `#EEF2F7` | 3 | static/style-part2.css:144, static/style-part3.css:3619, static/ui-kit.css:3070 |
+| `#EEF3F8` | 10 | static/style-part2.css:1035, static/style-part2.css:1642, static/style-part2.css:2576, static/style-part4.css:2030, static/style-part4.css:3108, static/style-part4.css:3493, static/ui-kit.css:38, static/ui-kit.css:3074, static/ui-kit.css:3135, static/ui-kit.css:3140 |
+| `#EEF4F8` | 1 | static/style-part1.css:1734 |
+| `#EEF4FA` | 4 | static/style-part3.css:917, static/style-part3.css:1023, static/style-part3.css:1154, static/style-part4.css:849 |
+| `#EEF4FB` | 9 | static/style-part4.css:1242, static/style-part4.css:1276, static/style-part4.css:1539, static/style-part4.css:1553, static/style-part4.css:1658, static/style-part4.css:1687, static/style-part4.css:1729, static/style-part4.css:1760, static/style-part4.css:1789 |
+| `#EEF4FF` | 1 | static/style-part1.css:1986 |
+| `#EEF5FC` | 1 | static/ui-kit.css:1183 |
+| `#EEF5FD` | 1 | static/ui-kit.css:2506 |
+| `#EEF5FF` | 3 | static/style-part2.css:511, static/style-part2.css:583, static/ui-kit.css:2436 |
+| `#EEF6FC` | 3 | static/style-part4.css:631, static/style-part4.css:851, static/style-part4.css:945 |
+| `#EEF6FF` | 7 | static/ui-kit.css:1218, static/ui-kit.css:1973, static/ui-kit.css:1984, static/ui-kit.css:3252, static/ui-kit.css:3268, static/ui-kit.css:3280, static/ui-kit.css:3287 |
+| `#EEF8F1` | 1 | static/style-part2.css:2302 |
+| `#EEF9F1` | 2 | static/style-part2.css:2452, static/style-part4.css:3342 [comment] |
+| `#EEFAF3` | 1 | static/style-part3.css:1295 |
+| `#EF4444` | 3 | static/style-part1.css:1329, static/style-part2.css:1513, static/style-part4.css:3060 |
+| `#EF4F5F` | 4 | static/style-part4.css:966, static/style-part4.css:967, static/style-part4.css:972, static/style-part4.css:1037 |
+| `#EFB6B1` | 1 | static/style-part4.css:3505 |
+| `#EFC8CC` | 1 | static/ui-kit.css:321 |
+| `#F0C75E` | 1 | static/ui-kit.css:2126 |
+| `#F0DDDA` | 1 | static/style-part1.css:931 |
+| `#F0E8D0` | 1 | static/style-part1.css:1752 |
+| `#F0EEEA` | 1 | static/style-part1.css:986 |
+| `#F0F0F0` | 13 | static/style-part1.css:161, static/style-part1.css:296, static/style-part1.css:489, static/style-part1.css:510, static/style-part1.css:528, static/style-part1.css:554, static/style-part1.css:1144, static/style-part1.css:1186, static/style-part1.css:1217, static/style-part1.css:1231, static/style-part1.css:1234, static/style-part1.css:1927, static/style-part1.css:2550 |
+| `#F0F2F5` | 10 | static/style-part1.css:13, static/style-part1.css:655, static/style-part1.css:1842, static/style-part1.css:1904, static/style-part1.css:1951, static/style-part1.css:2070, static/style-part1.css:2469, static/style-part1.css:2700, static/style-part2.css:3432, static/style-part4.css:3268 [comment] |
+| `#F0F4F0` | 1 | static/style-part1.css:596 |
+| `#F0F4F8` | 2 | static/style-part1.css:204, static/style-part2.css:3984 |
+| `#F1F3F6` | 1 | static/style-part1.css:3077 |
+| `#F1F8F3` | 1 | static/style-part2.css:1275 |
+| `#F2385A` | 1 | static/style-part4.css:3629 |
+| `#F2D17A` | 1 | static/ui-kit.css:2235 |
+| `#F2D38C` | 1 | static/style-part2.css:1586 |
+| `#F2DDDD` | 1 | static/style-part3.css:737 |
+| `#F2F4F7` | 2 | static/style-part2.css:1910, static/style-part2.css:2321 |
+| `#F2F7FB` | 2 | static/style-part3.css:2549, static/style-part3.css:2556 |
+| `#F2F7FC` | 2 | static/style-part4.css:3335 [comment], static/ui-kit.css:3216 |
+| `#F2F7FD` | 1 | static/ui-kit.css:2148 |
+| `#F3B63F` | 1 | static/style-part1.css:3381 |
+| `#F3F6F9` | 1 | static/style-part3.css:720 |
+| `#F3F6FA` | 2 | static/style-part2.css:402, static/style-part2.css:726 |
+| `#F3F6FB` | 1 | static/style-part1.css:3055 |
+| `#F3F7FB` | 2 | static/style-part3.css:2926, static/style-part4.css:2068 |
+| `#F3F8FF` | 1 | static/ui-kit.css:2650 |
+| `#F4F7FA` | 2 | static/style-part3.css:3712, static/style-part4.css:3099 |
+| `#F4F7FB` | 2 | static/style-part4.css:1399, static/ui-kit.css:3163 |
+| `#F4F8FC` | 7 | static/style-part4.css:640, static/style-part4.css:3181, static/style-part4.css:3376, static/ui-kit.css:1708, static/ui-kit.css:1716, static/ui-kit.css:1822, static/ui-kit.css:3259 |
+| `#F4F8FD` | 4 | static/style-part4.css:2034, static/style-part4.css:2408, static/style-part4.css:2794, static/style-part4.css:2841 |
+| `#F4F8FF` | 7 | static/ui-kit.css:2244, static/ui-kit.css:2252, static/ui-kit.css:2262, static/ui-kit.css:2263, static/ui-kit.css:2457, static/ui-kit.css:2927, static/ui-kit.css:2933 |
+| `#F4FBF6` | 1 | static/style-part2.css:1660 |
+| `#F59B2F` | 1 | static/ui-kit.css:1221 |
+| `#F59E0B` | 1 | static/style-part4.css:3055 |
+| `#F5A623` | 1 | static/style-part4.css:341 |
+| `#F5C542` | 5 | static/style-part2.css:2930, static/style-part2.css:2941, static/style-part2.css:3413, static/style-part3.css:34, static/style-part3.css:304 |
+| `#F5D980` | 1 | static/style-part1.css:924 |
+| `#F5DDDD` | 1 | static/style-part2.css:930 |
+| `#F5EDCF` | 1 | static/style-part2.css:924 |
+| `#F5EDE8` | 1 | static/style-part1.css:1095 |
+| `#F5F0E8` | 1 | static/style-part1.css:363 |
+| `#F5F3EF` | 1 | static/style-part1.css:778 |
+| `#F5F5F5` | 3 | static/style-part1.css:974, static/style-part1.css:1240, static/style-part1.css:1276 |
+| `#F5F7FA` | 16 | static/style-part1.css:406, static/style-part1.css:449, static/style-part1.css:1633, static/style-part1.css:2127, static/style-part1.css:2187, static/style-part1.css:2212, static/style-part1.css:2635, static/style-part1.css:2721, static/style-part2.css:3477, static/style-part2.css:3539, static/style-part3.css:293, static/style-part3.css:621, static/style-part3.css:3427, static/style-part3.css:3517, static/style-part4.css:1585, static/ui-kit.css:3071 |
+| `#F5F7FB` | 2 | static/style-part1.css:2822, static/style-part2.css:2834 |
+| `#F5F8FB` | 1 | static/style-part3.css:2252 |
+| `#F5F8FC` | 1 | static/style-part2.css:3594 |
+| `#F5F9FD` | 1 | static/style-part4.css:892 |
+| `#F5FFE8` | 1 | static/style-part1.css:213 |
+| `#F6F8FA` | 1 | static/style-part2.css:1263 |
+| `#F6F8FB` | 3 | static/style-part2.css:51, static/style-part2.css:2674, static/ui-kit.css:1207 |
+| `#F6F9FC` | 1 | static/style-part4.css:2932 |
+| `#F7E5E5` | 1 | static/style-part3.css:847 |
+| `#F7F9FB` | 2 | static/style-part3.css:41, static/style-part3.css:347 |
+| `#F7F9FC` | 10 | static/style-part3.css:405, static/style-part3.css:1801, static/style-part3.css:1855, static/style-part4.css:2031, static/style-part4.css:2378, static/ui-kit.css:864, static/ui-kit.css:2558, static/ui-kit.css:3073, static/ui-kit.css:3125, static/ui-kit.css:3134 |
+| `#F7FAFF` | 1 | static/style-part4.css:250 |
+| `#F7FBFF` | 1 | static/style-part3.css:3075 |
+| `#F8EDED` | 1 | static/style-part3.css:728 |
+| `#F8F0D8` | 1 | static/style-part1.css:995 |
+| `#F8F4E8` | 1 | static/style-part1.css:1748 |
+| `#F8F5F5` | 1 | static/style-part1.css:990 |
+| `#F8F6F2` | 1 | static/style-part1.css:1669 |
+| `#F8F8F8` | 1 | static/style-part1.css:723 |
+| `#F8F9FA` | 9 | static/style-part1.css:27, static/style-part1.css:561, static/style-part1.css:1503, static/style-part1.css:2412, static/style-part1.css:2561, static/style-part2.css:2054, static/style-part2.css:2068, static/style-part2.css:2134, static/style-part2.css:2142 |
+| `#F8F9FC` | 1 | static/style-part1.css:1842 |
+| `#F8FAFC` | 17 | static/style-part1.css:2942, static/style-part2.css:443, static/style-part2.css:633, static/style-part2.css:1028, static/style-part2.css:1364, static/style-part2.css:1599, static/style-part2.css:1801, static/style-part2.css:1870, static/style-part2.css:3571, static/style-part2.css:3678, static/style-part2.css:3802, static/style-part2.css:3884, static/style-part2.css:3907, static/style-part3.css:200, static/style-part3.css:1598, static/style-part4.css:162, static/ui-kit.css:2400 |
+| `#F8FBFF` | 6 | static/style-part2.css:1620, static/style-part3.css:917, static/style-part3.css:1023, static/style-part3.css:1154, static/style-part4.css:3846, static/ui-kit.css:1711 |
+| `#FAFBFC` | 5 | static/style-part1.css:315, static/style-part1.css:2104, static/style-part1.css:2612, static/style-part1.css:3273, static/style-part2.css:95 |
+| `#FAFBFD` | 1 | static/ui-kit.css:997 |
+| `#FAFFF5` | 1 | static/style-part1.css:209 |
+| `#FBE8A6` | 1 | static/style-part3.css:254 |
+| `#FBF5DF` | 1 | static/style-part2.css:2594 |
+| `#FBFCFE` | 3 | static/style-part3.css:644, static/style-part3.css:1460, static/style-part4.css:1611 |
+| `#FCD34D` | 1 | static/style-part4.css:1183 |
+| `#FCECEA` | 1 | static/style-part2.css:2600 |
+| `#FDF8E8` | 1 | static/style-part1.css:995 |
+| `#FECACA` | 1 | static/style-part2.css:662 |
+| `#FEE2E2` | 1 | static/style-part2.css:672 |
+| `#FF5722` | 2 | static/style-part1.css:210, static/style-part1.css:275 |
+| `#FF6262` | 1 | static/style-part1.css:3389 |
+| `#FF6B35` | 2 | static/style-part1.css:1886, static/style-part1.css:1895 |
+| `#FF6B6B` | 1 | static/style-part4.css:345 |
+| `#FF7D7D` | 1 | static/ui-kit.css:2127 |
+| `#FF858C` | 1 | static/style-part3.css:3562 |
+| `#FF8A80` | 1 | static/style-part4.css:3204 |
+| `#FF9DA4` | 1 | static/style-part4.css:3151 |
+| `#FFB3BA` | 1 | static/ui-kit.css:2229 |
+| `#FFB4BA` | 1 | static/style-part4.css:3527 |
+| `#FFB5BC` | 1 | static/style-part4.css:975 |
+| `#FFBBC0` | 1 | static/style-part4.css:3157 |
+| `#FFD35A` | 1 | static/style-part3.css:3556 |
+| `#FFE7E9` | 1 | static/style-part3.css:3545 |
+| `#FFE8E8` | 2 | static/style-part2.css:2446, static/style-part2.css:3994 |
+| `#FFE8EB` | 1 | static/style-part4.css:824 |
+| `#FFF0EF` | 2 | static/style-part4.css:112, static/style-part4.css:3504 |
+| `#FFF0F1` | 1 | static/style-part3.css:318 |
+| `#FFF2C7` | 1 | static/style-part3.css:3539 |
+| `#FFF2F3` | 1 | static/style-part4.css:3240 |
+| `#FFF3F3` | 1 | static/style-part3.css:1305 |
+| `#FFF4F2` | 1 | static/style-part2.css:1281 |
+| `#FFF4F5` | 1 | static/style-part4.css:807 |
+| `#FFF5F5` | 3 | static/style-part2.css:663, static/style-part2.css:2432, static/style-part4.css:3341 [comment] |
+| `#FFF9EA` | 1 | static/style-part3.css:1311 |
+| `#FFFAF0` | 1 | static/style-part2.css:1269 |
+| `#FFFFFF` | 46 | static/style-part1.css:1824, static/style-part1.css:2833, static/style-part1.css:2957, static/style-part1.css:3026, static/style-part1.css:3098, static/style-part2.css:407, static/style-part2.css:526, static/style-part2.css:735, static/style-part2.css:1215, static/style-part2.css:1766, static/style-part2.css:1816, static/style-part2.css:3387, static/style-part3.css:207, static/style-part3.css:354, static/style-part3.css:361, static/style-part3.css:417, static/style-part3.css:422, static/style-part3.css:516, static/style-part3.css:1289, static/style-part3.css:1460, static/style-part3.css:1958, static/style-part3.css:1977, static/style-part3.css:3018, static/style-part4.css:1222, static/style-part4.css:2032, static/style-part4.css:2033, static/style-part4.css:2251, static/style-part4.css:2345, static/style-part4.css:2352, static/style-part4.css:2416, static/style-part4.css:2512, static/style-part4.css:2751, static/style-part4.css:2883, static/style-part4.css:3147, static/style-part4.css:3189, static/style-part4.css:3277 [comment], static/style-part4.css:3386, static/ui-kit.css:2065, static/ui-kit.css:2100, static/ui-kit.css:2211, static/ui-kit.css:2732, static/ui-kit.css:3072, static/ui-kit.css:3089, static/ui-kit.css:3126, static/ui-kit.css:3127, static/ui-kit.css:3133 |

--- a/docs/theme-registry/tools/check_new_hex.py
+++ b/docs/theme-registry/tools/check_new_hex.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Flag raw 6-digit HEX literals introduced into MeshCenter's theming CSS
+that aren't already accounted for in docs/theme-registry/raw-hex-audit.md's
+registry (hex_registry.json, generated alongside it).
+
+Meant to gate theme-registry stage PRs: once later stages start migrating
+raw HEX to `--mc-*` tokens, any *new* raw HEX literal showing up in a diff is
+either a missed token opportunity or an undocumented one-off that the
+registry needs to know about.
+
+Two modes:
+
+1. Check specific file(s) as they stand on disk:
+     python check_new_hex.py static/style-part4.css static/ui-kit.css
+
+2. Check a git diff (unstaged, or against a ref) for newly *added* HEX
+   literals only - pass --diff [<git-diff-args...>]. With no extra args this
+   is `git diff` (unstaged changes); pass e.g. --diff HEAD~1 to check a
+   specific range. Only lines beginning with '+' (added lines, not the
+   '+++' file header) are scanned, so removed/untouched HEX is ignored.
+
+Exit status is 1 if any un-registered HEX literal is found (for CI use),
+0 otherwise.
+"""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY_PATH = Path(__file__).resolve().parent.parent / "hex_registry.json"
+
+HEX_RE = re.compile(r"#([0-9a-fA-F]{6})\b")
+
+THEME_CSS_FILES = {
+    "static/style-part1.css",
+    "static/style-part2.css",
+    "static/style-part3.css",
+    "static/style-part4.css",
+    "static/ui-kit.css",
+}
+
+
+def load_known_hex() -> set[str]:
+    if not REGISTRY_PATH.exists():
+        print(f"warning: registry not found at {REGISTRY_PATH}; treating all HEX as new", file=sys.stderr)
+        return set()
+    rows = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    return {row["value"].upper() for row in rows}
+
+
+def strip_comment_spans(text: str) -> str:
+    """Blank out /* ... */ comment contents so HEX inside design-note comments
+    doesn't get flagged as a new live declaration."""
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i:i + 2] == "/*":
+            j = text.find("*/", i + 2)
+            end = j + 2 if j != -1 else n
+            out.append(" " * (end - i))
+            i = end
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
+def check_files(paths: list[Path], known: set[str]) -> list[tuple[str, int, str]]:
+    findings = []
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        clean = strip_comment_spans(text)
+        for lineno, line in enumerate(clean.splitlines(), start=1):
+            for m in HEX_RE.finditer(line):
+                val = m.group(1).upper()
+                if val not in known:
+                    findings.append((str(path), lineno, val))
+    return findings
+
+
+def check_diff(diff_args: list[str], known: set[str]) -> list[tuple[str, str, str]]:
+    cmd = ["git", "diff", "--unified=0"] + diff_args
+    result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=True)
+    findings = []
+    current_file = None
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ "):
+            fname = line[4:].strip()
+            if fname.startswith("b/"):
+                fname = fname[2:]
+            current_file = fname
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if current_file is None or current_file.replace("\\", "/") not in THEME_CSS_FILES:
+            continue
+        added_line = strip_comment_spans(line[1:])
+        for m in HEX_RE.finditer(added_line):
+            val = m.group(1).upper()
+            if val not in known:
+                findings.append((current_file, added_line.strip()[:120], val))
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    known = load_known_hex()
+
+    if argv and argv[0] == "--diff":
+        diff_args = argv[1:]
+        findings = check_diff(diff_args, known)
+        if not findings:
+            print(f"OK: no unregistered HEX literals added (checked against {len(known)} known values).")
+            return 0
+        print(f"Found {len(findings)} unregistered HEX literal(s) in the diff:\n")
+        for fname, context, val in findings:
+            print(f"  {fname}: #{val}\n    {context}")
+        print(
+            "\nEach of these is either a new theme color that should become a "
+            "--mc-* token instead of raw HEX, or a legitimate new one-off that "
+            "needs to be added to docs/theme-registry/raw-hex-audit.md's "
+            "registry. Re-run the audit generator (.theme_stage0_scratch/"
+            "classify_hex.py + render_audit_md.py, or its successor) to update "
+            "hex_registry.json once triaged."
+        )
+        return 1
+
+    if not argv:
+        print(__doc__)
+        return 1
+
+    paths = [Path(p) for p in argv]
+    findings = check_files(paths, known)
+    if not findings:
+        print(f"OK: no unregistered HEX literals found in {len(paths)} file(s) (checked against {len(known)} known values).")
+        return 0
+    print(f"Found {len(findings)} unregistered HEX literal(s):\n")
+    for fname, lineno, val in findings:
+        print(f"  {fname}:{lineno}  #{val}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/theme-registry/tools/contrast_check.py
+++ b/docs/theme-registry/tools/contrast_check.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""WCAG 2.2 relative luminance / contrast ratio checker for MeshCenter's
+theme-registry work (Stage 0+). No third-party dependencies.
+
+Usage:
+    python contrast_check.py <hex1> <hex2> [<hex3> <hex4> ...]
+
+Each pair of consecutive arguments is checked as a foreground/background pair.
+Prints the WCAG 2.2 contrast ratio and whether it passes the standard text
+thresholds (4.5:1 normal text / AA, 3:1 large text or UI components / AA,
+7:1 / AAA).
+
+Example:
+    python contrast_check.py CC5500 263744
+"""
+import sys
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    value = value.strip().lstrip("#")
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    if len(value) != 6:
+        raise ValueError(f"not a 6-digit (or 3-digit) hex color: {value!r}")
+    r = int(value[0:2], 16)
+    g = int(value[2:4], 16)
+    b = int(value[4:6], 16)
+    return r, g, b
+
+
+def _channel_to_linear(c_8bit: int) -> float:
+    # WCAG 2.x relative luminance formula (sRGB -> linear-light).
+    c = c_8bit / 255.0
+    if c <= 0.03928:
+        return c / 12.92
+    return ((c + 0.055) / 1.055) ** 2.4
+
+
+def relative_luminance(hex_color: str) -> float:
+    r, g, b = _hex_to_rgb(hex_color)
+    r_lin = _channel_to_linear(r)
+    g_lin = _channel_to_linear(g)
+    b_lin = _channel_to_linear(b)
+    # ITU-R BT.709 coefficients, per WCAG 2.x spec section 1.4.3 Appendix.
+    return 0.2126 * r_lin + 0.7152 * g_lin + 0.0722 * b_lin
+
+
+def contrast_ratio(hex_a: str, hex_b: str) -> float:
+    l1 = relative_luminance(hex_a)
+    l2 = relative_luminance(hex_b)
+    lighter, darker = max(l1, l2), min(l1, l2)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def describe(ratio: float) -> str:
+    checks = []
+    checks.append(("AA normal text (>=4.5:1)", ratio >= 4.5))
+    checks.append(("AA large text / UI components (>=3:1)", ratio >= 3.0))
+    checks.append(("AAA normal text (>=7:1)", ratio >= 7.0))
+    return "\n".join(f"  [{'PASS' if ok else 'FAIL'}] {label}" for label, ok in checks)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2 or len(argv) % 2 != 0:
+        print(__doc__)
+        return 1
+    for i in range(0, len(argv), 2):
+        a, b = argv[i], argv[i + 1]
+        ratio = contrast_ratio(a, b)
+        print(f"#{a.lstrip('#').upper()} vs #{b.lstrip('#').upper()}: {ratio:.2f}:1")
+        print(describe(ratio))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Preparatory-only Stage 0 of the multi-stage theme/design-token normalization effort. No CSS values changed, no components touched, no runtime behavior affected.
- `docs/theme-registry/raw-hex-audit.md`: inventory of all 968 unique HEX literals (2019 occurrences) across the 5 theming CSS files, classified per file:line as semantic-status-candidate / ui-normalization-candidate / mixed. Includes an explicit scope caveat: Leaflet's own CSS is loaded externally and was not part of this grep, so its absence from the registry means "out of scope," not "checked and found clean."
- `docs/theme-registry/computed-styles-baseline.md`: computed background/text/border/box-shadow for 12 component categories (panel, card, control, primary button, popover, dialog, toast, badge, table, node card, media stage, telemetry chart container), both themes - the "before" reference later stages diff against.
- `docs/theme-registry/tools/contrast_check.py`: WCAG 2.2 relative-luminance/contrast-ratio checker, no dependencies.
- `docs/theme-registry/tools/check_new_hex.py`: flags any raw HEX literal not already in `hex_registry.json`, checkable against files on disk or a `git diff` - meant to gate every subsequent stage's PR from 1.1 onward.
- `docs/theme-registry/hex_registry.json`: machine-readable backing data for both the audit doc and the linter.

The baseline screenshots (light/dark renders of each screen, built via a throwaway Playwright/headless-Chromium harness loading the real CSS files directly) are not included here per the task's own instruction - they're throwaway and were handed back for review in-chat, not committed.

## Test plan
- [x] `contrast_check.py CC5500 263744` prints `2.84:1`, matching the independently-verified reference value
- [x] `check_new_hex.py` against the 5 CSS files as-is reports 0 unregistered HEX literals
- [x] `check_new_hex.py --diff` against a synthetic diff correctly flags a new `#ABCDEF` literal while ignoring an already-registered value
- [x] `python -m compileall` clean on both new scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)