### PR TITLE
Theme registry Stage 1.2: MeshCenter Dark node cards normalization

### DIFF
--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1079,12 +1079,19 @@ html[data-theme="dark"] .sensors-card,
 html[data-theme="dark"] .telemetry-section,
 html[data-theme="dark"] .weather-card,
 html[data-theme="dark"] .base-reference-location,
-html[data-theme="dark"] .node-card,
 html[data-theme="dark"] .settings-card,
 html[data-theme="dark"] .system-card {
     background-color: #202a36;
     border-color: #364253;
     color: #dbe5f1;
+}
+
+/* Node card (theme-registry Stage 1.2) - matches the tokens the later,
+   higher-specificity !important rule for .node-card already uses. */
+html[data-theme="dark"] .node-card {
+    background-color: var(--mc-bg-panel);
+    border-color: var(--mc-border);
+    color: var(--mc-text-primary);
 }
 
 /* Chat list row (theme-registry Stage 1.1) - matches the tokens the later,
@@ -1677,22 +1684,21 @@ html[data-theme="dark"] :is(
     color: var(--mc-text-primary) !important;
 }
 
-html[data-theme="dark"] :is(
-    .node-card:hover,
-    .about-resource-card:hover
-) {
+html[data-theme="dark"] .about-resource-card:hover {
     background: #233346 !important;
+}
+
+html[data-theme="dark"] .node-card:hover {
+    background: var(--mc-surface-2) !important;
 }
 
 html[data-theme="dark"] .chat-item:hover {
     background: var(--mc-chat-surface-raised) !important;
 }
 
-html[data-theme="dark"] :is(
-    .node-card.active, .node-card.selected
-) {
-    background: #263e58 !important;
-    border-color: #66a8ff !important;
+html[data-theme="dark"] :is(.node-card.active, .node-card.selected) {
+    background: var(--mc-primary-soft) !important;
+    border-color: var(--mc-border-active) !important;
 }
 
 html[data-theme="dark"] :is(.chat-item.active, .chat-item.selected) {
@@ -2277,7 +2283,7 @@ html[data-theme="dark"] .node-details-panel .node-title{
 /* Dark theme - node card titles (right panel and selected node header) */
 html[data-theme="dark"] .node-card-topline .node-card-title,
 html[data-theme="dark"] .node-card .node-card-title {
-    color: #f4f8ff !important;
+    color: var(--mc-text-primary) !important;
     font-weight: 700 !important;
     text-shadow: none !important;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260901-btn-system">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
Node cards domain only, MeshCenter Dark only. Replaces raw hex inside dark-mode node-card rules with existing canonical `--mc-*` tokens (`static/ui-kit.css`). No new tokens introduced, no visual redesign.

Same pattern as Stage 1.1 (#173): several rules bundled `.node-card` together with out-of-scope selectors (`.base-card`, `.settings-card`, `.system-card`, `.about-resource-card`) in one comma-separated rule - those were split so only the node-card side moves to tokens, the rest keeps its original raw hex untouched.

### Token replacements made (by role)
- **Base card chrome** (`.node-card`, previously bundled with `.base-card`/`.sensors-card`/`.settings-card`/`.system-card`): `#202a36`/`#364253`/`#dbe5f1` -> `--mc-bg-panel`/`--mc-border`/`--mc-text-primary`. This exactly matches the tokens the later, higher-specificity `!important` rule for `.node-card` already used - that rule already governed the live render, so this split is hygiene (removing a shadowed, inconsistent duplicate), not a visual change.
- **Hover** (`.node-card:hover`, previously bundled with `.about-resource-card:hover`): `#233346` -> `--mc-surface-2` (diff ~3/255 per channel from the old raw value).
- **Active/selected** (`.node-card.active`/`.node-card.selected` - already isolated to node cards after Stage 1.1's `.chat-item` split): `#263e58`/`#66a8ff` -> `--mc-primary-soft`/`--mc-border-active`. Identical raw values to what Stage 1.1 mapped for `.chat-item.active/.selected`, so this reuses the exact same token pair for consistency.
- **Card title** (`.node-card-topline .node-card-title`, `.node-card .node-card-title`): `#f4f8ff` -> `--mc-text-primary` (diff ~2/255).

### Flagged, not forced
- **Favorite-star color** (`.node-favorite-slot` / `.node-card.favorite .node-favorite-slot`, dark `#f5c542`): left as raw hex, untouched. This exact gold is reused deliberately ~6 times across the codebase (node card favorite slot, node-detail favorite button, etc.) as a consistent "favorite/starred" indicator - it's a genuine, distinct semantic concept with no existing token to match. The closest candidate, `--mc-warning` (`#f0c86a` dark), differs by ~40/255 on the blue channel alone - a real, likely-perceptible hue shift on a small saturated icon, not a safe substitution. Recommend a dedicated `--mc-favorite` token in a future stage that's explicitly about adding tokens, not this consolidation-only stage.
- **`.selected-node-card` / `.node-details-panel` block** (ui-kit.css, `.node-name`/`.node-title` color): confirmed dead - neither selector nor either child class appears anywhere in `static/chat.js`, `static/chat-*.js`, or `templates/index.html`. Left untouched rather than editing genuinely unreachable CSS.
- **Node Manager / node-detail-card selectors excluded as out-of-scope**: `.node-manager-avatar` (bundled with `.node-profile-icon`/`.device-hero-icon`, Node Manager workspace domain, and already using the legacy `--theme-*` chain, not raw hex) and `.node-detail-favorite`/`.node-detail-favorite-btn.active` (the expanded node-detail panel, a different, larger component from the compact `.node-card` list row - same category boundary as Stage 1.1 excluding the message-actions popover from the message-bubble domain).

### Contrast spot-checks (`contrast_check.py`)
All touched pairs pass AA (4.5:1 text / 3:1 border), several pass AAA. One **pre-existing** failure noticed while checking, not introduced by this diff and not fixed (out of scope): `.node-card`'s base border (`--mc-border` `#2f3e50`) against its own background (`--mc-bg-panel` `#1b2837`) is **1.37:1**, well under the 3:1 border threshold - but this pairing was already governing the live render before this PR (via the pre-existing, already-tokenized higher-specificity rule); this PR only adds a second, shadowed instance of the same pairing for hygiene, it doesn't change what's rendered.

### Verification
- `check_new_hex.py --diff origin/main HEAD`: clean, no unregistered raw hex introduced.
- `?v=` bumped for `ui-kit.css` (the only file this PR touches) in `templates/index.html`.
- Before/after render via the Stage 0 fixture harness (headless Chromium, real CSS):
  - **Dark node-list + node-detail**: visually indistinguishable side-by-side; pixel diff confined to the favorite/selected card's background+border (max delta 6/255 on any channel, ~2.4%); the node-detail-card panel above it (RSSI/SNR/tabs) shows **zero** diff, confirming this stage didn't touch that component.
  - **Dark chat/messages** (Stage 1.1's domain, re-rendered as a regression guard on the shared-selector split): **zero-pixel diff**, confirming the `.node-card`/`.chat-item` selector separation from Stage 1.1 wasn't disturbed.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `contrast_check.py` spot-checks on every touched text/surface/border pair
- [x] `?v=` bumped for `ui-kit.css`
- [x] Before/after fixture render comparison: node-list+detail (indistinguishable), chat-messages (zero-diff regression guard)
- [x] Brace-balance sanity check on the edited CSS file

🤖 Generated with [Claude Code](https://claude.com/claude-code)