### PR TITLE
Theme registry Stage 1.8: MeshCenter Dark Settings/System/Schedules normalization

### DIFF
--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -3015,7 +3015,7 @@ body {
 }
 
 html[data-theme="dark"] .settings-card-note--warning {
-    color: #f0c86a;
+    color: var(--mc-warning);
 }
 
 .telemetry-export-menu {

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -2559,6 +2559,12 @@ html[data-theme="dark"] .battery-runtime-value {
     color: #f2f7fb;
 }
 
+/* Dead code (theme-registry Stage 1.8, confirmed via computed styles).
+   Same mechanism as .settings-select in ui-kit.css: no !important here,
+   and ui-kit.css's generic html[data-theme="dark"] :is(input, select,
+   textarea, .message-input) rule (!important) matches this <input> too,
+   at equal-or-higher specificity, and always wins. Not deleted, out of
+   scope to clean up. */
 body[data-theme="dark"] .settings-number-input,
 html[data-theme="dark"] .settings-number-input {
     border-color: #334a61;

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -1192,6 +1192,12 @@
     line-height: 1.4;
     overflow-wrap: anywhere;
 }
+/* raw: MeshCenter Instance card radio-identity status colors
+   (theme-registry Stage 1.8) - no exact --mc-* match for any of the
+   three (closest: match #86efac vs --mc-success #72d69a, off by 63 sum;
+   mismatch #fcd34d vs --mc-warning #f0c86a, off by 52 sum; error #fca5a5
+   vs --mc-danger #ff7b85, off by 77 sum - none close), candidates for
+   Stage 3.1. */
 body[data-theme="dark"] .identity-match,
 html[data-theme="dark"] .identity-match { color: #86efac; }
 body[data-theme="dark"] .identity-mismatch,
@@ -3460,6 +3466,14 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 [data-theme="dark"] .export-time-sep {
     color: #9eb3c8;
 }
+/* raw: Updates card (theme-registry Stage 1.8) - checked every value
+   below against the current dark --mc-* tokens, no exact match for any
+   (nearest misses, sum of per-channel diffs: #9eb3c8 vs --mc-popover-muted
+   #9fb0c3 = 9; #e5eff8 vs --mc-button-secondary-text #eef6ff = 23;
+   #d9e7f5 vs same = 46; #c3d3e2 vs --mc-text-secondary #c3d1df = 5;
+   #16283a vs --mc-bg-panel #1b2837 = 8; #0f1c2a vs --mc-bg-workspace
+   #111c29 = 3), candidates for a dedicated Settings/System-token set in
+   Stage 3.1. */
 [data-theme="dark"] .updates-version-row {
     color: #9eb3c8;
 }
@@ -4028,7 +4042,24 @@ body[data-theme="dark"] .waypoint-action-toast.error {
    override (body/html[data-theme=dark] .node-info-panel, ~line 9501):
    bg #172638, border #263c52, shadow rgba(0,0,0,.24). Text colors reuse
    this same section's existing schedule/timer dark convention
-   (#e5eff8 primary, #9eb3c8 muted) rather than inventing new ones. */
+   (#e5eff8 primary, #9eb3c8 muted) rather than inventing new ones.
+   theme-registry Stage 1.8: #172638/#263c52 are the same literals already
+   checked (no exact --mc-* match) for .telemetry-card in Stage 1.5a - not
+   re-derived here, same conclusion applies. Every other raw value in this
+   Time/Schedules/Timer block below was checked individually against the
+   current dark --mc-* tokens - no exact match for any of them (they all
+   reuse this section's own two established shades, per the comment
+   above, rather than drifting into new one-off colors, which is at least
+   internally consistent even without a shared token yet). Candidates for
+   a dedicated Settings/System-token set in Stage 3.1.
+   .schedule-form-error's #ff9299 is the same non-matching value already
+   checked for the notification-error icon in Stage 1.7 (still not an
+   exact match for --mc-danger #ff7b85). .schedule-modal-footer's
+   border-top-color #344b61 is the same value already checked for
+   .modal-header's border-bottom-color in Stage 1.7 (also no match) -
+   consistent reuse of Stage 1.7's modal chrome color, as expected for a
+   modal built on the same .modal-overlay/.modal-content base; nothing
+   schedule/timer-specific to newly document there. */
 body[data-theme="dark"] #timeCard,
 html[data-theme="dark"] #timeCard {
     border-color: #263c52;

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1055,10 +1055,28 @@ html[data-theme="dark"] .app-container,
 html[data-theme="dark"] .main-layout,
 html[data-theme="dark"] .video-panel,
 html[data-theme="dark"] .media-panel,
-html[data-theme="dark"] .system-panel,
-html[data-theme="dark"] .settings-panel,
 html[data-theme="dark"] .base-sidebar,
 html[data-theme="dark"] .sidebar {
+    background-color: #18212c;
+    color: #dbe5f1;
+}
+
+/* Dead code (theme-registry Stage 1.8, confirmed via computed styles on a
+   real page). .settings-panel/.system-panel's background+color are always
+   shadowed by the legacy style-part4.css rule
+   ([data-theme="dark"] .settings-panel, [data-theme="dark"] .system-panel
+   { background: var(--theme-panel-bg) !important; color: var(--theme-text)
+   !important; ... }, ~line 2127) - !important beats this non-important
+   rule regardless of specificity. Not deleted, out of scope to clean up.
+   (Their border-color is governed by a third, still-different rule - the
+   "Stronger darker outline" bundle a bit further down this file,
+   border-color: #0a121c !important, which beats the legacy rule on
+   specificity since both are !important - already documented as a
+   no-match raw value in Stage 1.6's report for .devices-panel; same
+   rule, same conclusion, applies to .settings-panel/.system-panel too,
+   no new action needed here.) */
+html[data-theme="dark"] .settings-panel,
+html[data-theme="dark"] .system-panel {
     background-color: #18212c;
     color: #dbe5f1;
 }
@@ -1076,7 +1094,25 @@ html[data-theme="dark"] .messages-view {
 
 html[data-theme="dark"] .base-card,
 html[data-theme="dark"] .weather-card,
-html[data-theme="dark"] .base-reference-location,
+html[data-theme="dark"] .base-reference-location {
+    background-color: #202a36;
+    border-color: #364253;
+    color: #dbe5f1;
+}
+
+/* Dead code (theme-registry Stage 1.8, confirmed via computed styles).
+   Shadowed by the equal-specificity, later, already-tokenized
+   html[data-theme="dark"] :is(.chat-item, .node-card, .system-card,
+   .settings-card, ...) rule further down this file (background:
+   var(--mc-bg-panel), border-color: var(--mc-border), both !important -
+   later wins the tie). Not tokenized to match that winner here (unlike
+   the .chat-item/.node-card hygiene pattern from 1.1/1.2): .settings-card
+   and .system-card actually resolve to *different* live text colors
+   elsewhere (--mc-text-primary vs --mc-text-secondary, from a separate,
+   still-different color-only rule that also applies to .system-card), so
+   there's no single token that would accurately describe this shared
+   dead declaration's "real" color - documenting as dead is more honest
+   than picking one. */
 html[data-theme="dark"] .settings-card,
 html[data-theme="dark"] .system-card {
     background-color: #202a36;
@@ -1220,10 +1256,14 @@ html[data-theme="dark"] .workspace-menu-title {
     color: #91a2b6;
 }
 
+/* Workspace popover Panels section (theme-registry Stage 1.8). Confirmed
+   live (not shadowed) via computed styles. */
 html[data-theme="dark"] .workspace-menu-section {
-    border-bottom-color: #364253;
+    border-bottom-color: var(--mc-workspace-header-border);
 }
 
+/* raw: no exact --mc-* match yet (closest: --mc-button-secondary-text
+   #eef6ff, off by 19,17,14), candidate for Stage 3.1. */
 html[data-theme="dark"] .workspace-setting-row {
     color: #dbe5f1;
 }
@@ -1791,6 +1831,9 @@ html[data-theme="dark"] a {
 }
 
 /* System chart and log */
+/* raw: System Log / chart well background (theme-registry Stage 1.8) - no
+   exact --mc-* match yet (closest: --mc-bg-subtle #162231, off by 0,1,0),
+   candidate for Stage 3.1. border-color/color here are already tokenized. */
 html[data-theme="dark"] :is(.chart-container, .system-chart, .system-log-body, .log-container) {
     background: #162331 !important;
     border-color: var(--mc-border) !important;
@@ -2692,6 +2735,13 @@ html[data-theme="dark"] .chat-item .chat-time {
     font-weight: 700;
 }
 
+/* raw: Workspace popover Application nav row (System/Settings/About)
+   (theme-registry Stage 1.8) - confirmed live via computed styles, no
+   exact --mc-* match for any value below (closest: hover background
+   #22364a vs --mc-button-secondary-bg #223349, off by 0,3,1; hover
+   border #36516c vs --mc-button-secondary-border #3a526d, off by 4,1,1;
+   :hover/.active color #fff, no token is pure white), candidates for
+   Stage 3.1. */
 html[data-theme="dark"] .workspace-nav-btn {
     color: #dce8f6;
 }
@@ -3030,6 +3080,15 @@ body[data-theme="light"] .mc-workspace-panel {
 html[data-theme="dark"] .weather-location-name { color: #f4f8ff; }
 html[data-theme="dark"] .weather-location-coordinates { color: #8fa7c2; }
 html[data-theme="dark"] .weather-location-block:hover .weather-location-name { color: #66b2ff; }
+/* Dead code (theme-registry Stage 1.8, confirmed via computed styles).
+   None of these three declarations render: this rule has no !important,
+   and the generic html[data-theme="dark"] :is(input, select, textarea,
+   .message-input) rule (background: #0f1a26 !important; color:
+   var(--mc-text-primary) !important; border-color: var(--mc-border)
+   !important;) matches every <select>, including .settings-select, at
+   equal-or-higher specificity - its !important always wins. Not deleted,
+   out of scope to clean up (that generic rule is app-wide and untouched,
+   same as Stage 1.1 left it). */
 html[data-theme="dark"] .settings-select {
     border-color: #34475d;
     background: #0f1d2b;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,11 +6,11 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260824-ble-receive-warning">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260903-theme-stage1-8">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-5a">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-8">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
Settings page, System page (Updates/System Log/MeshCenter Instance/Security/Network), Time/Schedules, and the Workspace popover's Panels/Display/Application-nav sections, MeshCenter Dark. Across `static/ui-kit.css`, `static/style-part1.css`, `static/style-part3.css`, `static/style-part4.css`.

## Exact matches tokenized (2)
| Selector | Value | Token |
|---|---|---|
| `.settings-card-note--warning` color | `#f0c86a` | `--mc-warning` |
| `.workspace-menu-section` border-bottom-color | `#364253` | `--mc-workspace-header-border` (name mismatch, exact value, confirmed live) |

## Dead code confirmed via computed styles (not deleted, documented)
- **`.settings-panel`/`.system-panel`** (split out of the `.app-container`/`.video-panel`/`.base-sidebar`/etc bundle in `ui-kit.css`): background+color always lose to the legacy `style-part4.css` `!important` rule (`--theme-panel-bg`/`--theme-text`) - **another confirmed consumer of the Stage 3.1 legacy-family debt**, alongside `.camera-panel`, `.devices-panel`/`.media-panel`, `.waypoint-action-toast`. Border-color is separately governed by the already-documented (Stage 1.6) "Stronger darker outline" bundle (`#0a121c`, no match) - same rule, same conclusion, now confirmed to apply here too.
- **`.settings-card`/`.system-card`** (split out of the `.base-card`/`.weather-card`/`.base-reference-location` bundle): shadowed by the later, already-tokenized "Dark surfaces and cards" bundle. **Not** tokenized to match the winner (unlike the `.chat-item`/`.node-card` hygiene pattern from 1.1/1.2) because `.settings-card` and `.system-card` actually resolve to *different* live text colors there (`--mc-text-primary` vs `--mc-text-secondary`, from a separate color-only rule) - no single token would honestly describe the shared dead declaration, so left undocumented-as-a-token, just marked dead.
- **`.settings-select`** (`ui-kit.css`) and **`.settings-number-input`** (`style-part3.css`): both lose to the generic `html[data-theme="dark"] :is(input, select, textarea, .message-input)` rule (app-wide, untouched, same as Stage 1.1 left it) - confirmed via computed styles that the real `<select>`/`<input>` elements render that generic rule's colors, not their own specific (and now-documented-dead) rules.

## Checked, no exact match, left raw with comments
System Log/chart well background (`#162331`), MeshCenter Instance identity status colors (`.identity-match`/`.identity-mismatch`/`.identity-not-found`/`.identity-detection-error`/`.identity-error`), the full Updates card (6 declarations), the full Time/Schedules/Timer block (20+ declarations, all consistently reusing this section's own two established shades rather than drifting - noted as internally consistent even without a shared token), `.workspace-setting-row` color, the Workspace popover's Application-nav row (5 declarations). Nearest-token near-miss noted per value in the code comments for the Stage 3.1 backlog.

Two values noted as reusing literals already checked in earlier stages rather than re-derived, per your instruction: `.schedule-form-error`'s `#ff9299` = Stage 1.7's notification-error icon (still no match); `.schedule-modal-footer`'s `#344b61` = Stage 1.7's `.modal-header` border (also no match, expected since it's built on the same `.modal-overlay`/`.modal-content` base).

## Out of scope, confirmed untouched
The Appearance/theme-radio segment of the Workspace popover (Stage 3.2), the legacy `--theme-*` family itself (Stage 3.1 - `style-part4.css:2127-2128`'s `.settings-panel`/`.system-panel` rule confirmed present and referenced in the dead-code comment above, not migrated), the About page, Network card (confirmed no dark-specific raw hex exists for it at all - purely inherits from `.system-card` + already-tokenized `.system-row`).

## Cache-busting
`style-part1.css` and `ui-kit.css` bumped (both had real value changes - `style-part1.css` had never been bumped by any theme-registry stage before this one). `style-part3.css` and `style-part4.css` are comments-only this stage, not bumped.

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean.
- `tinycss2` parse: `ui-kit.css` 485 rules, `style-part1.css` 490 rules, `style-part3.css` 530 rules, `style-part4.css` 669 rules - 0 errors each.
- Diff (attached) touches only the described selectors.
- Contrast spot-check on both exact-match substitutions: `#F0C86A` vs `#202A36` (a plausible surface) is 9.11:1, passes AAA. `#364253` vs `#18212C` is 1.59:1, under the 3:1 border threshold - but this is the **same raw value as before** (only swapped for an identical-value token), a pre-existing thin-divider situation matching the pattern already seen in prior stages - report only, not fixed.
- **Live check on dev** (real hardware): branch checked out, service restarted, walked Settings (General/Telemetry/Units cards, the `<select>` and number input), System (Network, MeshCenter Instance incl. a live "Radio identity check failed" error banner and "Identity: Verified" success text, Updates, System Log, Security), the Time & Timers hero clock, and the Workspace popover (Panels toggles, Compact mode, Application nav row) in Dark - all rendered correctly. Pulled computed styles via JS throughout to confirm exactly: `.settings-card` renders via the tokenized winning bundle (not the now-documented-dead raw rule), `.settings-select`/`.settings-number-input` render via the generic input rule (not their own dead rules), `.workspace-menu-section` border matches the token value exactly, Time hero clock color and Updates version-row color both matched their untouched raw values exactly. DOM-injected `.schedule-modal-footer` and `.identity-match` (avoiding a real schedule/modal action) confirmed their raw values unchanged too. Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean on all four touched files
- [x] Diff scoped to only the described selectors
- [x] Dead-code claims verified via computed styles, not just specificity/comment claims
- [x] Contrast spot-check on both exact-match substitutions
- [x] Live dev check across Settings, System (Network/Instance/Updates/Log/Security), Time card, and Workspace popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)