### PR TITLE
Theme registry Stage 1.7: MeshCenter Dark dialogs/popover/toast normalization

### DIFF
--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -3749,12 +3749,31 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
 .notification-item-copy small { color: var(--mc-muted, #7b8796); font-size: 9px; }
 .notification-empty { padding: 30px 16px; color: var(--mc-muted, #7b8796); font-size: 11px; text-align: center; }
 
+/* Dead code (theme-registry Stage 1.7, confirmed via computed styles).
+   These four rules use `[data-theme="dark"] .selector` (specificity
+   0,2,0 / 0,3,0 for the :hover ones) - static/ui-kit.css has an
+   equal-or-higher-specificity `html[data-theme="dark"] .selector` rule
+   for each of these same four selectors (~line 3100-3141, already
+   tokenized via var(--mc-popover-*)), which always wins regardless of
+   file load order since it's strictly more specific (one extra `html`
+   type selector). Not deleted, out of scope to clean up dead CSS here. */
 [data-theme="dark"] .dock-notification-btn { background: #17283a; border-color: #344a60; color: #bdd0e4; }
 [data-theme="dark"] .dock-notification-btn:hover { background: #21364b; }
 [data-theme="dark"] .notification-popover { background: #172638; border-color: #34485e; }
 [data-theme="dark"] .notification-item:hover { background: #203449; }
-[data-theme="dark"] .notification-success .notification-item-icon { color: #72d69a; background: rgba(57,164,100,.16); }
-[data-theme="dark"] .notification-warning .notification-item-icon { color: #f0c86a; background: rgba(196,143,31,.17); }
+/* raw: notification status icons (theme-registry Stage 1.7) - live, not
+   shadowed (no ui-kit.css override exists for any of these four).
+   #72d69a and #f0c86a are exact matches for --mc-success/--mc-warning,
+   tokenized. #ff9299 and #8fc7f0 checked against every dark --mc-* token,
+   no exact match for either (closest: --mc-danger #ff7b85 for the error
+   icon, off by 31,30,29 - not close; --mc-info #78b6ff for the info icon,
+   off by 23,17,15), left raw, candidates for Stage 3.1. The rgba(...)
+   background halos next to each are a separate, non-hex question (not in
+   check_new_hex.py's scope either) - each halo's RGB triplet doesn't
+   match its own icon's token color or any other token, so there's no
+   direct var() substitution available for them regardless. */
+[data-theme="dark"] .notification-success .notification-item-icon { color: var(--mc-success); background: rgba(57,164,100,.16); }
+[data-theme="dark"] .notification-warning .notification-item-icon { color: var(--mc-warning); background: rgba(196,143,31,.17); }
 [data-theme="dark"] .notification-error .notification-item-icon { color: #ff9299; background: rgba(207,71,82,.17); }
 [data-theme="dark"] .notification-info .notification-item-icon { color: #8fc7f0; background: rgba(48,126,184,.18); }
 

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -859,6 +859,10 @@
 .map-layout-option { display:flex; align-items:center; gap:8px; padding:8px 9px; border-radius:8px; cursor:pointer; }
 .map-layout-option:hover { background: var(--mc-surface-alt, #eef4fa); }
 .map-layout-option input { margin:0; }
+/* raw: map layout popover surface + hover (theme-registry Stage 1.7) - no
+   exact --mc-* match yet (closest: color #eef6fc vs --mc-chat-text
+   #eef6ff, off by 0,0,3), candidate for a dedicated dialog/popover-token
+   set in Stage 3.1. */
 [data-theme="dark"] .map-layout-popover { background:#142434; border-color:#314a62; color:#eef6fc; }
 [data-theme="dark"] .map-layout-option:hover { background:#20384e; }
 
@@ -2959,6 +2963,12 @@ body[data-theme="dark"] .node-manager-detect-radio-btn:hover {
     color: #fff;
 }
 
+/* theme-registry Stage 1.7: the base rule below is another consumer of
+   the legacy --theme-* token family (same debt already flagged for
+   .camera-panel in Stage 1.4 and .devices-panel/.media-panel in Stage
+   1.6) - not touched here, that's a real family migration for Stage 3.1,
+   not a per-selector swap (none of --theme-elevated-bg/--theme-border/
+   --theme-text's dark values match any current --mc-* token exactly). */
 [data-theme="dark"] .waypoint-action-toast,
 body[data-theme="dark"] .waypoint-action-toast {
     background: var(--theme-elevated-bg) !important;
@@ -2966,6 +2976,10 @@ body[data-theme="dark"] .waypoint-action-toast {
     color: var(--theme-text) !important;
 }
 
+/* raw: error-state border, not part of the legacy bundle above (theme-registry
+   Stage 1.7) - #e05d68 checked against every dark --mc-* token, no exact
+   match (closest: --mc-danger #ff7b85, off by 31,30,29 - not close),
+   candidate for Stage 3.1. */
 [data-theme="dark"] .waypoint-action-toast.error,
 body[data-theme="dark"] .waypoint-action-toast.error {
     border-color: #e05d68 !important;
@@ -3178,6 +3192,16 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     background: #344b61;
 }
 
+/* Generic modal chrome (theme-registry Stage 1.7). Checked every value
+   below against the current dark --mc-* tokens: only .modal-header span's
+   #f4f8fc is an exact match (--mc-tab-text-active - a semantically odd
+   name for modal-header text, but the value is byte-identical, so
+   tokenized anyway per the reuse-if-exact rule). Everything else has no
+   exact match, left raw - candidates for a dedicated dialog-token set in
+   Stage 3.1. (.modal-content's #1b2d40 is the same near-miss already
+   noted at the telemetry-modal override further down this file - since
+   it's not being tokenized here either, that override does not become
+   redundant.) */
 [data-theme="dark"] .modal-overlay {
     background: rgba(3, 10, 18, .72);
     backdrop-filter: blur(3px);
@@ -3195,7 +3219,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 }
 
 [data-theme="dark"] .modal-header span {
-    color: #f4f8fc;
+    color: var(--mc-tab-text-active);
 }
 
 [data-theme="dark"] .modal-close {

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1178,6 +1178,17 @@ html[data-theme="dark"] .dock-right {
     color: #91a2b6;
 }
 
+/* Dead code (theme-registry Stage 1.7, confirmed via computed styles on a
+   real page, not just specificity reasoning - not deleted, out of scope
+   to clean up dead CSS here). All three rules below are shadowed by the
+   equal-specificity, later, already-tokenized
+   html[data-theme="dark"] .workspace-popover / .workspace-popover-header
+   / .workspace-popover::after rules further down this file
+   (~line 3100: var(--mc-popover-bg)/var(--mc-popover-border)/
+   var(--mc-popover-text)/var(--mc-popover-shadow), ~3110:
+   var(--mc-popover-header-bg)/var(--mc-popover-divider)) - later wins the
+   tie, no legacy !important complication this time (unlike the
+   .devices-panel case from Stage 1.6). */
 html[data-theme="dark"] .workspace-popover {
     background: #202a36;
     border-color: #445164;
@@ -1195,6 +1206,14 @@ html[data-theme="dark"] .workspace-popover-header {
     border-bottom-color: #364253;
 }
 
+/* This one IS live (confirmed via computed styles) - no later rule
+   re-declares .workspace-popover-header span's color specifically, only
+   the background/border-bottom-color above are shadowed. #91a2b6 checked
+   against every dark --mc-* token, no exact match (closest:
+   --mc-text-muted #90a5ba, off by 1,3,4), left raw. Not split out of this
+   bundle since nothing is being tokenized either way, and
+   .workspace-setting-row/.workspace-menu-title are outside this stage's
+   popover/toast scope. */
 html[data-theme="dark"] .workspace-popover-header span,
 html[data-theme="dark"] .workspace-setting-row small,
 html[data-theme="dark"] .workspace-menu-title {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,8 +8,8 @@
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-5a">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-5a">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-5a">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
## Summary
Modal/popover/notification/toast domain, MeshCenter Dark, across `static/ui-kit.css`, `static/style-part3.css`, `static/style-part4.css`.

## A-E value/dead-code table

| Item | Selector(s) | Result |
|---|---|---|
| A | `.modal-overlay` bg | rgba, N/A |
| A | `.modal-content` bg `#1b2d40` | no exact match (closest `--mc-bg-panel` `#1b2837`, off by 0,5,9) |
| A | `.modal-content` border `#3a526a` | no exact match (closest `--mc-button-secondary-border` `#3a526d`, off by 0,0,3) |
| A | `.modal-content` color `#d9e7f5` | no exact match |
| A | `.modal-header` border-bottom `#344b61` | no exact match |
| A | **`.modal-header span` color `#f4f8fc`** | **exact match `--mc-tab-text-active`** - tokenized (flagged: semantically odd token name for modal text, but byte-identical value) |
| A | `.modal-close` color `#a9bed1` | no exact match |
| A | `.modal-close:hover` color `#ffffff` | no exact match (no token is pure white) |
| A | `.confirm-text` color `#c6d7e8` | no exact match |
| B | `ui-kit.css` `.workspace-popover`/`::after`/`-header` (~1181) | **dead code, confirmed via computed styles** (equal-specificity, later, tokenized rule ~1900 lines down wins) |
| B | `.workspace-popover-header span` color `#91a2b6` | **live** (no later override exists for this specific declaration) - checked, no exact match |
| B | `style-part3.css` `.dock-notification-btn`(`:hover`)/`.notification-popover`/`.notification-item:hover` | **dead code, confirmed via computed styles** (lower specificity than `ui-kit.css`'s `html[data-theme="dark"]` versions, always loses regardless of file order) |
| C | `.notification-success` icon `#72d69a` | **exact match `--mc-success`** - tokenized |
| C | `.notification-warning` icon `#f0c86a` | **exact match `--mc-warning`** - tokenized |
| C | `.notification-error` icon `#ff9299` | no exact match (`--mc-danger` `#ff7b85`, off by 31,30,29 - not close) |
| C | `.notification-info` icon `#8fc7f0` (found via the same check, 4th sibling not named in the brief) | no exact match |
| C | rgba background halos (all four) | not hex literals; each halo's RGB triplet doesn't match its own icon's token or any other token either, so no `var()` substitution available regardless |
| D | `.map-layout-popover` bg/border/color | no exact match for any (`color` closest: `#eef6fc` vs `--mc-chat-text` `#eef6ff`, off by 0,0,3) |
| D | `.map-layout-option:hover` bg | no exact match |
| E | base `.waypoint-action-toast` rule | legacy `--theme-*` family, confirmed, **not touched** - another consumer of the Stage 3.1 debt (alongside `.camera-panel`, `.devices-panel`/`.media-panel`) |
| E | `.waypoint-action-toast.error` border `#e05d68` | no exact match (`--mc-danger` `#ff7b85`, off by 31,30,29) |

## Dead-code verification method
Same rigor as Stage 1.6: built a standalone test page loading the real CSS and checked `getComputedStyle()` directly, rather than trusting specificity reasoning alone. Confirmed both dead-code hypotheses in the brief exactly as described, plus found the popover-header span exception (live, not dead) by checking whether a later override existed for that *specific* declaration rather than just the containing rule.

## Observation, not acted on (out of scope, found while DOM-injecting the toast for the live check)
The `.waypoint-action-toast.success` class's own `border-color: #2a9a60` (a light/theme-agnostic base rule) is silently overridden by the dark base rule's `border-color: var(--theme-border) !important` - since `!important` beats non-important regardless of specificity, a success toast in dark mode gets the generic border color, not green. This is pre-existing behavior, unrelated to anything in this PR (I didn't touch the base rule or `.success`'s own rule) - noting it for the record, not fixing it.

## Cache-busting
`style-part3.css` and `style-part4.css` bumped (both had real value changes). `ui-kit.css` is comments-only this stage, not bumped.

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean.
- `tinycss2` parse: `ui-kit.css` 483 rules, `style-part3.css` 530 rules, `style-part4.css` 669 rules - 0 errors each.
- Diff (attached) touches only the described selectors.
- Contrast spot-check on both exact-match substitutions: `#F4F8FC` vs `.modal-content`'s bg `#1B2D40` is 13.15:1, `#72D69A`/`#F0C86A` vs `.notifications-card`'s bg `#1B2837` are 8.40:1/9.38:1 - all pass AAA, no pre-existing failures to report for these two.
- **Live check on dev** (real hardware): branch checked out, service restarted, opened the real notification popover in Dark (bell icon in the status dock) - confirmed correct rendering and pulled computed styles via JS (`rgb(27,40,55)`/`rgb(58,82,109)` = `#1b2837`/`#3a526d`, matching the tokenized values exactly, confirming the dead style-part3.css rule really doesn't render). For the modal and waypoint toast, avoided triggering real destructive actions (a system restart button didn't visibly open a confirm dialog on the first click, and I didn't want to risk it firing for real) - instead safely DOM-injected `.modal-overlay`/`.modal-content`/`.modal-header`/`.confirm-text` and `.waypoint-action-toast.success`/`.error` elements into the live page (real loaded CSS, zero app-state risk) and read their computed styles: modal content `rgb(27,45,64)`/`rgb(58,82,106)`/`rgb(217,231,245)` and header span `rgb(244,248,252)` all matched expected values exactly (raw unchanged / token-identical); toast success/error backgrounds and text matched the legacy tokens unchanged, error border `rgb(224,93,104)` = `#e05d68` matched the untouched raw value exactly.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean on all three touched files
- [x] Diff scoped to only the described selectors
- [x] Contrast spot-check on both exact-match substitutions
- [x] Dead-code claims verified via computed styles, not just specificity reasoning
- [x] Live dev check: real notification popover + DOM-injected modal and waypoint toast (success/error), avoiding real destructive actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)