### PR TITLE
Theme registry Stage 1.3: MeshCenter Dark map/waypoints — raw-hex annotation, stale fallback fix

### DIFF
--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -573,9 +573,9 @@
     overflow: hidden;
 }
 .map-fit-btn {
-    border: 1px solid var(--mc-border, #314a62);
-    background: var(--mc-surface-2, #17293a);
-    color: var(--mc-text, #eaf3fb);
+    border: 1px solid var(--mc-border, #2f3e50);
+    background: var(--mc-surface-2, #202f40);
+    color: var(--mc-text, #f2f7fc);
     border-radius: 8px;
     padding: 7px 11px;
     cursor: pointer;
@@ -591,9 +591,9 @@
     justify-content:space-between;
     gap:12px;
     padding:8px 14px;
-    border-bottom:1px solid var(--mc-border, #314a62);
-    background:var(--mc-surface, #142434);
-    color:var(--mc-muted, #9db0c1);
+    border-bottom:1px solid var(--mc-border, #2f3e50);
+    background:var(--mc-surface, #1b2837);
+    color:var(--mc-muted, #c3d1df);
     font-size:12px;
 }
 .map-legend { display:flex; align-items:center; flex-wrap:wrap; gap:14px; }
@@ -609,15 +609,24 @@
 }
 .map-legend span { display:inline-flex; align-items:center; gap:6px; }
 .map-legend-dot { width:10px; height:10px; border-radius:50%; display:inline-block; box-shadow:0 0 0 2px rgba(255,255,255,.12); }
+/* raw: map legend accent dots (reference/node/selected) - no exact --mc-* match
+   yet (checked against every dark-mode token in ui-kit.css), candidate for a
+   dedicated map-token set in Stage 3.1. Same three colors reused by
+   .meshcenter-map-marker-dot below. */
 .map-legend-reference { background:#38d68a; }
 .map-legend-node { background:#4aa3ff; }
 .map-legend-selected { background:#df5d68; }
+/* raw: map canvas plus Leaflet's own built-in zoom/attribution controls - no
+   exact --mc-* match yet, candidate for a dedicated map-token set in Stage 3.1. */
 .mesh-map { flex:1 1 auto; min-height:280px; width:100%; background:#0e1b28; }
 .mesh-map .leaflet-control-zoom a { background:#172a3d; color:#eaf3fb; border-color:#304a63; }
 .mesh-map .leaflet-control-zoom a:hover { background:#203a52; }
 .mesh-map .leaflet-control-attribution { background:rgba(10,21,32,.78); color:#a9bac9; }
 .mesh-map .leaflet-control-attribution a { color:#72b8ff; }
 [data-theme="dark"] .mesh-map .leaflet-tile-pane { filter: brightness(.72) saturate(.72) contrast(1.12); }
+/* raw: marker accent dots (node/selected/reference) - no exact --mc-* match
+   yet, candidate for a dedicated map-token set in Stage 3.1. Same three colors
+   as the legend above. */
 .meshcenter-map-marker { background:transparent; border:0; }
 .meshcenter-map-marker-dot {
     width:18px; height:18px; border-radius:50%;
@@ -627,6 +636,8 @@
 }
 .meshcenter-map-marker.selected .meshcenter-map-marker-dot { background:#df5d68; box-shadow:0 3px 12px rgba(0,0,0,.42),0 0 0 7px rgba(223,93,104,.20); transform:scale(1.12); }
 .meshcenter-map-marker.reference .meshcenter-map-marker-dot { background:#38d68a; box-shadow:0 3px 12px rgba(0,0,0,.42),0 0 0 6px rgba(56,214,138,.22); }
+/* raw: popup surface, text and action button - no exact --mc-* match yet,
+   candidate for a dedicated map-token set in Stage 3.1. */
 .meshcenter-map-popup .leaflet-popup-content-wrapper,
 .meshcenter-map-popup .leaflet-popup-tip { background:#17293a; color:#eef6fc; }
 .meshcenter-map-popup .leaflet-popup-content-wrapper { border:1px solid #36516b; border-radius:12px; box-shadow:0 12px 34px rgba(0,0,0,.38); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260901-dock-uptime">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-3">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
## Summary
Map/waypoints domain, MeshCenter Dark, `static/style-part4.css` only (`EMBEDDED MAP WORKSPACE (Leaflet)` section). **No colors changed.**

Every raw hex value in this section was checked individually against the current dark-mode `--mc-*` token values in `ui-kit.css` (~lines 3232-3310). **None match exactly** - the closest candidates (`--mc-primary` vs marker blue, `--mc-danger` vs selected red, `--mc-success` vs reference green, `--mc-text-muted` vs popup-grid label gray, `--mc-border-focus` vs attribution-link blue) are all close-but-not-equal. Per the consolidation-only rule (reuse an exact match, never round to a near value - that's a visual redesign, not normalization), every one of them stays raw hex for this stage. They're already correctly registered in `docs/theme-registry/hex_registry.json` as `ui-normalization-candidate`, so nothing new is unregistered.

### What changed
1. **Grouped explanatory comments** above three logical blocks (map legend + marker dots, map canvas + Leaflet's built-in zoom/attribution controls, popup surface/text/button), each noting the color is intentionally still raw hex with no exact token match, flagged as a candidate for a dedicated map-token set in Stage 3.1 (not this stage - no new tokens invented here).
2. **Stale `var()` fallback literals fixed** on the two already-tokenized rules (`.map-fit-btn`, `.map-toolbar`): the fallback values had drifted from an earlier token rename and no longer matched the real current dark values. Fixed for documentation accuracy only - `var()` always resolves to the live custom property when it's defined (it always is here, `ui-kit.css`'s `:root`/dark block define every one of these), so the stale fallback text was dead weight that never actually rendered. Zero visual effect.
   - `var(--mc-border, #314a62)` → `var(--mc-border, #2f3e50)` (both occurrences)
   - `var(--mc-surface-2, #17293a)` → `var(--mc-surface-2, #202f40)`
   - `var(--mc-text, #eaf3fb)` → `var(--mc-text, #f2f7fc)`
   - `var(--mc-surface, #142434)` → `var(--mc-surface, #1b2837)`
   - `var(--mc-muted, #9db0c1)` → `var(--mc-muted, #c3d1df)`
3. **`?v=` bumped** for `style-part4.css` in `templates/index.html` (also happens to pick up Stage 1.1's forgotten bump for this same file, since #174 hasn't merged yet).

### Exact-match tokens found: none
Checked every raw value in the table below against all current dark `--mc-*` tokens - zero exact matches. Full per-selector reasoning already covered in the task brief's own table; independently re-verified here, same conclusion for every entry (`.mesh-map` bg, both leaflet-control-zoom states, attribution bg/link, both marker-dot colors + selected/reference states, all three legend dots, popup wrapper/tip/border, `.map-popup-name`, `.map-popup-grid` label, `.map-popup-details-btn` + hover).

### Out of scope, untouched (confirmed via diff)
- The `[data-theme="light"]` overrides at the end of the section (Stage 2.3's job) - byte-identical, see attached diff.
- Leaflet's own CDN stylesheet and default marker icons (MeshCenter never shows Leaflet's stock pin - custom `.meshcenter-map-marker`/`.meshcenter-map-marker-dot` only, confirmed by Stage 0's audit note).
- The `.leaflet-tile-pane { filter: ... }` rule - untouched, it's a filter not a color.
- No new `--mc-*` tokens invented (Stage 3.1's job).

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean, no new unregistered hex.
- `tinycss2` parse: `static/style-part4.css` - 669 rules, 0 errors.
- Property-level diff of the full map section (comments stripped) confirms the **only** non-comment changes are the 6 fallback literals listed above - nothing else moved, including the light block below.
- Contrast: N/A - no color values changed, so no new text/surface/border pairing to check (the fallback fixes have zero rendering effect).
- Live check on dev (192.168.2.104, this branch checked out + service restarted): opened Map in Dark on the real running app with real mesh data - toolbar, Leaflet zoom control, all three legend dots, a node marker, and a popup (clicked a real marker, saw it flip to the red "selected" state) all render identically to before. Screenshots sent in chat. Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean on the edited file
- [x] Diff confirmed scoped to exactly: 3 grouped comments, 6 fallback-literal fixes, the `?v=` bump - nothing else
- [x] Live dev check: map toolbar, all 3 marker states, legend, and a real popup in Dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)