### PR TITLE
Theme registry Stage 1.6: devices/hardware residue — dead-code + no-match documentation

### DIFF
--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -2693,16 +2693,35 @@ html[data-theme="dark"] .workspace-nav-arrow {
     color: #90a6bc;
 }
 
+/* Dead code (theme-registry Stage 1.6, confirmed via computed styles, not
+   deleted - out of scope to clean up dead CSS here). Neither declaration
+   below actually renders: the legacy style-part4.css rule
+   `[data-theme="dark"] .devices-panel { background: var(--theme-panel-bg)
+   !important; border-color: var(--theme-border) !important; ... }` beats
+   this one on !important alone, regardless of specificity or file order -
+   so it's shadowed one level deeper than a same-specificity/later-wins
+   case would be (the equal-specificity, later, already-tokenized
+   `html[data-theme="dark"] .devices-panel` rule further down this file,
+   ~line 2898, is *also* shadowed by that same legacy !important rule, for
+   the same reason - not just this raw-hex one). */
 html[data-theme="dark"] .devices-panel {
     border-color: #2f4357;
     background: #172432;
 }
 
+/* Dead code (theme-registry Stage 1.6, confirmed via computed styles, not
+   deleted). Shadowed by the equal-specificity, later, already-tokenized
+   `html[data-theme="dark"] .devices-empty-state` rule further down this
+   file (~line 2912: border-color: var(--mc-border-soft); background:
+   var(--mc-bg-subtle);) - no legacy --theme-* override exists for this
+   selector, unlike .devices-panel above. */
 html[data-theme="dark"] .devices-empty-state {
     border-color: #3a5269;
     background: #1d2d3d;
 }
 
+/* raw: devices-empty-state heading/body text + tag chips (theme-registry
+   Stage 1.6) - no exact --mc-* match yet, candidate for Stage 3.1. */
 html[data-theme="dark"] .devices-empty-state h3 {
     color: #f3f8ff;
 }
@@ -2955,7 +2974,15 @@ body[data-theme="dark"] .mc-workspace-panel {
         0 8px 24px rgba(0, 0, 0, .16) !important;
 }
 
-/* Devices previously had a lighter outline; the shared shell owns it now. */
+/* Devices previously had a lighter outline; the shared shell owns it now.
+   theme-registry Stage 1.6: this rule IS live (confirmed via computed
+   styles) - its higher specificity (one extra class) than the legacy
+   `[data-theme="dark"] .devices-panel { border-color: var(--theme-border)
+   !important; ... }` rule in style-part4.css is what lets it win despite
+   both being !important; without it, .devices-panel would fall back to
+   that legacy border instead of the shared workspace-shell one. #0a121c
+   checked against every current dark --mc-* token, no exact match,
+   candidate for Stage 3.1. */
 html[data-theme="dark"] .devices-panel.mc-workspace-panel,
 body[data-theme="dark"] .devices-panel.mc-workspace-panel {
     border-color: #0a121c !important;


### PR DESCRIPTION
## Summary
Devices/hardware residue outside the legacy `--theme-*` block, `static/ui-kit.css` only. **No colors changed** - comments only, confirming (and in one case, refining) the task's own hypotheses via computed styles rather than trusting them.

### Item 1 — `.devices-panel` raw-hex dark rule (~line 2696)
**Confirmed dead, but one level deeper than hypothesized.** Built a standalone test page loading the real CSS and checked computed styles directly. Result: `.devices-panel`'s actual dark background/border come from neither this raw-hex rule nor the equal-specificity, later, already-tokenized rule at ~line 2898 (`var(--mc-border)`/`var(--mc-bg-panel)`) - **both are shadowed** by the legacy `style-part4.css` rule (`[data-theme="dark"] .devices-panel { background: var(--theme-panel-bg) !important; border-color: var(--theme-border) !important; ... }`), whose `!important` beats any non-important rule regardless of specificity or file order. Computed values confirmed this: `rgb(22,36,51)` = `#162433` = `--theme-panel-bg`, not `--mc-bg-panel` (`#1b2837`) and not the raw `#172432`.
Marked dead with a comment, not deleted, per scope. Did **not** touch the ~2898 rule (as instructed) even though it's also dead - that's part of the known Stage 3.1 legacy-migration debt, not a new finding to annotate piecemeal here.

### Item 2 — `.devices-empty-state` raw-hex dark rule (~line 2701)
**Confirmed dead, exactly as hypothesized.** Computed styles matched the later, already-tokenized rule at ~line 2912 exactly (`rgb(22,34,49)` = `--mc-bg-subtle`, `rgb(36,50,67)` = `--mc-border-soft`) - no legacy override exists for this selector, unlike `.devices-panel`. Also checked the raw values against every dark token regardless (per the brief's instruction) - no exact match either way (`#3a5269` is close to `--mc-button-secondary-border` `#3a526d`, off by 4 on blue only, but not equal). Marked dead with a comment, not deleted.

### Item 3 — `.devices-panel.mc-workspace-panel` border (~line 2959)
**Confirmed live, not dead.** Computed style on the real `.devices-panel` element matched this rule's raw value exactly (`rgb(10,18,28)` = `#0a121c`), not the legacy `--theme-border` value. Its extra class (`.mc-workspace-panel`) gives it higher specificity than the legacy per-panel-type `!important` rule, which is precisely what lets it win despite both being `!important` - this is why `.devices-panel` gets the shared workspace-shell border instead of the legacy panel border. `#0a121c` checked against every dark token, no exact match. Left raw with a comment explaining the mechanism, not just "no match."

### Systematic pass: 3 more raw-hex dark rules found, not in the task's 3 known items
- `.devices-empty-state h3` (`#f3f8ff`) and `.devices-empty-state p` (`#9fb1c5`) - not shadowed (no later duplicate exists), no exact match (`#9fb1c5` is close to `--mc-chat-muted`/`--mc-popover-muted` `#9fb0c3`, off by 0,1,2, but not equal).
- `.devices-empty-tags span` (`border-color: #3a5269`, `background: #162534`, `color: #b8cbe0`) - not shadowed, no exact match for any of the three.

All five left raw with grouped comments, candidates for Stage 3.1.

### Cache-busting
None needed - no live rendering value changed anywhere in this PR, comments only.

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean.
- `tinycss2` parse: `ui-kit.css` 483 rules, 0 errors.
- Diff (attached) touches only these five rules' surrounding comments - nothing else.
- No computed-color changes anywhere (nothing was tokenized, since no exact matches existed for any of the six raw-hex rules checked in total).
- **Live check on dev** (real hardware): branch checked out, service restarted, opened the Devices tab in Dark - camera, e-Paper, RTC, environmental sensor, and power-monitor cards all rendered correctly, plus the "Add device" empty-state prompt at the bottom. Pulled `.devices-panel`'s computed style via JS: `rgb(22,36,51)` / `rgb(10,18,28)` - background from the legacy token, border from item 3's rule, exactly matching the local computed-style investigation. Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean
- [x] Diff scoped to only the five documented rules' comments
- [x] Computed-style verification (local test page + live dev) for all three original items plus the live/dead distinction
- [x] Live dev check on the real Devices tab in Dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)