### PR TITLE
Theme registry Stage 1.4: MeshCenter Dark camera/video/media normalization

### DIFF
--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1893,6 +1893,10 @@ html[data-theme="dark"] .about-project-card {
 /* ============================================================
    DARK THEME — camera workspace and Management Tools contrast
    ============================================================ */
+/* raw: media-stage surface (frame + stream canvas) - no exact --mc-* match
+   yet (checked against every dark-mode token, incl. --mc-bg-media-stage
+   #101923 which is the closest, still not equal), candidate for a
+   dedicated media-token set in Stage 3.1. */
 html[data-theme="dark"] .video-frame-wrap,
 html[data-theme="dark"] .video-view .video-frame-wrap {
     background: #111b27 !important;
@@ -2003,25 +2007,29 @@ html[data-theme="dark"] .message-input:focus {
 
 
 html[data-theme="dark"] .camera-white-balance-group select {
+    /* raw: no exact --mc-* match yet, candidate for Stage 3.1 */
     background-color: #101d2b !important;
-    color: #eef6ff !important;
-    border-color: #3a526d !important;
+    color: var(--mc-dark-control-text) !important;
+    border-color: var(--mc-dark-control-border) !important;
 }
 
+/* raw: no exact --mc-* match yet, candidate for Stage 3.1 */
 html[data-theme="dark"] .camera-white-balance-group label {
     color: #9fb4cc !important;
 }
 
 /* Camera defaults button should belong to the dark control surface. */
 html[data-theme="dark"] .camera-defaults-btn {
-    background: #223349 !important;
-    color: #eef6ff !important;
-    border-color: #3a526d !important;
+    background: var(--mc-button-secondary-bg) !important;
+    color: var(--mc-button-secondary-text) !important;
+    border-color: var(--mc-button-secondary-border) !important;
     box-shadow: none !important;
 }
 
 html[data-theme="dark"] .camera-defaults-btn:hover {
-    background: #2b4059 !important;
+    background: var(--mc-button-secondary-bg-hover) !important;
+    /* raw: no exact --mc-* match yet (--mc-button-secondary-border-hover
+       is #4b6685, not equal), candidate for Stage 3.1 */
     border-color: #5b82aa !important;
 }
 
@@ -2460,6 +2468,10 @@ html[data-theme="dark"] #nodeDetails .node-detail-radio .radio-param {
     font-size: 11px;
 }
 
+/* raw: camera-loading placeholder surface + title - no exact --mc-* match
+   yet (all four values are within a few points of an existing token but
+   none are byte-equal, e.g. background #101c29 vs --mc-bg-workspace
+   #111c29), candidate for a dedicated media-token set in Stage 3.1. */
 html[data-theme="dark"] .camera-loading-placeholder {
     border-color: #2f4053;
     background: #101c29;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-2">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-4">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
Camera/video/media-stage domain, MeshCenter Dark, `static/ui-kit.css` only. `static/style-part4.css` was checked but not modified this stage (see below).

### Exact-match findings for `.camera-defaults-btn` / `.camera-white-balance-group` (as requested)
Confirmed both of your leads, plus one you flagged correctly as a non-match:
- **`.camera-defaults-btn`** `background: #223349` -> `--mc-button-secondary-bg` **EXACT MATCH**, `color: #eef6ff` -> `--mc-button-secondary-text` **EXACT MATCH**, `border-color: #3a526d` -> `--mc-button-secondary-border` **EXACT MATCH**.
- **`.camera-defaults-btn:hover`** `background: #2b4059` -> `--mc-button-secondary-bg-hover` **EXACT MATCH**. `border-color: #5b82aa` vs `--mc-button-secondary-border-hover` (`#4b6685`) - **confirmed NOT a match**, left raw with a comment, exactly as you flagged.
- **`.camera-white-balance-group select`**: `color: #eef6ff` and `border-color: #3a526d` are the *same* two values as the button - tokenized, but to a different, more semantically-correct pair: `--mc-dark-control-text` / `--mc-dark-control-border` (a `<select>` is a form control, not a button; `--mc-button-secondary-*` and `--mc-dark-control-*` happen to share identical dark values today, but they're different roles - reusing the button-specific alias for a dropdown would be the wrong kind of "exact match," so I used the control-specific one instead). `background-color: #101d2b` - checked against every dark token, no exact match, left raw.
- **`.camera-white-balance-group label`**: `color: #9fb4cc` - checked, no exact match, left raw.

### Everything else checked, no exact match found (left raw, grouped comments added)
- `.video-frame-wrap` / `.video-view .video-frame-wrap` (`background: #111b27`, `border-color: #263547`) and `.camera-stream` (`background: #080d13`, `box-shadow` color `#2b3a4c`) - closest candidate is `--mc-bg-media-stage` (`#101923`), still not equal.
- `.camera-loading-placeholder` (`border-color: #2f4053`, `background: #101c29`, `color: #94a8bd`) and `.camera-loading-title` (`color: #eef5ff`) - all four are within a few points of a token (e.g. `#101c29` vs `--mc-bg-workspace` `#111c29`) but none byte-equal.

### Already tokenized, verified only, untouched
- `.video-view` / `.media-view` (`color: var(--mc-text-primary)`).
- `.media-title` / `.video-title` / `.media-subtitle` / `.video-subtitle` and the "residual navy text" bundle (`.media-title`, `.camera-control-label`, `.camera-value`, etc.) - both already use `--mc-text-primary` / `--mc-text-secondary` / `--mc-chat-text` / `--mc-chat-muted`.
- `.camera-off-placeholder` / `-title` / `-text` / `-icon` (`style-part4.css`) - already `var(--mc-card-bg)` / `var(--mc-text)` / `var(--mc-text-secondary)` / filter-only.
- `.camera-panel` / `.media-panel`'s legacy `--theme-*` bundle (`style-part4.css` ~2126) - confirmed untouched, per your explicit instruction (checked its dark values again myself, still no exact `--mc-*` match, still shared across 7 unrelated panel types).

### One judgment call, flagged rather than acted on silently
`.video-panel` / `.media-panel`'s shared background bundle (`ui-kit.css` ~1054-1064, bundled with `.app-container`/`.main-layout`/`.system-panel`/`.settings-panel`/`.base-sidebar`/`.sidebar`, raw `background-color: #18212c; color: #dbe5f1;`): checked both values against every dark token, **no exact match for either**. Since there's nothing to tokenize, I did **not** split `.video-panel`/`.media-panel` out of this bundle (unlike the `.chat-item`/`.node-card` splits in 1.1/1.2, which existed to move real token substitutions) - a value-free split would just be selector-shuffling with zero rendering effect, and it also would've meant adding a domain-specific comment inside a rule shared with several out-of-scope selectors, which felt like the wrong place for it. Documenting it here instead. Happy to add the split anyway if you'd rather have the explicit paper trail in the CSS itself even without a token change.

Also incidentally confirmed: `.media-panel`'s *actual* rendered background is governed by the legacy `--theme-*` `!important` rule in `style-part4.css` (higher precedence than any `!important`-free rule), not by this raw-hex bundle at all - `.video-panel` isn't in that legacy bundle though, so its background genuinely does come from here. Doesn't change the "no exact match" conclusion either way, just noting it since it's a bit subtle.

### Cache-busting
Only `ui-kit.css` changed this stage - bumped its `?v=` in `templates/index.html`. `style-part4.css`'s `?v=` was already current from Stage 1.3, left alone (verified before assuming).

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean.
- `tinycss2` parse on `ui-kit.css`: 482 rules, 0 errors.
- Diff (attached) touches only the five known entry points' raw-hex lines + comments - nothing in `.camera-panel`'s legacy bundle, nothing in map/chat/node-card/settings rules.
- Contrast spot-checks on every touched pairing: text/bg pairs all pass AA/AAA (`#eef6ff` vs `#101d2b`/`#223349`/`#2b4059` all 9.7-15.6:1). Two **pre-existing** border-vs-surface failures found (unchanged by this diff - same raw values before and after, one is now token-backed with an identical value): `--mc-button-secondary-border` (`#3a526d`) vs `.camera-white-balance-group select`'s background `#101d2b` is 2.12:1, and vs `.camera-defaults-btn`'s background `#223349` is 1.59:1 (both under the 3:1 border threshold) - report only, not fixed, per scope.
- Before/after render via the Stage 0 fixture harness: `camera-video`, `chat-messages`, `node-list-and-detail`, and `map` all came back at a literal **0.000% pixel diff** (the fixture's camera section doesn't exercise the white-balance select/Defaults button specifically, so this mainly confirms zero collateral damage to the other three domains).
- **Live check on dev** (real hardware, real camera stream): branch checked out, service restarted, opened Camera -> Image tab in Dark - live video stream, White Balance select, and Defaults button all rendered correctly. Pulled computed styles via JS to confirm exactly: Defaults button `rgb(34,51,73)` / `rgb(238,246,255)` / `rgb(58,82,109)` (`#223349`/`#eef6ff`/`#3a526d`, matching the token values exactly), White Balance select background unchanged at `rgb(16,29,43)` (`#101d2b`, the untouched raw value). Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean
- [x] Diff scoped to only the described selectors
- [x] Contrast spot-checks, pre-existing failures reported not fixed
- [x] Fixture before/after: zero-diff on all four screens checked
- [x] Live dev check with computed-style verification on the real camera view

🤖 Generated with [Claude Code](https://claude.com/claude-code)