### PR TITLE
Theme registry Stage 3.1: migrate legacy --theme-* family to --mc-legacy-* tokens

### DIFF
--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -2045,23 +2045,33 @@ body.node-manager-open #messagesView[hidden] {
    UNIFIED LIGHT / DARK THEME LAYER
    Final cascade for workspace cards, Node Manager, Devices,
    Tools and local-node header.
+
+   theme-registry Stage 3.1: the 14 --theme-* custom properties below are
+   now aliases onto the --mc-legacy-* tokens defined in ui-kit.css's
+   canonical token block, not first-class hardcoded values - do not put
+   raw hex back here. This keeps every var(--theme-*) consumer in this
+   file (and the --card-bg/--surface-secondary/--border-color/etc
+   compatibility layer just below, which already chains through
+   --theme-*) working exactly as before while giving the underlying
+   colors one real source of truth. See ui-kit.css's --mc-legacy-*
+   comment for why these aren't merged into the generic --mc-* family.
    ============================================================ */
 
 :root {
-    --theme-app-bg: #eef3f8;
-    --theme-workspace-bg: #f7f9fc;
-    --theme-panel-bg: #ffffff;
-    --theme-card-bg: #ffffff;
-    --theme-card-hover: #f4f8fd;
-    --theme-elevated-bg: #edf4fb;
-    --theme-border: #d5dfeb;
-    --theme-border-soft: #e7edf4;
-    --theme-text: #14243a;
-    --theme-text-secondary: #506983;
-    --theme-text-muted: #7d91a7;
-    --theme-accent: #1769e0;
-    --theme-focus: #4f8cff;
-    --theme-shadow: 0 8px 24px rgba(29, 53, 87, .08);
+    --theme-app-bg: var(--mc-legacy-app-bg);
+    --theme-workspace-bg: var(--mc-legacy-workspace-bg);
+    --theme-panel-bg: var(--mc-legacy-panel-bg);
+    --theme-card-bg: var(--mc-legacy-card-bg);
+    --theme-card-hover: var(--mc-legacy-card-hover);
+    --theme-elevated-bg: var(--mc-legacy-elevated-bg);
+    --theme-border: var(--mc-legacy-border);
+    --theme-border-soft: var(--mc-legacy-border-soft);
+    --theme-text: var(--mc-legacy-text);
+    --theme-text-secondary: var(--mc-legacy-text-secondary);
+    --theme-text-muted: var(--mc-legacy-text-muted);
+    --theme-accent: var(--mc-legacy-accent);
+    --theme-focus: var(--mc-legacy-focus);
+    --theme-shadow: var(--mc-legacy-shadow);
 
     /* Compatibility tokens used by existing components. */
     --card-bg: var(--theme-card-bg);
@@ -2078,20 +2088,20 @@ body.node-manager-open #messagesView[hidden] {
 [data-theme="dark"] {
     color-scheme: dark;
 
-    --theme-app-bg: #09111a;
-    --theme-workspace-bg: #0f1a26;
-    --theme-panel-bg: #162433;
-    --theme-card-bg: #1c2c3d;
-    --theme-card-hover: #24374b;
-    --theme-elevated-bg: #25394d;
-    --theme-border: #344a61;
-    --theme-border-soft: #2a3e53;
-    --theme-text: #f3f7fb;
-    --theme-text-secondary: #c3d3e3;
-    --theme-text-muted: #91a7bc;
-    --theme-accent: #65a3ff;
-    --theme-focus: #73adff;
-    --theme-shadow: 0 12px 30px rgba(0, 0, 0, .24);
+    --theme-app-bg: var(--mc-legacy-app-bg);
+    --theme-workspace-bg: var(--mc-legacy-workspace-bg);
+    --theme-panel-bg: var(--mc-legacy-panel-bg);
+    --theme-card-bg: var(--mc-legacy-card-bg);
+    --theme-card-hover: var(--mc-legacy-card-hover);
+    --theme-elevated-bg: var(--mc-legacy-elevated-bg);
+    --theme-border: var(--mc-legacy-border);
+    --theme-border-soft: var(--mc-legacy-border-soft);
+    --theme-text: var(--mc-legacy-text);
+    --theme-text-secondary: var(--mc-legacy-text-secondary);
+    --theme-text-muted: var(--mc-legacy-text-muted);
+    --theme-accent: var(--mc-legacy-accent);
+    --theme-focus: var(--mc-legacy-focus);
+    --theme-shadow: var(--mc-legacy-shadow);
 
     --card-bg: var(--theme-card-bg);
     --surface-secondary: var(--theme-elevated-bg);

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -3330,6 +3330,37 @@ body[data-theme="dark"] .workspace-popover::after {
     --mc-scrollbar-thumb: #9fb3c8;
     --mc-scrollbar-thumb-hover: #829bb5;
 
+    /* Legacy --theme-* family (theme-registry Stage 3.1): backs the
+       ~190 var(--theme-*) call sites in style-part4.css's "UNIFIED LIGHT
+       / DARK THEME LAYER" (Node Manager, Waypoints, Devices/Peripherals,
+       Tools, workspace-panel chrome, local-node header) plus the
+       ~64-site --card-bg/--surface-secondary/--border-color/etc
+       compatibility-alias layer. Deliberately NOT merged into the
+       generic --mc-bg-panel/--mc-border/--mc-text-primary/etc family
+       above even where a value happens to coincide in one theme mode
+       (checked all 14 individually - see the Stage 3.1 report for the
+       full near-miss table; none match an existing token consistently
+       across *both* light and dark, so reusing one would silently drift
+       one of the two modes). --mc-legacy-* is a separate, self-contained
+       set purely so style-part4.css's --theme-* declarations can point
+       at a real token instead of a hardcoded hex - do not add new
+       hardcoded colors here, and do not use these tokens for anything
+       outside that migration. */
+    --mc-legacy-app-bg: #eef3f8;
+    --mc-legacy-workspace-bg: #f7f9fc;
+    --mc-legacy-panel-bg: #ffffff;
+    --mc-legacy-card-bg: #ffffff;
+    --mc-legacy-card-hover: #f4f8fd;
+    --mc-legacy-elevated-bg: #edf4fb;
+    --mc-legacy-border: #d5dfeb;
+    --mc-legacy-border-soft: #e7edf4;
+    --mc-legacy-text: #14243a;
+    --mc-legacy-text-secondary: #506983;
+    --mc-legacy-text-muted: #7d91a7;
+    --mc-legacy-accent: #1769e0;
+    --mc-legacy-focus: #4f8cff;
+    --mc-legacy-shadow: 0 8px 24px rgba(29, 53, 87, .08);
+
     /* Shadows */
     --mc-shadow-panel: 0 2px 8px rgba(15, 35, 63, .045);
     --mc-shadow-hover: 0 6px 16px rgba(15, 35, 63, .09);
@@ -3460,6 +3491,23 @@ html[data-theme="dark"] {
     --mc-scrollbar-track: #202936;
     --mc-scrollbar-thumb: #526174;
     --mc-scrollbar-thumb-hover: #67788d;
+
+    /* Legacy --theme-* family (theme-registry Stage 3.1) - see the :root
+       block above for the full explanation of why this is a separate set. */
+    --mc-legacy-app-bg: #09111a;
+    --mc-legacy-workspace-bg: #0f1a26;
+    --mc-legacy-panel-bg: #162433;
+    --mc-legacy-card-bg: #1c2c3d;
+    --mc-legacy-card-hover: #24374b;
+    --mc-legacy-elevated-bg: #25394d;
+    --mc-legacy-border: #344a61;
+    --mc-legacy-border-soft: #2a3e53;
+    --mc-legacy-text: #f3f7fb;
+    --mc-legacy-text-secondary: #c3d3e3;
+    --mc-legacy-text-muted: #91a7bc;
+    --mc-legacy-accent: #65a3ff;
+    --mc-legacy-focus: #73adff;
+    --mc-legacy-shadow: 0 12px 30px rgba(0, 0, 0, .24);
 
     /* Shadows */
     --mc-shadow-panel: 0 3px 10px rgba(0, 0, 0, .24);

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,8 +9,8 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260903-theme-stage1-8">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage1-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage1-8">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage3-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary
Zero visual change. `static/style-part4.css`'s 14 `--theme-*` custom properties (backing ~190 `var(--theme-*)` consumers - Node Manager, Waypoints, Devices/Peripherals, Tools, the `.settings-panel`/`.system-panel`/`.camera-panel` legacy `!important` bundle, workspace-panel chrome - plus the ~64-site `--card-bg`/`--border-color`/etc compatibility alias layer) now resolve through 14 new, dedicated `--mc-legacy-*` tokens in `ui-kit.css`'s canonical block, instead of hardcoded hex. No consumer selector touched - the indirection through `var(--theme-x)` is what makes every one of those ~254 combined usages inherit the fix automatically.

## Naming
`--mc-legacy-<name>` (e.g. `--mc-legacy-panel-bg`), one per `--theme-*` name, 1:1. Chosen specifically to avoid colliding with the existing `--mc-bg-panel`/`--mc-border`/`--mc-text-primary`/etc family (which carry different values) while making the reason for the separate namespace self-evident to a future reader: this is the legacy `--theme-*` family's own value set, now centralized, not a rename or a merge into the generic tokens. Comments at both definition sites (ui-kit.css's `:root` and dark blocks) explain this.

## Near-miss table (per your request, even though none were reused)
Checked all 14 against every current `--mc-*` token, in **both** light and dark (a token only qualifies as reusable if it matches consistently in both modes - that's the bar that actually matters for a safe merge). None do. Worth noting: a few pairs land on a byte-exact match in *one* mode only, coincidentally, to *different* `--mc-*` tokens depending on the mode - which is exactly the trap that would make reusing them look safe on a spot-check but silently drift the other theme:

| `--theme-*` name | Light value | Light nearest (delta sum) | Dark value | Dark nearest (delta sum) |
|---|---|---|---|---|
| `--theme-app-bg` | `#eef3f8` | `--mc-bg-muted` `#eef3f8` (**EXACT, light only**) | `#09111a` | `--mc-text-inverse` `#0b1520` (12) |
| `--theme-workspace-bg` | `#f7f9fc` | `--mc-bg-subtle` `#f7f9fc` (**EXACT, light only**) | `#0f1a26` | `--mc-bg-media-stage` `#101923` (5) |
| `--theme-panel-bg` | `#ffffff` | `--mc-bg-panel` `#ffffff` (**EXACT, light only**) | `#162433` | `--mc-card-bg` `#162433` (**EXACT, dark only - different token than the light match!**) |
| `--theme-card-bg` | `#ffffff` | `--mc-bg-panel` `#ffffff` (**EXACT, light only**) | `#1c2c3d` | `--mc-chat-input` `#1b2b3d` (2) |
| `--theme-card-hover` | `#f4f8fd` | `--mc-workspace-header-bg` `#f4f7fb` (3) | `#24374b` | `--mc-button-secondary-bg` `#223349` (8) |
| `--theme-elevated-bg` | `#edf4fb` | `--mc-button-secondary-bg` `#edf3f9` (3) | `#25394d` | `--mc-button-secondary-bg` `#223349` (13) |
| `--theme-border` | `#d5dfeb` | `--mc-border` `#d7e0ea` (4) | `#344a61` | `--mc-primary-muted` `#294967` (18) |
| `--theme-border-soft` | `#e7edf4` | `--mc-bg-media-stage` `#e9edf2` (4) | `#2a3e53` | `--mc-border` `#2f3e50` (8) |
| `--theme-text` | `#14243a` | `--mc-text-primary` `#10233f` (10) | `#f3f7fb` | `--mc-text-primary` `#f2f7fc` (2) |
| `--theme-text-secondary` | `#506983` | `--mc-text-secondary` `#58708f` (27) | `#c3d3e3` | `--mc-text-secondary` `#c3d1df` (6) |
| `--theme-text-muted` | `#7d91a7` | `--mc-text-muted` `#8798ad` (23) | `#91a7bc` | `--mc-text-muted` `#90a5ba` (5) |
| `--theme-accent` | `#1769e0` | `--mc-primary` `#1f6fdb` (19) | `#65a3ff` | `--mc-primary` `#66a8ff` (6) |
| `--theme-focus` | `#4f8cff` | `--mc-info` `#2f80ed` (62) | `#73adff` | `--mc-border-focus` `#73b2ff` (5) |
| `--theme-shadow` | box-shadow | (not a color, no comparison) | box-shadow | (not a color, no comparison) |

This confirms your own pre-check exactly (the brief's stated single exact match, `--theme-panel-bg` light vs `--mc-bg-panel` light, is the only case where the *same* delta-0 result shows up here too) and shows precisely why "mint 14 new tokens" was the right call rather than "reuse the close ones."

## Compatibility alias layer
Confirmed untouched (`--card-bg`, `--surface-secondary`, `--border-color`, `--border-light`, `--text-primary`, `--text-secondary`, `--primary-color`) - still `var(--theme-*)` in both the light and dark blocks, unchanged. Since it already resolves through `--theme-*`, and `--theme-*` now resolves through `--mc-legacy-*`, it inherits the fix with zero additional work, as expected - verified this is actually true (not just assumed) by including `.mc-workspace-header` in the computed-style check, which is one of the ~64 compatibility-layer consumers.

## Comment update
The module-level comment above `:root` now explicitly states the 14 `--theme-*` properties are aliases onto `--mc-legacy-*`, not first-class values, with a pointer to `ui-kit.css`'s own explanation of why the namespace is separate - so a future contributor won't reintroduce raw hex here.

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean (the 28 new `--mc-legacy-*` hex literals are byte-identical copies of values already in the Stage 0 registry, so nothing new).
- `tinycss2` parse: `ui-kit.css` 485 rules, `style-part4.css` 669 rules - 0 errors each.
- Diff (attached) touches only the 28 `--theme-*` declarations (14 × 2 themes) plus the 28 new `--mc-legacy-*` definitions and two comments - no consumer selector anywhere.
- **Zero-visual-change check, computed styles, before vs after, both themes**, one representative element per domain listed in your point 3:
  - Node Manager: `.node-manager-hero-card` - MATCH (light + dark)
  - Waypoints: `.waypoint-action-toast` - MATCH (light + dark)
  - Devices/Peripherals: `.device-info-card` - MATCH (light + dark)
  - `.camera-panel`/`.settings-panel`/`.system-panel` legacy bundle: `.settings-panel` - MATCH (light + dark)
  - Workspace page chrome: `.mc-workspace-header` - MATCH (light + dark)
  
  All ten before/after pairs (background, border, color, box-shadow) matched exactly, checked with a local before/after test harness (original files fetched from `origin/main` alongside the edited ones).
- **Live check on dev** (real hardware): branch checked out, service restarted, pulled computed styles via JS on the real `.settings-panel`, `.devices-panel`, `.mc-workspace-header`, a DOM-injected `.waypoint-action-toast` (avoiding a real waypoint action), and - after opening the real Node Manager view - `.node-manager-hero-card` and `.device-info-card`. Every value matched the local before/after comparison exactly (e.g. `.node-manager-hero-card`: `rgb(28,44,61)`/`rgb(52,74,97)`/`rgb(243,247,251)` = `#1c2c3d`/`#344a61`/`#f3f7fb`, the expected `--mc-legacy-card-bg`/`--mc-legacy-border`/`--mc-legacy-text` dark values). Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` parse clean on both touched files
- [x] Diff scoped to only the 14×2 `--theme-*` redirections + 14×2 new token definitions + comments
- [x] Computed-style zero-visual-change check across all 5 required domains, both themes
- [x] Compatibility alias layer confirmed still resolving correctly (not just assumed)
- [x] Live dev check on real Node Manager, Devices, Settings panel, workspace header, and a DOM-injected waypoint toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)