### PR TITLE
Theme registry Stage 1.1: MeshCenter Dark chat/messages normalization

### DIFF
--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -2091,12 +2091,18 @@ body[data-theme="dark"] {
 
 [data-theme="dark"] .app-container,
 [data-theme="dark"] .main-layout,
-[data-theme="dark"] .chat-area,
 [data-theme="dark"] .workspace-view,
 [data-theme="dark"] .devices-view,
 [data-theme="dark"] .node-manager-view {
     background: var(--theme-workspace-bg);
     color: var(--theme-text);
+}
+
+/* Chat/messages domain (theme-registry Stage 1.1): canonical --mc-*
+   tokens instead of the legacy --theme-* alias chain used above. */
+[data-theme="dark"] .chat-area {
+    background: var(--mc-chat-bg);
+    color: var(--mc-chat-text);
 }
 
 /* Workspace panels and headers. */

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1053,10 +1053,6 @@ html[data-theme="dark"] body {
 
 html[data-theme="dark"] .app-container,
 html[data-theme="dark"] .main-layout,
-html[data-theme="dark"] .chat-area,
-html[data-theme="dark"] .chat-header,
-html[data-theme="dark"] .chat-list-container,
-html[data-theme="dark"] .messages-view,
 html[data-theme="dark"] .video-panel,
 html[data-theme="dark"] .media-panel,
 html[data-theme="dark"] .system-panel,
@@ -1067,13 +1063,23 @@ html[data-theme="dark"] .sidebar {
     color: #dbe5f1;
 }
 
+/* Chat/messages domain (theme-registry Stage 1.1): tokenized instead of
+   the raw hex above so the chat workspace shares the --mc-chat-* surface
+   family with the rest of the chat rules further down this file. */
+html[data-theme="dark"] .chat-area,
+html[data-theme="dark"] .chat-header,
+html[data-theme="dark"] .chat-list-container,
+html[data-theme="dark"] .messages-view {
+    background-color: var(--mc-chat-bg);
+    color: var(--mc-chat-text);
+}
+
 html[data-theme="dark"] .base-card,
 html[data-theme="dark"] .sensors-card,
 html[data-theme="dark"] .telemetry-section,
 html[data-theme="dark"] .weather-card,
 html[data-theme="dark"] .base-reference-location,
 html[data-theme="dark"] .node-card,
-html[data-theme="dark"] .chat-item,
 html[data-theme="dark"] .settings-card,
 html[data-theme="dark"] .system-card {
     background-color: #202a36;
@@ -1081,7 +1087,14 @@ html[data-theme="dark"] .system-card {
     color: #dbe5f1;
 }
 
-html[data-theme="dark"] .chat-title,
+/* Chat list row (theme-registry Stage 1.1) - matches the tokens the later,
+   higher-specificity !important rule for .chat-item already uses. */
+html[data-theme="dark"] .chat-item {
+    background-color: var(--mc-bg-panel);
+    border-color: var(--mc-border);
+    color: var(--mc-text-primary);
+}
+
 html[data-theme="dark"] .workspace-page-title,
 html[data-theme="dark"] .base-card-title,
 html[data-theme="dark"] .sensors-title,
@@ -1090,12 +1103,19 @@ html[data-theme="dark"] .weather-card-title {
     color: #edf4fb;
 }
 
-html[data-theme="dark"] .chat-subtitle,
+html[data-theme="dark"] .chat-title {
+    color: var(--mc-chat-text);
+}
+
 html[data-theme="dark"] .workspace-page-subtitle,
 html[data-theme="dark"] .sensor-label,
-html[data-theme="dark"] .node-meta,
-html[data-theme="dark"] .message-time {
+html[data-theme="dark"] .node-meta {
     color: #96a6b8;
+}
+
+html[data-theme="dark"] .chat-subtitle,
+html[data-theme="dark"] .message-time {
+    color: var(--mc-chat-muted);
 }
 
 html[data-theme="dark"] input,
@@ -1658,18 +1678,26 @@ html[data-theme="dark"] :is(
 }
 
 html[data-theme="dark"] :is(
-    .chat-item:hover, .node-card:hover,
+    .node-card:hover,
     .about-resource-card:hover
 ) {
     background: #233346 !important;
 }
 
+html[data-theme="dark"] .chat-item:hover {
+    background: var(--mc-chat-surface-raised) !important;
+}
+
 html[data-theme="dark"] :is(
-    .chat-item.active, .chat-item.selected,
     .node-card.active, .node-card.selected
 ) {
     background: #263e58 !important;
     border-color: #66a8ff !important;
+}
+
+html[data-theme="dark"] :is(.chat-item.active, .chat-item.selected) {
+    background: var(--mc-primary-soft) !important;
+    border-color: var(--mc-border-active) !important;
 }
 
 /* Inputs, selectors and table-like rows */
@@ -1927,13 +1955,13 @@ html[data-theme="dark"] .message.rx .bubble {
 }
 
 html[data-theme="dark"] .message.rx .bubble .sender {
-    color: #8fc5ff !important;
+    color: var(--mc-primary-hover) !important;
 }
 
 html[data-theme="dark"] .message.system .bubble {
-    background: #273140 !important;
-    color: #d8e2ed !important;
-    border-color: #3b4858 !important;
+    background: var(--mc-surface-2) !important;
+    color: var(--mc-text-secondary) !important;
+    border-color: var(--mc-chat-border) !important;
 }
 
 html[data-theme="dark"] .bubble .time,
@@ -1943,7 +1971,7 @@ html[data-theme="dark"] .message-time {
 
 /* Composer: slightly lighter than the chat canvas, with a subdued frame. */
 html[data-theme="dark"] .input-area {
-    background: #142130 !important;
+    background: var(--mc-chat-surface) !important;
     border-top-color: var(--mc-chat-border) !important;
 }
 
@@ -1951,19 +1979,19 @@ html[data-theme="dark"] .input-form input[type="text"],
 html[data-theme="dark"] .message-input {
     background: var(--mc-chat-input) !important;
     color: var(--mc-chat-text) !important;
-    border-color: #36506a !important;
+    border-color: var(--mc-dark-control-border) !important;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.015);
 }
 
 html[data-theme="dark"] .input-form input[type="text"]::placeholder,
 html[data-theme="dark"] .message-input::placeholder {
-    color: #8fa3b8 !important;
+    color: var(--mc-text-muted) !important;
 }
 
 html[data-theme="dark"] .input-form input[type="text"]:focus,
 html[data-theme="dark"] .message-input:focus {
-    background: #203247 !important;
-    border-color: #4ea1ff !important;
+    background: var(--mc-chat-surface-raised) !important;
+    border-color: var(--mc-border-focus) !important;
     box-shadow: 0 0 0 2px rgba(78, 161, 255, 0.16) !important;
 }
 
@@ -2454,25 +2482,25 @@ html[data-theme="dark"] .camera-loading-title {
    Exact classes used by renderChatItem() in static/chat.js.
    ========================================================== */
 html[data-theme="dark"] .chat-item .chat-name {
-    color: #f4f8ff !important;
+    color: var(--mc-chat-text) !important;
     font-weight: 700 !important;
 }
 
 html[data-theme="dark"] .chat-item .chat-last-msg,
 html[data-theme="dark"] .chat-item .chat-last-sender,
 html[data-theme="dark"] .chat-item .chat-last-text {
-    color: #aebed0 !important;
+    color: var(--mc-chat-muted) !important;
 }
 
 html[data-theme="dark"] .chat-item.selected .chat-last-sender,
 html[data-theme="dark"] .chat-item.selected .chat-last-text,
 html[data-theme="dark"] .chat-item.active .chat-last-sender,
 html[data-theme="dark"] .chat-item.active .chat-last-text {
-    color: #c9d7e6 !important;
+    color: var(--mc-text-secondary) !important;
 }
 
 html[data-theme="dark"] .chat-item .chat-time {
-    color: #9fb0c2 !important;
+    color: var(--mc-chat-muted) !important;
 }
 
 


### PR DESCRIPTION
## Summary
Chat/messages domain only, MeshCenter Dark only. Replaces raw hex and legacy `--theme-*` references inside dark-mode chat/message rules with existing canonical `--mc-*` tokens (`static/ui-kit.css`, `static/style-part4.css`). No new tokens introduced. No visual redesign - goal is byte-for-byte-adjacent, not identical, colors.

Several rules previously bundled chat selectors (`.chat-area`, `.chat-item`, `.chat-title`, etc.) together with out-of-scope selectors (`.node-card`, `.settings-card`, `.workspace-view`, ...) in one comma-separated rule. Those were split so only the chat side moves to tokens - the non-chat side keeps its original raw hex untouched, out of scope for this stage.

### Token replacements made (by role)
**Chat workspace surfaces** (`.chat-area`, `.chat-header`, `.chat-list-container`, `.messages-view`, `.chat-item`, `.input-area`): raw hex -> `--mc-chat-bg`, `--mc-chat-text`, `--mc-bg-panel`, `--mc-border`, `--mc-text-primary`, `--mc-chat-surface`. Legacy `--theme-workspace-bg`/`--theme-text` chain on `.chat-area` (style-part4.css) -> `--mc-chat-bg`/`--mc-chat-text`.

**Chat list row states**: `.chat-item:hover` -> `--mc-chat-surface-raised`; `.chat-item.active/.selected` -> `--mc-primary-soft` bg + `--mc-border-active` border; `.chat-name` -> `--mc-chat-text`; `.chat-last-msg/-sender/-text` + `.chat-time` -> `--mc-chat-muted`; selected/active last-sender/text -> `--mc-text-secondary`.

**Message bubbles & timestamps**: `.message.system .bubble` -> `--mc-surface-2` bg / `--mc-text-secondary` text / `--mc-chat-border` border. `.message.rx .bubble .sender` -> `--mc-primary-hover` (flagged below - value-driven pick, not a clean role match).

**Composer**: `.input-form input[type="text"]` (+ legacy `.message-input`, dead selector, see below) border -> `--mc-dark-control-border`; placeholder -> `--mc-text-muted`; `:focus` background -> `--mc-chat-surface-raised`, border -> `--mc-border-focus`.

### Flagged, not silently forced
- **`.message.rx .bubble .sender` color** (`#8fc5ff` -> `--mc-primary-hover`): no existing token's *name* fits a static sender-name accent color - the closest role-appropriate tokens (`--mc-primary`, `--mc-info`) differ visibly (~16%/~9% per channel), while `--mc-primary-hover` (a hover-state token) matches the old value almost exactly (diff 5,7,0). Picked for value fidelity over strict role purity; worth a dedicated token (e.g. `--mc-chat-sender-accent`) in a later stage rather than reusing a hover-state token for static text.
- **`.input-form input[type="text"]:focus` border** (`#4ea1ff` -> `--mc-border-focus`): `--mc-border-focus` is the correct role but its dark value differs from the old raw hex by up to ~14.5% on the red channel - the largest value delta in this diff. Flagged for a closer look if focus-ring fidelity ever becomes a concern; the visual weight is mostly carried by the (untouched) box-shadow glow.
- **Dead `.message-input` selector** left alone where it's bundled with genuinely app-wide `input, select, textarea` (ui-kit.css ~1676) - no live element carries this class, and touching that block would affect all app inputs, not just chat. Where `.message-input` rides along with the real, chat-scoped `.input-form input[type="text"]` selector it was tokenized along with it (zero risk, since it's unreachable).
- **No dark-mode override exists at all** (so nothing to normalize) for `.chat-icon`, `.chat-unread-badge`, `.reply-composer`, `.emoji-*`, or the split channels/DM list section (`.chat-section-heading`, `.dm-section`) - confirmed by grep, not just absence of a match.
- **Excluded as out-of-scope "popover"**, not "message bubble": `.message-actions-menu` / `.message-action-item` / `.message-info-*` (the per-message ⋮ dropdown and its info panel) - these are contextual popovers, same category as the dialogs/popovers explicitly excluded from this stage.

### Contrast spot-checks (`contrast_check.py`)
All touched text/surface pairs pass AA (4.5:1 normal text / 3:1 large text & borders) except one pre-existing failure, unchanged by this diff:
- `.input-form input[type="text"]` border vs its background: **1.79:1** (was 1.72:1 with the old raw hex `#36506a` vs `#1b2b3d`) - already below the 3:1 border threshold before this change; not fixed, since fixing contrast is out of scope for this stage.
- Everything else checked (chat-item text/bg, selected-state text/bg, system-bubble text/bg, sender accent vs bubble bg, chat-area text vs bg, placeholder vs input bg, focus border vs surface) passes AA, several pass AAA.

### Verification
- `check_new_hex.py --diff`: clean, no unregistered raw hex introduced.
- Before/after render via the Stage 0 fixture harness (headless Chromium, real CSS): dark chat-messages screen is visually indistinguishable - pixel diff mean delta ~3/255 (~1.3%) with a max of ~24/255 in isolated spots (the two flagged value-driven picks above), confirmed with a side-by-side and an 8x-amplified diff image (shared in chat). Dark node-list-and-detail screen: **zero pixel diff** confirming no spillover outside the chat domain.

## Test plan
- [x] `check_new_hex.py --diff` clean
- [x] `contrast_check.py` spot-checks on every touched text/surface and border pair
- [x] Before/after fixture render comparison (light untouched entirely; dark chat-messages visually identical, dark node-list-and-detail zero-diff)
- [x] Brace-balance sanity check on both edited CSS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)