### PR TITLE
Theme registry Stage 1.5b: Chart.js chrome colors — checked, no --mc-* match

### DIFF
--- a/static/chat-telemetry.js
+++ b/static/chat-telemetry.js
@@ -673,6 +673,22 @@ function renderTelemetryChart(container, records, type) {
     // Dark theme: only axis/grid/legend/tooltip chrome changes here - the
     // per-series line/fill colors (SENSOR_COLORS/SENSOR_BG_COLORS) already
     // work on a dark background and are left untouched.
+    //
+    // theme-registry Stage 1.5b: every dark-mode literal below (tickColor,
+    // the legend label color, and the four tooltip colors further down)
+    // was checked individually against the full --mc-* dark token table in
+    // ui-kit.css's html[data-theme="dark"] block - none of them are an
+    // exact match for any token (closest misses: tickColor #a0aec0 vs
+    // --mc-chat-muted #9fb0c3 off by 1-3 per channel, tooltip background
+    // #0f1923 vs --mc-bg-media-stage #101923 off by 1 on red only), so
+    // they stay hardcoded literals rather than being wired through
+    // getComputedStyle(document.documentElement).getPropertyValue('--mc-*')
+    // - there's no existing token to read. Candidates for a dedicated
+    // chart-chrome token set in Stage 3.1, same category as the raw
+    // telemetry-card/battery colors from Stage 1.5a. (No getComputedStyle
+    // precedent exists anywhere else in this codebase for reading --mc-*
+    // from JS either, for what it's worth - moot here since nothing
+    // matched, but noted in case Stage 3.1 wants to establish one.)
     const isDark = document.documentElement.dataset.theme === 'dark';
     const gridColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
     const tickColor = isDark ? '#a0aec0' : '#666';
@@ -882,9 +898,18 @@ function renderTelemetryChart(container, records, type) {
                 plugins: {
                     legend: {
                         position: 'top',
+                        // raw: no exact --mc-* match, see the Stage 1.5b
+                        // comment near isDark/tickColor above
                         labels: { usePointStyle: true, padding: 15, font: { size: 11 }, color: isDark ? '#cbd5e0' : '#333' }
                     },
                     tooltip: {
+                        // raw: no exact --mc-* match for any of these four
+                        // (bodyColor intentionally reuses the same literal
+                        // as the legend label color above - both were
+                        // '#cbd5e0' already, kept as one shared shade for
+                        // now rather than split into two independent
+                        // copies); see the Stage 1.5b comment near
+                        // isDark/tickColor above
                         backgroundColor: isDark ? '#0f1923' : 'rgba(255,255,255,0.95)',
                         titleColor: isDark ? '#e2e8f0' : '#333',
                         bodyColor: isDark ? '#cbd5e0' : '#666',


### PR DESCRIPTION
## Summary
Telemetry chart chrome domain, JS only, `static/chat-telemetry.js`. **No colors changed** - comments only.

### Independent verification of the 6 values
Re-checked all 6 dark-mode literals individually against the full `--mc-*` dark token table in `ui-kit.css` (not trusting the pre-check in the brief, per the standing rule):

| # | Value/property | Literal | Closest token (not a match) |
|---|---|---|---|
| 1 | `tickColor` | `#a0aec0` | `--mc-chat-muted` `#9fb0c3` (off by 1,2,3) |
| 2 | legend label `color` | `#cbd5e0` | `--mc-text-secondary` `#c3d1df` (off by 8,4,1) |
| 3 | tooltip `backgroundColor` | `#0f1923` | `--mc-bg-media-stage` `#101923` (off by 1,0,0) |
| 4 | tooltip `titleColor` | `#e2e8f0` | no close candidate at all (~16-20 off everywhere) |
| 5 | tooltip `bodyColor` | `#cbd5e0` | same literal as #2, same non-match |
| 6 | tooltip `borderColor` | `#263c52` | `--mc-border` `#2f3e50` (off by 9,2,2) - same value/conclusion as `.telemetry-card`'s border from Stage 1.5a |

**Confirmed: zero exact matches**, same conclusion as the brief's own pre-check. Since nothing matched, the `getComputedStyle` vs. hardcoded-literal question is moot - there's no token to wire through either way. For the record: no `getComputedStyle(...).getPropertyValue('--mc-*')` precedent exists anywhere else in this codebase for reading tokens from JS, so there was nothing to follow as precedent regardless.

On the bodyColor/legend-color literal reuse (#5): both were already `#cbd5e0` before this PR. Noted in a code comment as an observation, not changed - can't tell from the code alone whether it's intentional or coincidental, and it's not this PR's call to split or merge them since neither is being tokenized.

### What changed
Added a comment block above `isDark`/`tickColor` (the primary explanation, covering all 6 values with the full check detail) plus two short pointer comments at the legend and tooltip option blocks referencing it - same documentation pattern as Stage 1.3/1.4/1.5a's grouped "raw, no exact match" comments for CSS, adapted for JS. All 6 candidates for a dedicated chart-chrome token set in Stage 3.1.

`SENSOR_COLORS`/`SENSOR_BG_COLORS` and every consumer (chart dataset colors, live sensor-value text) - untouched, not even inspected for tokenization, per scope.

### Cache-busting
None - no CSS files touched, and this JS change is comments-only with zero behavioral difference, so a stale-cached copy would render identically either way. Didn't bump `chat-telemetry.js`'s own `?v=` for a change with nothing to actually pick up.

## Verification
- **`check_new_hex.py` does not cover `.js` files** - confirmed by reading the tool's source (`THEME_CSS_FILES` whitelists only the 5 CSS files; a diff against `chat-telemetry.js` reports "OK" vacuously, without ever inspecting the file). Ran it anyway (came back clean, as expected) but treated the manual 6-value table above as the real verification, per the brief's instruction not to assume tool coverage.
- `node --check static/chat-telemetry.js`: syntax OK.
- Diff (attached) is comments-only, 25 lines added, 0 removed, 0 modified - confirmed no color literal changed.
- **Live check on dev** (real hardware, real telemetry data): branch checked out, service restarted, opened the Power Supply telemetry chart in Dark (the Environment chart has no real sensor data on this node - no BME280, consistent with earlier stages' notes - so used Power/Voltage instead, which has 10 real records). Confirmed axis tick labels, legend ("Voltage V"), grid lines, and a hovered tooltip all render correctly. Pulled the live Chart.js instance's own resolved option values via JS to confirm all 6 exactly: `tickColor` `#a0aec0`, legend `color` `#cbd5e0`, tooltip `backgroundColor` `#0f1923`, `titleColor` `#e2e8f0`, `bodyColor` `#cbd5e0`, `borderColor` `#263c52` - byte-identical to the pre-edit literals. Dev restored to `main` afterward.

## Test plan
- [x] Independent re-verification of all 6 values against current dark tokens (table above)
- [x] `check_new_hex.py` confirmed not to cover `.js` files (manual check substituted)
- [x] `node --check` syntax clean
- [x] Diff confirmed comments-only
- [x] Live dev check with real telemetry data, tooltip hover, and live Chart.js option readout

🤖 Generated with [Claude Code](https://claude.com/claude-code)