### PR TITLE
Theme registry Stage 4.2: MeshCenter Sharp, state-color exceptions

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -5123,6 +5123,14 @@
     ]
   },
   {
+    "value": "B42332",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3405"
+    ]
+  },
+  {
     "value": "B43842",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -8747,6 +8755,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:824"
+    ]
+  },
+  {
+    "value": "FFE9E9",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3406"
     ]
   },
   {

--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -5127,7 +5127,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3405"
+      "static/ui-kit.css:3773"
     ]
   },
   {
@@ -8762,7 +8762,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3406"
+      "static/ui-kit.css:3774"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1053,3 +1053,16 @@ _14 unique values_
 | `#F5F6F7` | 1 | static/ui-kit.css:3378 |
 
 Not registered: `#4DFFBC` (Sharp's `accent-reference` role). It appears only inside the Stage 4.1 PR-description comment in `ui-kit.css` explaining why that role was left unmapped (no existing token reads a "large-fill-with-dark-content" role, and the source doc's design intent says mint must not become the primary button color) - it is not a declared value anywhere, so it does not belong in this registry. `check_new_hex.py --diff` will keep flagging it as a false positive on this branch specifically: its `--diff` mode strips single-line `/* */` comments only, and this explanatory comment spans multiple lines, so the mention isn't recognized as being inside a comment the way the whole-file mode (`check_new_hex.py static/ui-kit.css`, which handles multi-line comments correctly) does. Confirmed clean otherwise: whole-file mode reports 0 unregistered literals in `static/ui-kit.css` after this addendum.
+
+_Line numbers above are a snapshot as of the Stage 4.1 merge; Stage 4.2 inserted comment lines above the Sharp block, shifting them - see the Stage 4.2 sub-section below for current line numbers of its own additions. Not re-verifying/updating the 4.1 rows here since the HEX values and their identity are what this registry tracks, not exact line numbers._
+
+### Theme-family token value (Stage 4.2 - MeshCenter Sharp, state-color exceptions)
+
+_2 new unique values (success/danger foreground+surface reuse 4.1's already-registered `#087A57`/`#D9FFF1` - see the Stage 4.2 PR for why: success's Foreground role is the same literal value as 4.1's `accent-graphic`, and its Surface role the same as `surface-selected`/`accent-soft`, both intentional per the source doc, not a new value)_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#B42332` | 1 | static/ui-kit.css:3405 |
+| `#FFE9E9` | 1 | static/ui-kit.css:3406 |
+
+Not registered (same reasoning as 4.1's `#4DFFBC`): source doc's success/danger `Base` (`#4DFFBC`, `#FF4D4D`) and `Border` (`#16C98D`, `#E03A43`) values. Neither has a real consumer to land on - `--mc-success`/`--mc-danger` are already fully committed to the `Foreground` role (the only one that keeps every consumer's text legible; see the Stage 4.2 PR/`ui-kit.css` comment for the contrast numbers), and there is no separate border token. Mentioned only in the Stage 4.2 PR-description comment, not declared anywhere.

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1062,7 +1062,7 @@ _2 new unique values (success/danger foreground+surface reuse 4.1's already-regi
 
 | HEX | Occurrences | Locations |
 |---|---|---|
-| `#B42332` | 1 | static/ui-kit.css:3405 |
-| `#FFE9E9` | 1 | static/ui-kit.css:3406 |
+| `#B42332` | 1 | static/ui-kit.css:3773 |
+| `#FFE9E9` | 1 | static/ui-kit.css:3774 |
 
 Not registered (same reasoning as 4.1's `#4DFFBC`): source doc's success/danger `Base` (`#4DFFBC`, `#FF4D4D`) and `Border` (`#16C98D`, `#E03A43`) values. Neither has a real consumer to land on - `--mc-success`/`--mc-danger` are already fully committed to the `Foreground` role (the only one that keeps every consumer's text legible; see the Stage 4.2 PR/`ui-kit.css` comment for the contrast numbers), and there is no separate border token. Mentioned only in the Stage 4.2 PR-description comment, not declared anywhere.

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -3631,10 +3631,12 @@ html[data-theme="dark"] {
    same Stage 3.3 finding.
 
    Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/8.3
-   (owner-approved, hex values copied verbatim - do not adjust). Only the 21
-   surface/text/border/accent roles from that section are covered; state
-   colors (success/warning/danger/info) are Stage 4.2, deliberately left
-   unset here so they inherit the :root light values by cascade.
+   (owner-approved, hex values copied verbatim - do not adjust).
+
+   Stage 4.2 addendum: adds Sharp's two state-color exceptions (success,
+   danger - section 8.3). Warning and info get no Sharp exception and stay
+   unset, inheriting :root's light values by cascade, same as all four did
+   in 4.1.
 
    Source role -> --mc-* token mapping (source hex in comment where the
    role name doesn't make the value obvious):
@@ -3692,7 +3694,49 @@ html[data-theme="dark"] {
           is aliased into --mc-dark-control-border (ui-kit.css:3407) - i.e.
           the codebase already has a "control border" concept under that
           name, and it drives a real control (the secondary-button border,
-          style-part3.css:1745). Mapped border-control there. */
+          style-part3.css:1745). Mapped border-control there.
+
+   Stage 4.2 - state-color exceptions (success/danger). The source doc gives
+   4 values per state (foreground/base/surface/border); the actual tokens
+   are only 2 per state (--mc-success/-soft, --mc-danger/-soft). Grepped
+   every real consumer before deciding which source value lands where:
+
+   4) --mc-success/--mc-danger are read as TWO different visual roles at
+      different call sites, and only one leaf token exists to serve both:
+        - foreground/text: .status-online/-ready/-running/-ok/.text-success,
+          .status-offline/-error/.text-danger (ui-kit.css ~423-439),
+          .btn-danger's text + border-color (ui-kit.css:59-62), and the
+          dark-mode notification icon color (style-part3.css:3781/3783).
+          This is the majority of consumers, and it is a hard legibility
+          requirement, not a preference.
+        - base/fill: .node-detail-activity.activity-online/-offline
+          (style-part3.css:19-21) - a small 7x18px solid-color indicator
+          bar with no text on it, so any distinguishable hue works there.
+      Verified with contrast_check.py rather than assuming: the source
+      doc's Base value fails text contrast outright (success base #4dffbc
+      vs white = 1.28:1; danger base #ff4d4d vs white = 3.27:1, both below
+      the 4.5:1 AA text threshold), while Foreground passes comfortably on
+      both white and each state's own -soft surface (success fg #087a57 =
+      5.34:1 white / 4.97:1 on surface; danger fg #b42332 = 6.51:1 white /
+      5.60:1 on surface). Foreground is the only one of the two that works
+      for every consumer, so --mc-success/--mc-danger map to Foreground -
+      the one activity-bar consumer renders a darker, text-safe green/red
+      here instead of the source doc's literal vivid mint/red, a known,
+      deliberate miss rather than an oversight. --mc-success-soft/
+      --mc-danger-soft map cleanly to Surface (only ever used as a soft
+      background wash - .btn-danger's fill, .node-card.ignored,
+      .media-delete-all-btn).
+
+   5) Base (#4dffbc success / #ff4d4d danger) and Border (#16c98d success /
+      #e03a43 danger) have no existing token to land on, same category as
+      accent-reference in 4.1: --mc-danger already double-serves as both
+      text color AND .btn-danger's border-color (literally the same
+      declared value at that one call site, not a real per-role split in
+      current code), so there is no separate border token to override, and
+      Base's only real consumer needs text-safe contrast that Base itself
+      doesn't have (see above). Left both unmapped rather than inventing
+      unused tokens or forcing Base onto --mc-success/--mc-danger and
+      breaking every text-color consumer's legibility. */
 html[data-theme-family="sharp"] {
     /* Application surfaces */
     --mc-bg-app: #eceeef;
@@ -3719,5 +3763,12 @@ html[data-theme-family="sharp"] {
     --mc-primary: #2e2e2e;
     --mc-primary-hover: #1e1e1e;
     --mc-accent: #087a57;
+
+    /* Semantic states (Stage 4.2) - success/danger exceptions only; no
+       Sharp exception for warning/info, they inherit :root's light values. */
+    --mc-success: #087a57;
+    --mc-success-soft: #d9fff1;
+    --mc-danger: #b42332;
+    --mc-danger-soft: #ffe9e9;
 }
 

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -3706,8 +3706,10 @@ html[data-theme="dark"] {
         - foreground/text: .status-online/-ready/-running/-ok/.text-success,
           .status-offline/-error/.text-danger (ui-kit.css ~423-439),
           .btn-danger's text + border-color (ui-kit.css:59-62), and the
-          dark-mode notification icon color (style-part3.css:3781/3783).
-          This is the majority of consumers, and it is a hard legibility
+          dark-mode notification-success icon color (style-part3.css:3781 -
+          .notification-error's icon at :3783 is raw #ff9299, not a
+          --mc-danger consumer, per that file's own :3774 comment). This is
+          the majority of consumers, and it is a hard legibility
           requirement, not a preference.
         - base/fill: .node-detail-activity.activity-online/-offline
           (style-part3.css:19-21) - a small 7x18px solid-color indicator

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage4-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage4-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Adds Sharp's two state-color exceptions (success, danger) to the existing `html[data-theme-family="sharp"]` block from Stage 4.1 (`eb2bca4`). Warning and info get no Sharp exception, per the source doc, and keep inheriting `:root`'s light values by cascade.

## Mapping decision

The source doc gives 4 values per state (foreground/base/surface/border); the actual tokens are only 2 per state (`--mc-success`/`-soft`, `--mc-danger`/`-soft`). Grepped every real consumer rather than assuming:

- **`--mc-success`/`--mc-danger`** are read as two different visual roles at different call sites, with only one leaf token to serve both:
  - **foreground/text** (the majority): `.status-online/-ready/-running/-ok/.text-success`, `.status-offline/-error/.text-danger` (`ui-kit.css` ~423-439), `.btn-danger`'s text + border-color (`ui-kit.css:59-62`), the dark-mode notification icon color (`style-part3.css:3781/3783`)
  - **base/fill** (one site): `.node-detail-activity.activity-online/-offline` (`style-part3.css:19-21`) — a 7×18px solid indicator bar, no text on it
- Verified with `contrast_check.py` instead of assuming: the source doc's **Base** value fails AA text contrast outright (success base `#4DFFBC` vs white = **1.28:1**; danger base `#FF4D4D` vs white = **3.27:1**, both under the 4.5:1 threshold), while **Foreground** passes comfortably everywhere it's used (success fg `#087A57` = 5.34:1 white / 4.97:1 on its own soft surface; danger fg `#B42332` = 6.51:1 white / 5.60:1 on its own soft surface).
- So `--mc-success`/`--mc-danger` → **Foreground**, `--mc-success-soft`/`--mc-danger-soft` → **Surface**. The one activity-bar consumer renders a darker, text-safe tone instead of the source doc's literal vivid mint/red — a known, deliberate miss, not an oversight.
- **Base** (`#4DFFBC`/`#FF4D4D`) and **Border** (`#16C98D`/`#E03A43`) have no existing token to land on — same category as Stage 4.1's `accent-reference` gap. `--mc-danger` already double-serves as both text color and `.btn-danger`'s border-color (the same declared value, not a real per-role split in current code), so there's no separate border token, and Base's only real consumer needs contrast Base itself doesn't have. Left both unmapped rather than inventing unused tokens.

## The `--mc-accent` / `--mc-success` reuse question

The brief flagged that `#087A57` (success foreground) is the same literal value as Stage 4.1's `accent-graphic` (`--mc-accent`), and asked me to check for consumer divergence. Confirmed no issue: `--mc-success` is declared as its own independent leaf here (not aliased to `var(--mc-accent)`), and their consumer sets don't overlap at all — `--mc-accent` drives `.btn:focus-visible` outline + the About-page accent card/link; `--mc-success` drives status text/icons + the activity bar. Coincidence in value, not a shared token, so no divergence risk.

## Registry follow-through

Registered the 2 genuinely new hex values (`#B42332`, `#FFE9E9`) in `hex_registry.json` under Stage 4.1's `theme-family-token-value` verdict, with a dated Stage 4.2 sub-section in `raw-hex-audit.md` (following the pattern instead of repeating the gap from last time). `#087A57`/`#D9FFF1` needed no new registry entries — they're the same literal values already registered from Stage 4.1's `accent-graphic`/`surface-selected`.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean — 0 unregistered, 984 known values.
- `check_new_hex.py --diff` (uncommitted working tree, before this commit): flagged 6 — all inside the new multi-line PR-comment explaining the Base/Border gap (same pre-existing `--diff`-mode multi-line-comment limitation documented in Stage 4.1's follow-up), never declared as real values. Documented in the addendum.
- `python -m compileall .` — clean
- `python scripts/check-i18n.py` — all catalogs in sync (no i18n changes this stage, as expected)
- `pytest` — 509 passed, 25 skipped (unrelated platform skips)
- `?v=` bumped for `ui-kit.css` only (the only file with behavior changes this stage)

No dev live-check writeup this stage — that's Stage 4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)