### PR TITLE
Theme registry Stage 1.5a: MeshCenter Dark telemetry/battery/sensor cards normalization

### DIFF
--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -2354,6 +2354,9 @@ html[data-theme="dark"] .node-info-panel {
     box-shadow: 0 3px 10px rgba(0, 0, 0, .24);
 }
 
+/* raw: sensors/telemetry card accent stripe + battery indicator frame
+   (theme-registry Stage 1.5a) - no exact --mc-* match yet, candidate for
+   a dedicated telemetry-token set in Stage 3.1. */
 body[data-theme="dark"] .node-info-panel > .sensors-card::before,
 body[data-theme="dark"] .node-info-panel > .telemetry-section::before,
 html[data-theme="dark"] .node-info-panel > .sensors-card::before,
@@ -2527,6 +2530,13 @@ html[data-theme="dark"] .node-info-panel .battery-indicator {
     font-size: 11px;
 }
 
+/* raw: sensor-grid item chrome + battery runtime text (theme-registry
+   Stage 1.5a) - no exact --mc-* match yet, candidate for a dedicated
+   telemetry-token set in Stage 3.1. (.sensor-label/.sensor-value/
+   .sensor-unit's color contribution here is shadowed by a later,
+   equal-specificity rule further down this file - also checked, also no
+   exact match - .battery-runtime-row/.battery-runtime-value are not
+   repeated there and stay live from here.) */
 body[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-item,
 html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-item {
     border-color: #334a61;
@@ -2765,6 +2775,8 @@ html[data-theme="dark"] .settings-number-input {
     display: none !important;
 }
 
+/* raw: same #334a61/#1c2e41 pair as .sensor-item above - no exact --mc-*
+   match, see that comment. */
 body[data-theme="dark"] .node-telemetry-surface,
 html[data-theme="dark"] .node-telemetry-surface {
     border-color: #334a61;
@@ -2778,6 +2790,9 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-item:nth-chi
     border-color: #334a61;
 }
 
+/* raw: battery bar track + scale labels (theme-registry Stage 1.5a) - no
+   exact --mc-* match yet, candidate for a dedicated telemetry-token set
+   in Stage 3.1. */
 body[data-theme="dark"] .battery-bar,
 html[data-theme="dark"] .battery-bar {
     background: #34485a;
@@ -3063,6 +3078,11 @@ html[data-theme="dark"] .base-node-avatar {
     line-height: 1.15;
 }
 
+/* raw: this is the winning declaration for .sensor-label/-value/-unit
+   text color (equal specificity, later in cascade than the earlier block
+   near line 2539 - that one is shadowed for these three selectors).
+   Checked against every dark --mc-* token, no exact match, candidate for
+   Stage 3.1. */
 body[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-label,
 html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-label {
     color: #9eb5c9;

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -3266,7 +3266,13 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 /* Telemetry stat cards (#telemetryCards inside #telemetryModal) - no
    existing dark coverage for .telemetry-card, so this follows the
    #timeCard pattern (~line 14683: bg #172638, border #263c52, text
-   #e5eff8 primary / #9eb3c8 muted). */
+   #e5eff8 primary / #9eb3c8 muted).
+   theme-registry Stage 1.5a: all four values re-checked against every
+   current dark --mc-* token, none are an exact match, so left raw -
+   candidates for a dedicated telemetry-token set in Stage 3.1. Note for
+   Stage 1.5b: this border-color (#263c52) is the same literal
+   chat-telemetry.js uses for the chart tooltip's dark borderColor - not
+   tokenized here (no exact match), so nothing for 1.5b to align to yet. */
 [data-theme="dark"] .telemetry-card {
     background: #172638;
     border-color: #263c52;
@@ -3284,7 +3290,10 @@ body[data-theme="dark"] .waypoint-action-toast.error {
    so the surrounding well needs its own dark background instead of the
    light-mode #f0f2f5. Slightly darker than the .telemetry-card bg
    (#172638) so the cards and chart don't visually merge into one flat
-   surface, but still clearly not black. */
+   surface, but still clearly not black.
+   theme-registry Stage 1.5a: both values re-checked against every current
+   dark --mc-* token, no exact match (background #1a2535 is closest to
+   --mc-bg-panel #1b2837, off by 1-3 per channel, not equal), left raw. */
 [data-theme="dark"] .telemetry-chart-container {
     background: #1a2535;
     border-color: #263c52;
@@ -3304,7 +3313,10 @@ body[data-theme="dark"] .waypoint-action-toast.error {
    Verified live via DevTools computed styles on the dev node before and
    after: modal bg was rgb(255,255,255) unconditionally, is now
    rgb(27,45,64) in dark theme, and header/close text (already
-   rgb(244,248,252)/rgb(169,190,209)) reads correctly against it. */
+   rgb(244,248,252)/rgb(169,190,209)) reads correctly against it.
+   theme-registry Stage 1.5a: #1b2d40 re-checked against every current
+   dark --mc-* token, no exact match (--mc-bg-panel #1b2837 is closest,
+   R matches but G/B are off by 5/9), left raw. */
 [data-theme="dark"] .modal-overlay.telemetry-modal .modal-content {
     background: #1b2d40;
 }
@@ -3327,7 +3339,11 @@ body[data-theme="dark"] .waypoint-action-toast.error {
    dark" colors (#263b50/#dbe8f5/#415a72, #304a62 hover - see
    [data-theme="dark"] .modal-action-btn:not(.danger) a few lines up)
    instead of inventing new ones, for consistency with every other
-   secondary button already dark-themed in this file. */
+   secondary button already dark-themed in this file.
+   theme-registry Stage 1.5a: every value here re-checked against the
+   current dark --mc-* tokens (including --mc-button-secondary-bg/-text/
+   -border, the family this comment's own "secondary button on dark"
+   colors predate), no exact match for any of them, left raw. */
 [data-theme="dark"] .telemetry-export-btn {
     background: #263b50;
     color: #dbe8f5;

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1075,14 +1075,25 @@ html[data-theme="dark"] .messages-view {
 }
 
 html[data-theme="dark"] .base-card,
-html[data-theme="dark"] .sensors-card,
-html[data-theme="dark"] .telemetry-section,
 html[data-theme="dark"] .weather-card,
 html[data-theme="dark"] .base-reference-location,
 html[data-theme="dark"] .settings-card,
 html[data-theme="dark"] .system-card {
     background-color: #202a36;
     border-color: #364253;
+    color: #dbe5f1;
+}
+
+/* Sensors/telemetry card (theme-registry Stage 1.5a). Background and text
+   were checked against every dark --mc-* token, no exact match - left raw.
+   Border-color IS an exact match for --mc-workspace-header-border, so
+   that one's tokenized even though the token's own name suggests a
+   different original use case (a workspace header, not a sensor card);
+   flagged in the Stage 1.5a report rather than left uncommented. */
+html[data-theme="dark"] .sensors-card,
+html[data-theme="dark"] .telemetry-section {
+    background-color: #202a36;
+    border-color: var(--mc-workspace-header-border);
     color: #dbe5f1;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,9 +8,9 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-4">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-5a">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-5a">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-5a">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
Telemetry/CPU/battery card domain, CSS only, MeshCenter Dark. `static/ui-kit.css` + `static/style-part3.css` + `static/style-part4.css`. Excludes `SENSOR_COLORS`/`SENSOR_BG_COLORS` in `chat.js` and their `chat-telemetry.js` consumers entirely, per scope - untouched, not even inspected for tokenization since they're theme-independent categorical data, not UI chrome.

### Exact-match tokens found: one, across the whole domain
Every raw hex value in all five known entry points plus the systematic pass was checked individually against the current dark `--mc-*` token table. Only one byte-exact match turned up:

- **`.sensors-card` / `.telemetry-section`** border-color `#364253` = **exact match** for `--mc-workspace-header-border`. Tokenized, flagging the name mismatch explicitly: that token's name suggests it was meant for workspace headers, not sensor cards - it's an exact value coincidence, not a semantic fit. Worth a dedicated token in Stage 3.1 if this bothers you; left as-is here since forcing a *new* token wasn't in scope and the value is genuinely identical. Background (`#202a36`) and text (`#dbe5f1`) on the same rule were also checked, no match, stayed raw.

Split `.sensors-card`/`.telemetry-section` out of the shared bundle they used to share with `.base-card`/`.weather-card`/`.settings-card`/`.system-card` (same treatment `.chat-item`/`.node-card`/`.video-panel` got in 1.1/1.2/1.4).

### Everything else checked: no exact match, stayed raw with grouped comments
- `.node-info-panel > .sensors-card::before` / `::telemetry-section::before` (accent stripe, `#31465c`) and `.node-info-panel .battery-indicator` (`#40556b`).
- `.node-info-panel .node-metrics-grid .sensor-item` (`#334a61`/`#1c2e41`) and its nth-child border variant, `.node-telemetry-surface` (same pair).
- `.sensor-label`/`.battery-runtime-row` (`#8ea6bc`) and `.sensor-value`/`.sensor-unit`/`.battery-runtime-value` (`#f2f7fb`) - **this declaration is shadowed** for `.sensor-label`/`.sensor-value`/`.sensor-unit` by an equal-specificity, later rule further down `style-part3.css` (`.battery-runtime-*` isn't repeated there, stays live from here). Both the shadowed and the winning declaration (`#9eb5c9`/`#f7fbff`) were checked - no match either way.
- `.battery-bar` (`#34485a`) / `.battery-scale` (`#71879b`).
- `.telemetry-card` (`#172638`/`#263c52`), `.card-label`/`.card-range` (`#9eb3c8`), `.card-value` (`#e5eff8`), `.telemetry-chart-container` (`#1a2535`/`#263c52`).
- `.modal-overlay.telemetry-modal .modal-content` (`#1b2d40`), `.telemetry-export-btn` + `:hover` (`#263b50`/`#dbe8f5`/`#415a72`, `#304a62` hover), `.telemetry-records-count` (`#9eb3c8`).
- `.sensors-title`/`.telemetry-title` and the generic `.sensor-label` bundle (both share selectors with out-of-scope selectors like `.workspace-page-title`/`.node-meta`) - checked, no match either, **not split** since a value-free split (no token substitution resulting) would just be selector-shuffling with zero effect - same judgment call as `.video-panel`/`.media-panel` in Stage 1.4.

### Cross-file consistency note for Stage 1.5b (as requested, not acted on)
`.telemetry-card`'s border-color (`#263c52`) is the same literal `chat-telemetry.js` uses for the chart tooltip's dark `borderColor`. Since it has **no exact `--mc-*` match**, nothing was tokenized here - so there's no resulting token name for 1.5b to align the JS tooltip to yet. Noted in a code comment at the site for whoever picks up 1.5b.

### Cache-busting
All three touched files' `?v=` bumped in `templates/index.html`. `style-part3.css` had never been bumped by any theme-registry stage before this one (verified - it was still on the pre-1.1 baseline value).

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean.
- `tinycss2` parse on all three files: `ui-kit.css` 483 rules, `style-part3.css` 530 rules, `style-part4.css` 669 rules - 0 errors each.
- Diff (attached) touches only the described selectors.
- Contrast spot-check on the one exact-match substitution: `--mc-workspace-header-border` (`#364253`) vs `.sensors-card`'s background (`#202a36`) is **1.43:1**, under the 3:1 border threshold - but this is the *same* raw value as before the token swap (pre-existing, not introduced or worsened), report only per scope.
- Before/after render via the Stage 0 fixture harness: `telemetry-cpu-battery`, `node-list-and-detail`, `chat-messages`, `camera-video`, and `map` all came back at a literal **0.000% pixel diff** - expected, since the one substitution made is value-identical by construction.
- **Live check on dev** (real hardware, real node telemetry): branch checked out, service restarted, opened the NODE TELEMETRY card (sensors grid + battery indicator) and the Environment telemetry modal (stat cards + chart container + export button) in Dark. Pulled computed styles via JS to confirm exactly: `#sensorsCard` `rgb(32,42,54)`/`rgb(54,66,83)`/`rgb(219,229,241)` (`#202a36`/`#364253`/`#dbe5f1`, matching pre-edit values exactly since the border is now token-backed with an identical value), `.telemetry-card`/`.telemetry-chart-container`/`.telemetry-export-btn` all confirmed unchanged too. Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean on all three touched files
- [x] Diff scoped to only the described selectors
- [x] Contrast spot-check, pre-existing failure reported not fixed
- [x] Fixture before/after: zero-diff on all five screens checked
- [x] Live dev check with computed-style verification on real telemetry card + modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)