### PR TITLE
Fix stale cache-busting version for Stage 1.1 CSS changes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,8 +9,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260901-btn-system">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
- PR #173 (theme-registry Stage 1.1) changed `static/ui-kit.css` and `static/style-part4.css` but didn't bump their `?v=` cache-busting query strings in `templates/index.html`, so a browser that already cached either file would keep serving the pre-Stage-1.1 version indefinitely.
- Bumps both to `20260903-theme-stage1-1`.

Found this while doing the post-merge dev deploy/visual check for #173.

## Test plan
- [x] `python -m compileall` / no code changes beyond the two query strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)