### PR TITLE
🛡️ Sentinel: Add HTTP security headers

### DIFF
--- a/server.py
+++ b/server.py
@@ -442,6 +442,15 @@ if not os.path.exists(SCREENSHOTS_DIR):
     os.makedirs(SCREENSHOTS_DIR, exist_ok=True)
 
 app = Flask(__name__)
+
+@app.after_request
+def add_security_headers(response):
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
+
 waypoint_store = WaypointStore(WAYPOINTS_DB_FILE)
 
 # Flask session cookies (used by the optional password protection below)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,16 @@
+"""Tests for HTTP security headers added via @app.after_request in server.py."""
+
+
+def test_security_headers_present_on_all_responses(server_module):
+    app = server_module.app
+    client = app.test_client()
+
+    routes = ["/", "/api/sensors", "/api/base_status"]
+    for route in routes:
+        response = client.get(route)
+        headers = response.headers
+
+        assert headers.get("X-Content-Type-Options") == "nosniff"
+        assert headers.get("X-Frame-Options") == "SAMEORIGIN"
+        assert headers.get("X-XSS-Protection") == "1; mode=block"
+        assert headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: Missing HTTP security headers on application responses.
🎯 Impact: Without explicit security headers, browsers may perform MIME-type sniffing, allow framing (clickjacking), or leak Referrer headers off-origin.
🔧 Fix: Added an `@app.after_request` handler in `server.py` to set `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy` on every HTTP response.
✅ Verification: Added unit tests in `tests/test_security_headers.py` and ran full pytest suite (535 passed).

---
*PR created automatically by Jules for task [17411547580471465971](https://jules.google.com/task/17411547580471465971) started by @FlintUA*