### PR TITLE
Theme registry Stage 3.2: themeFamily/themeMode model + Appearance UI rework

### DIFF
--- a/docs/theme-registry/tools/check_new_hex.py
+++ b/docs/theme-registry/tools/check_new_hex.py
@@ -83,7 +83,10 @@ def check_files(paths: list[Path], known: set[str]) -> list[tuple[str, int, str]
 
 def check_diff(diff_args: list[str], known: set[str]) -> list[tuple[str, str, str]]:
     cmd = ["git", "diff", "--unified=0"] + diff_args
-    result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=True)
+    result = subprocess.run(
+        cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+        encoding="utf-8", errors="replace",
+    )
     findings = []
     current_file = None
     for line in result.stdout.splitlines():

--- a/static/chat.js
+++ b/static/chat.js
@@ -8004,10 +8004,70 @@ function formatUptime(seconds) {
 // EVENT LISTENERS
 // ============================================================
 const WORKSPACE_STORAGE_KEY = 'meshcenter.workspace';
+
+// theme-registry Stage 3.2: two-level Appearance model. Level 1 picks a
+// theme *family* (only 'original' exists today - Stages 4-8 add
+// Sharp/Gunmetal/Alpine/Teal here, one entry each, no rewrite needed).
+// Level 2 is Auto/Light/Dark for a 'paired' family (a family that ships
+// both a light and dark rendering), or a single fixed-mode label with no
+// picker for a 'fixed' family (a family that only ever renders one mode).
+// 'original' is paired, so its level 2 behaves exactly like the old
+// System/Light/Dark row - just relabeled ("Auto", not "System") and
+// nested under the family card instead of being the whole Appearance
+// section by itself.
+const WORKSPACE_THEME_FAMILIES = Object.freeze([
+    Object.freeze({ id: 'original', kind: 'paired' })
+    // A future fixed family would look like:
+    // Object.freeze({ id: 'sharp-dark', kind: 'fixed', mode: 'dark' })
+]);
+const WORKSPACE_THEME_FAMILY_IDS = WORKSPACE_THEME_FAMILIES.map(family => family.id);
+
+function getWorkspaceThemeFamily(id) {
+    return WORKSPACE_THEME_FAMILIES.find(family => family.id === id) || WORKSPACE_THEME_FAMILIES[0];
+}
+
+// theme-registry Stage 3.2: renders the Appearance section's level-2
+// control - an Auto/Light/Dark radiogroup for a 'paired' family, or a
+// single non-interactive label for a 'fixed' one. Called from
+// Workspace.syncControls() (idempotent - safe to call on every apply(),
+// not just when the family actually changes) so #workspaceThemeModeRow
+// always reflects whichever family is currently selected. Listens via
+// delegation on the container (wired once in initializeWorkspace()), not
+// per-input, since this rebuilds the row's DOM on every call.
+function renderWorkspaceThemeModeRow() {
+    const container = document.getElementById('workspaceThemeModeRow');
+    if (!container) return;
+    const family = getWorkspaceThemeFamily(Workspace.state.themeFamily);
+
+    if (family.kind === 'fixed') {
+        const key = family.mode === 'dark' ? 'workspace.theme_mode_fixed_dark' : 'workspace.theme_mode_fixed_light';
+        container.innerHTML = `<div class="workspace-theme-fixed-label">${escapeHtml(window.I18N.t(key))}</div>`;
+        return;
+    }
+
+    const mode = Workspace.state.themeMode;
+    const options = [
+        { value: 'auto', icon: '◉', key: 'workspace.theme_mode_auto' },
+        { value: 'light', icon: '☀', key: 'workspace.theme_mode_light' },
+        { value: 'dark', icon: '◐', key: 'workspace.theme_mode_dark' }
+    ];
+    container.innerHTML = `
+        <div class="workspace-theme-options" role="radiogroup" aria-label="${escapeHtml(window.I18N.t('common.mode'))}">
+            ${options.map(opt => `
+                <label class="workspace-theme-option">
+                    <input type="radio" name="workspaceThemeMode" value="${opt.value}" ${mode === opt.value ? 'checked' : ''}>
+                    <span>${opt.icon} ${escapeHtml(window.I18N.t(opt.key))}</span>
+                </label>
+            `).join('')}
+        </div>
+    `;
+}
+
 const WORKSPACE_DEFAULTS = Object.freeze({
     leftPanel: true,
     rightPanel: true,
-    theme: 'system',
+    themeFamily: 'original',
+    themeMode: 'auto',
     compactMode: false
 });
 
@@ -8191,6 +8251,7 @@ const Workspace = {
             const stored = JSON.parse(localStorage.getItem(WORKSPACE_STORAGE_KEY) || '{}');
             this.state = this.sanitize(stored);
             this.migrateLegacyPanelSettings();
+            this.migrateLegacyThemeField(stored);
         } catch (error) {
             console.warn('[WORKSPACE] Unable to load preferences:', error);
             this.state = { ...WORKSPACE_DEFAULTS };
@@ -8203,7 +8264,8 @@ const Workspace = {
         return {
             leftPanel: source.leftPanel !== false,
             rightPanel: source.rightPanel !== false,
-            theme: ['system', 'light', 'dark'].includes(source.theme) ? source.theme : 'system',
+            themeFamily: WORKSPACE_THEME_FAMILY_IDS.includes(source.themeFamily) ? source.themeFamily : 'original',
+            themeMode: ['auto', 'light', 'dark'].includes(source.themeMode) ? source.themeMode : 'auto',
             compactMode: source.compactMode === true
         };
     },
@@ -8222,6 +8284,28 @@ const Workspace = {
         }
     },
 
+    // theme-registry Stage 3.2: non-destructive migration from the old
+    // single `theme: 'system'|'light'|'dark'` field to `themeFamily`/
+    // `themeMode`, same pattern as migrateLegacyPanelSettings() above -
+    // only touches storage when the old shape is present and the new one
+    // isn't, so it runs exactly once per browser and never re-applies
+    // once migrated. A user's existing choice survives exactly: old
+    // 'system' -> themeMode 'auto' (still follows the OS), old 'light'/
+    // 'dark' -> the same themeMode (still pinned).
+    migrateLegacyThemeField(stored) {
+        try {
+            const hasOldTheme = stored && typeof stored === 'object' && typeof stored.theme === 'string';
+            const hasNewFields = stored && typeof stored === 'object'
+                && (('themeFamily' in stored) || ('themeMode' in stored));
+            if (!hasOldTheme || hasNewFields) return;
+            this.state.themeFamily = 'original';
+            this.state.themeMode = (stored.theme === 'light' || stored.theme === 'dark') ? stored.theme : 'auto';
+            this.save();
+        } catch (error) {
+            console.warn('[WORKSPACE] Theme field migration failed:', error);
+        }
+    },
+
     save() {
         try {
             localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify(this.state));
@@ -8237,7 +8321,12 @@ const Workspace = {
     },
 
     resolveTheme() {
-        if (this.state.theme !== 'system') return this.state.theme;
+        // A 'fixed' family always resolves to its own mode regardless of
+        // themeMode - 'original' is 'paired', so this behaves exactly
+        // like the old system/light/dark logic for it today.
+        const family = getWorkspaceThemeFamily(this.state.themeFamily);
+        if (family.kind === 'fixed') return family.mode;
+        if (this.state.themeMode !== 'auto') return this.state.themeMode;
         return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     },
 
@@ -8245,7 +8334,8 @@ const Workspace = {
         const resolvedTheme = this.resolveTheme();
         const themeChanged = document.documentElement.dataset.theme !== resolvedTheme;
         document.documentElement.dataset.theme = resolvedTheme;
-        document.documentElement.dataset.themePreference = this.state.theme;
+        document.documentElement.dataset.themeFamily = this.state.themeFamily;
+        document.documentElement.dataset.themePreference = this.state.themeMode;
         document.documentElement.style.colorScheme = resolvedTheme;
         // Chart.js bakes axis/grid/legend/tooltip colors in at creation
         // time, so a live theme switch needs an explicit rebuild of any
@@ -8268,9 +8358,10 @@ const Workspace = {
         if (left) left.checked = this.state.leftPanel;
         if (right) right.checked = this.state.rightPanel;
         if (compact) compact.checked = this.state.compactMode;
-        document.querySelectorAll('input[name="workspaceTheme"]').forEach(input => {
-            input.checked = input.value === this.state.theme;
+        document.querySelectorAll('input[name="workspaceThemeFamily"]').forEach(input => {
+            input.checked = input.value === this.state.themeFamily;
         });
+        renderWorkspaceThemeModeRow();
     }
 };
 
@@ -8375,16 +8466,24 @@ function initializeWorkspace() {
     document.getElementById('workspaceCompactMode')?.addEventListener('change', event => {
         Workspace.update({ compactMode: event.target.checked });
     });
-    document.querySelectorAll('input[name="workspaceTheme"]').forEach(input => {
+    document.querySelectorAll('input[name="workspaceThemeFamily"]').forEach(input => {
         input.addEventListener('change', event => {
-            if (event.target.checked) Workspace.update({ theme: event.target.value });
+            if (event.target.checked) Workspace.update({ themeFamily: event.target.value });
         });
     });
+    // #workspaceThemeModeRow's radio inputs are rebuilt on every render
+    // (renderWorkspaceThemeModeRow()), so this listens via delegation on
+    // the container instead of on the individual inputs.
+    document.getElementById('workspaceThemeModeRow')?.addEventListener('change', event => {
+        if (event.target.name === 'workspaceThemeMode' && event.target.checked) {
+            Workspace.update({ themeMode: event.target.value });
+        }
+    });
 
-    // When Theme is set to System, follow Windows/browser changes live.
+    // When Mode is set to Auto, follow Windows/browser changes live.
     const systemThemeQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
     const handleSystemThemeChange = () => {
-        if (Workspace.state.theme === 'system') Workspace.applyTheme();
+        if (Workspace.state.themeMode === 'auto') Workspace.applyTheme();
     };
     if (systemThemeQuery?.addEventListener) {
         systemThemeQuery.addEventListener('change', handleSystemThemeChange);

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -19,7 +19,7 @@
     var FALLBACK_LOCALE = 'en';
     // Bumped manually alongside catalog content changes, same convention as
     // the ?v= query strings on <script>/<link> tags in index.html.
-    var CATALOG_VERSION = '20260806-6';
+    var CATALOG_VERSION = '20260903-theme-stage3-2';
 
     var catalogs = {};      // locale -> flattened {dottedKey: value}
     var loadPromises = {};  // locale -> in-flight/completed fetch promise

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1145,5 +1145,14 @@
     "login_error": "Falsches Passwort.",
     "login_throttled": "Zu viele Versuche. Versuche es in {seconds} Sekunden erneut.",
     "login_submit": "Anmelden"
+  },
+  "workspace": {
+    "theme_family_group_label": "Themenfamilie",
+    "theme_family_original": "MeshCenter Original",
+    "theme_mode_auto": "Auto",
+    "theme_mode_light": "Hell",
+    "theme_mode_dark": "Dunkel",
+    "theme_mode_fixed_light": "Immer hell",
+    "theme_mode_fixed_dark": "Immer dunkel"
   }
 }

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1145,5 +1145,14 @@
     "login_error": "Incorrect password.",
     "login_throttled": "Too many attempts. Try again in {seconds} seconds.",
     "login_submit": "Sign in"
+  },
+  "workspace": {
+    "theme_family_group_label": "Theme family",
+    "theme_family_original": "MeshCenter Original",
+    "theme_mode_auto": "Auto",
+    "theme_mode_light": "Light",
+    "theme_mode_dark": "Dark",
+    "theme_mode_fixed_light": "Fixed Light",
+    "theme_mode_fixed_dark": "Fixed Dark"
   }
 }

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -1145,5 +1145,14 @@
     "login_error": "Неверный пароль.",
     "login_throttled": "Слишком много попыток. Повторите через {seconds} сек.",
     "login_submit": "Войти"
+  },
+  "workspace": {
+    "theme_family_group_label": "Семейство тем",
+    "theme_family_original": "MeshCenter Original",
+    "theme_mode_auto": "Авто",
+    "theme_mode_light": "Светлая",
+    "theme_mode_dark": "Тёмная",
+    "theme_mode_fixed_light": "Всегда светлая",
+    "theme_mode_fixed_dark": "Всегда тёмная"
   }
 }

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -1145,5 +1145,14 @@
     "login_error": "Невірний пароль.",
     "login_throttled": "Забагато спроб. Спробуйте ще раз через {seconds} с.",
     "login_submit": "Увійти"
+  },
+  "workspace": {
+    "theme_family_group_label": "Сімейство тем",
+    "theme_family_original": "MeshCenter Original",
+    "theme_mode_auto": "Авто",
+    "theme_mode_light": "Світла",
+    "theme_mode_dark": "Темна",
+    "theme_mode_fixed_light": "Завжди світла",
+    "theme_mode_fixed_dark": "Завжди темна"
   }
 }

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -972,6 +972,95 @@ a:focus-visible,
     transform: translateX(15px);
 }
 
+/* theme-registry Stage 3.2: level-1 family picker. Uses --mc-* tokens
+   directly (not raw hex) so it's already theme-aware in both light and
+   dark with no separate dark-mode block needed - unlike most of this
+   file's pre-Stage-3 CSS, this is new code with no legacy debt to carry. */
+.workspace-theme-families {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.workspace-theme-family-option {
+    cursor: pointer;
+}
+
+.workspace-theme-family-option input {
+    position: absolute;
+    opacity: 0;
+}
+
+.workspace-theme-family-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--mc-border);
+    border-radius: 9px;
+    background: var(--mc-bg-panel);
+    transition: .16s ease;
+}
+
+.workspace-theme-family-option input:checked + .workspace-theme-family-card {
+    border-color: var(--mc-border-active);
+    background: var(--mc-primary-soft);
+    box-shadow: inset 0 0 0 1px var(--mc-border-active);
+}
+
+.workspace-theme-family-option input:focus-visible + .workspace-theme-family-card {
+    outline: 2px solid var(--mc-border-focus);
+    outline-offset: 1px;
+}
+
+/* 4-swatch mini-preview (background / panel / primary action / warning),
+   shown for each family card in that family's *currently resolved* mode
+   (light or dark) - the swatches reference the live --mc-* custom
+   properties, so switching Auto/Light/Dark updates them automatically
+   with no JS-computed color. */
+.workspace-theme-swatches {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2px;
+    width: 24px;
+    height: 24px;
+    flex: 0 0 auto;
+    border: 1px solid var(--mc-border);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.workspace-theme-swatch {
+    width: 100%;
+    height: 100%;
+}
+.workspace-theme-swatch--bg { background: var(--mc-bg-app); }
+.workspace-theme-swatch--panel { background: var(--mc-bg-panel); }
+.workspace-theme-swatch--primary { background: var(--mc-primary); }
+.workspace-theme-swatch--warning { background: var(--mc-warning); }
+
+.workspace-theme-family-label {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--mc-text-primary);
+}
+
+/* Level-2 fixed-mode label (a 'fixed' family has no Auto/Light/Dark
+   picker) - unreachable today since 'original' is the only family and
+   it's 'paired', but styled now so the branch isn't untested-looking
+   dead code once Stage 4+ adds a fixed family. */
+.workspace-theme-fixed-label {
+    padding: 8px 10px;
+    border: 1px solid var(--mc-border);
+    border-radius: 8px;
+    background: var(--mc-bg-subtle);
+    color: var(--mc-text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+    text-align: center;
+}
+
 .workspace-theme-options {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage3-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260903-theme-stage3-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
@@ -1917,20 +1917,31 @@
 
                 <div class="workspace-menu-section">
                     <div class="workspace-menu-title">Appearance</div>
-                    <div class="workspace-theme-options" role="radiogroup" aria-label="Theme">
-                        <label class="workspace-theme-option">
-                            <input type="radio" name="workspaceTheme" value="system" checked>
-                            <span>◉ System</span>
-                        </label>
-                        <label class="workspace-theme-option">
-                            <input type="radio" name="workspaceTheme" value="light">
-                            <span>☀ Light</span>
-                        </label>
-                        <label class="workspace-theme-option">
-                            <input type="radio" name="workspaceTheme" value="dark">
-                            <span>◐ Dark</span>
+                    <!-- Level 1: theme family. Only "MeshCenter Original" exists
+                         today (theme-registry Stage 3.2) - Stages 4-8 add
+                         Sharp/Gunmetal/Alpine/Teal as more <label> entries here,
+                         each with its own data-family value; no JS rewrite
+                         needed, see WORKSPACE_THEME_FAMILIES in chat.js. -->
+                    <div class="workspace-theme-families" id="workspaceThemeFamilies" role="radiogroup" aria-label="Theme family" data-i18n-aria-label="workspace.theme_family_group_label">
+                        <label class="workspace-theme-family-option" data-family="original">
+                            <input type="radio" name="workspaceThemeFamily" value="original" checked>
+                            <span class="workspace-theme-family-card">
+                                <span class="workspace-theme-swatches" aria-hidden="true">
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--bg"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--panel"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--primary"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--warning"></span>
+                                </span>
+                                <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_original">MeshCenter Original</span>
+                            </span>
                         </label>
                     </div>
+                    <!-- Level 2: Auto/Light/Dark for a paired family, or a single
+                         fixed-mode label for a fixed one - rendered by
+                         renderWorkspaceThemeModeRow() in chat.js, not static
+                         markup, since its content depends on which family is
+                         selected. -->
+                    <div class="workspace-theme-mode-row" id="workspaceThemeModeRow"></div>
                 </div>
 
                 <div class="workspace-menu-section">
@@ -2207,7 +2218,7 @@
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/chart.umd.min.js"></script>
-<script src="/static/i18n.js?v=20260806-6"></script>
+<script src="/static/i18n.js?v=20260903-theme-stage3-2"></script>
 <script>
     // Server already resolved "auto" (stored ui.language, or an
     // Accept-Language guess) to a concrete locale for <html lang> above —
@@ -2223,7 +2234,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260901-identity-hint-btn-system"></script>
+<script src="/static/chat.js?v=20260903-theme-stage3-2"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary
Introduces the two-level Appearance model (family -> mode) that Stages 4-8 (Sharp/Gunmetal/Alpine/Teal) will plug into. Only "MeshCenter Original" exists as a family today and stays the only real option after this PR - no new family CSS/tokens shipped here, per scope.

## State model rename
`static/chat.js`'s `Workspace.state.theme` (`'system'|'light'|'dark'`) becomes two fields:
- `themeFamily`: `'original'` only for now, validated against `WORKSPACE_THEME_FAMILY_IDS` (derived from a small metadata array, `WORKSPACE_THEME_FAMILIES`) so adding Sharp/Gunmetal/etc. later is a one-line addition to that array.
- `themeMode`: `'auto'|'light'|'dark'` (renamed from `'system'`, per the already-approved plan doc).

`WORKSPACE_THEME_FAMILIES` shape: `{ id, kind: 'paired'|'fixed', mode? }`. `resolveTheme()` branches on `kind`: `'fixed'` always resolves to `family.mode` regardless of `themeMode`; `'paired'` behaves exactly like the old system/light/dark logic. `'original'` is `'paired'`, so today's resolved-theme behavior is byte-for-byte unchanged - the `'fixed'` branch exists in the code path and is styled in CSS, but is genuinely unreachable until a fixed family exists.

`data-theme` is untouched (still 2-valued, every existing `[data-theme="dark"]` CSS consumer keeps working with zero changes). Added `data-theme-family` (new attribute, not consumed by any CSS yet - wiring for future family-scoped rules, per the critical-review doc's compatibility approach). `data-theme-preference` now tracks `themeMode` instead of the old 3-valued `theme`.

## Migration (concrete before/after)
`Workspace.load()` now also calls `migrateLegacyThemeField(stored)`, same non-destructive pattern as `migrateLegacyPanelSettings()` right above it (only touches storage when the old shape is present and the new one isn't - runs once per browser, never re-applies).

**Verified live on dev**: seeded `localStorage['meshcenter.workspace'] = '{"leftPanel":true,"rightPanel":false,"theme":"dark","compactMode":false}'`, reloaded. Result:
```
localStorage: {"leftPanel":true,"rightPanel":false,"themeFamily":"original","themeMode":"dark","compactMode":false}
data-theme: "dark"          (resolved correctly, no flash of wrong theme)
data-theme-family: "original"
data-theme-preference: "dark"
```
Old `'system'` maps to `themeMode: 'auto'` (still follows the OS); old `'light'`/`'dark'` map to the same `themeMode` (still pinned) - a user's existing choice survives exactly, as required.

## Family-metadata shape
```js
const WORKSPACE_THEME_FAMILIES = Object.freeze([
    Object.freeze({ id: 'original', kind: 'paired' })
    // A future fixed family: { id: 'sharp-dark', kind: 'fixed', mode: 'dark' }
]);
```
`getWorkspaceThemeFamily(id)` looks it up (falls back to the first entry). Nothing here names `'original'` specifically in any if/else - the paired/fixed branch in both `resolveTheme()` and `renderWorkspaceThemeModeRow()` (the new function that renders level 2) reads `family.kind`.

## Appearance UI rework
- **Level 1** (`templates/index.html`): a family list (`#workspaceThemeFamilies`), one `<label>` per family - just "MeshCenter Original" today, styled as a card (`static/ui-kit.css`) with a 4-swatch mini-preview referencing `var(--mc-bg-app)`/`var(--mc-bg-panel)`/`var(--mc-primary)`/`var(--mc-warning)` directly - **no hardcoded hex in any of the new CSS**. Adding family #2 later: one more metadata entry + one more `<label>` block, no JS rewrite.
- **Preview mode shown**: the family's **currently resolved** mode (light or dark), not both side by side - explicit choice, documented in the CSS comment. Since the swatches are live custom properties, switching Auto/Light/Dark updates them automatically with zero JS-computed color.
- **Level 2**: rendered by `renderWorkspaceThemeModeRow()` (JS, not static markup - its content depends on the selected family's `kind`). For `'paired'`, an Auto/Light/Dark radiogroup reusing the *existing* `.workspace-theme-options`/`.workspace-theme-option` CSS unchanged (just relabeled). For `'fixed'`, a single `.workspace-theme-fixed-label` (styled now, unreachable today).
- Event wiring: level-1 family radios get direct listeners (static, never rebuilt). Level-2 mode radios are rebuilt on every render, so they're wired via delegation on `#workspaceThemeModeRow` instead.

## i18n
New `workspace.*` namespace (7 keys: family group label, family name, Auto/Light/Dark, the two unreachable Fixed labels) added to all four catalogs in this commit. `check-i18n.py` passes. The pre-existing Panels/Display/Application-nav strings in this same popover are untouched - already done in Stage 1.8, still hardcoded English as before, not this PR's scope to retrofit.

## Bonus fix
Found and fixed a latent encoding bug in `check_new_hex.py --diff` while verifying this PR: `subprocess.run()` didn't force UTF-8 on Windows, so a diff containing non-ASCII bytes (this PR's new `ru.json`/`uk.json` Cyrillic content - the first time in this effort a diff has included any) crashed with `UnicodeDecodeError` instead of running the check. One-line fix (`encoding="utf-8", errors="replace"`), included in this PR since it directly blocked verifying this PR and will block any future stage touching non-English content.

## Cache-busting
`ui-kit.css`, `chat.js`, and `i18n.js` bumped (all three changed real behavior) - plus `i18n.js`'s own internal `CATALOG_VERSION` constant, which versions the `/static/i18n/<locale>.json` fetch independently of the `<script>` tag's own `?v=`.

## Verification
- `check_new_hex.py --diff origin/main HEAD`: clean (after the encoding fix above).
- `tinycss2` parse: `ui-kit.css` 499 rules, 0 errors.
- `node --check` on `chat.js` and `i18n.js`: clean.
- `python -m compileall`: clean.
- `check-i18n.py`: all four catalogs in sync.
- **Live check on dev** (real hardware): branch checked out, service restarted.
  - Fresh install (no `localStorage` key at all): defaults to `themeFamily: 'original', themeMode: 'auto'`, resolves correctly, both radiogroups show the right defaults on load with no user interaction needed.
  - Old-shape migration (documented above): confirmed exact.
  - Opened the real Workspace popover: family card renders with visible swatch preview, Auto/Light/Dark row renders under it with the correct option pre-checked.
  - Clicked "Light" via a real UI click: whole app switched to light theme immediately, family swatch preview updated to light colors, `data-theme`/`data-theme-preference`/`localStorage` all updated correctly.
  - Toggled "Auto" programmatically (via the real delegated change listener, not a shortcut): `data-theme-preference` updated to `auto`, `data-theme` resolved correctly.
  - No new console errors introduced (confirmed the correct new `chat.js?v=20260903-theme-stage3-2` was actually being served, 200 OK).
  - Dev restored to `main` afterward.

## Test plan
- [x] `check_new_hex.py --diff origin/main HEAD` clean
- [x] `tinycss2` / `node --check` / `compileall` / `check-i18n.py` all clean
- [x] Migration verified with a concrete before/after localStorage example
- [x] Live dev check: fresh install, migration, popover UI, live Auto/Light/Dark switching, swatch preview
- [x] Confirmed `data-theme` still 2-valued and unchanged for existing CSS consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
