### PR TITLE
Theme registry Stage 5.1: MeshCenter Gunmetal, base tokens (dark, fixed)

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -37,7 +37,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3421"
+      "static/ui-kit.css:3858"
     ]
   },
   {
@@ -79,8 +79,8 @@
     "verdict": "theme-family-token-value",
     "count": 2,
     "locations": [
-      "static/ui-kit.css:996",
-      "static/ui-kit.css:3418"
+      "static/ui-kit.css:1066",
+      "static/ui-kit.css:3855"
     ]
   },
   {
@@ -157,7 +157,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3430"
+      "static/ui-kit.css:3867"
     ]
   },
   {
@@ -271,7 +271,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3419"
+      "static/ui-kit.css:3856"
     ]
   },
   {
@@ -725,8 +725,8 @@
     "verdict": "theme-family-token-value",
     "count": 2,
     "locations": [
-      "static/ui-kit.css:997",
-      "static/ui-kit.css:3420"
+      "static/ui-kit.css:1067",
+      "static/ui-kit.css:3857"
     ]
   },
   {
@@ -964,7 +964,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3422"
+      "static/ui-kit.css:3859"
     ]
   },
   {
@@ -1464,7 +1464,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3423"
+      "static/ui-kit.css:3860"
     ]
   },
   {
@@ -2094,7 +2094,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3433"
+      "static/ui-kit.css:3870"
     ]
   },
   {
@@ -2407,7 +2407,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3424"
+      "static/ui-kit.css:3861"
     ]
   },
   {
@@ -2836,7 +2836,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3434"
+      "static/ui-kit.css:3871"
     ]
   },
   {
@@ -3244,7 +3244,7 @@
     "verdict": "ui-normalization-candidate",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:998"
+      "static/ui-kit.css:1068"
     ]
   },
   {
@@ -3333,9 +3333,9 @@
     "verdict": "theme-family-token-value",
     "count": 3,
     "locations": [
-      "static/ui-kit.css:998",
-      "static/ui-kit.css:3439",
-      "static/ui-kit.css:3441"
+      "static/ui-kit.css:1068",
+      "static/ui-kit.css:3876",
+      "static/ui-kit.css:3878"
     ]
   },
   {
@@ -3510,7 +3510,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3435"
+      "static/ui-kit.css:3872"
     ]
   },
   {
@@ -4072,7 +4072,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3440"
+      "static/ui-kit.css:3877"
     ]
   },
   {
@@ -4686,7 +4686,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3429"
+      "static/ui-kit.css:3866"
     ]
   },
   {
@@ -4848,7 +4848,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3436"
+      "static/ui-kit.css:3873"
     ]
   },
   {
@@ -5553,7 +5553,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3428"
+      "static/ui-kit.css:3865"
     ]
   },
   {
@@ -8124,7 +8124,7 @@
     "verdict": "theme-family-token-value",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:3427"
+      "static/ui-kit.css:3864"
     ]
   },
   {
@@ -8646,7 +8646,7 @@
     "verdict": "ui-normalization-candidate",
     "count": 1,
     "locations": [
-      "static/ui-kit.css:997"
+      "static/ui-kit.css:1067"
     ]
   },
   {

--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -33,6 +33,14 @@
     ]
   },
   {
+    "value": "090B0C",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3421"
+    ]
+  },
+  {
     "value": "09111A",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -64,6 +72,15 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:3219"
+    ]
+  },
+  {
+    "value": "0C0E0F",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:996",
+      "static/ui-kit.css:3418"
     ]
   },
   {
@@ -133,6 +150,14 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:2932"
+    ]
+  },
+  {
+    "value": "101417",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3430"
     ]
   },
   {
@@ -239,6 +264,14 @@
     "count": 1,
     "locations": [
       "static/style-part3.css:2982"
+    ]
+  },
+  {
+    "value": "121516",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3419"
     ]
   },
   {
@@ -688,6 +721,15 @@
     ]
   },
   {
+    "value": "181C1E",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:997",
+      "static/ui-kit.css:3420"
+    ]
+  },
+  {
     "value": "18212C",
     "verdict": "ui-normalization-candidate",
     "count": 8,
@@ -915,6 +957,14 @@
     "locations": [
       "static/style-part3.css:2533",
       "static/style-part3.css:2771"
+    ]
+  },
+  {
+    "value": "1D2225",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3422"
     ]
   },
   {
@@ -1407,6 +1457,14 @@
       "static/style-part1.css:3459",
       "static/style-part2.css:1507",
       "static/style-part4.css:3038"
+    ]
+  },
+  {
+    "value": "23292D",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3423"
     ]
   },
   {
@@ -2032,6 +2090,14 @@
     ]
   },
   {
+    "value": "2F373C",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3433"
+    ]
+  },
+  {
     "value": "2F3B4D",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -2334,6 +2400,14 @@
       "static/style-part4.css:3373",
       "static/style-part4.css:3429",
       "static/style-part4.css:4019"
+    ]
+  },
+  {
+    "value": "353E43",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3424"
     ]
   },
   {
@@ -2755,6 +2829,14 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:1705"
+    ]
+  },
+  {
+    "value": "47535A",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3434"
     ]
   },
   {
@@ -3247,6 +3329,16 @@
     ]
   },
   {
+    "value": "63A1C2",
+    "verdict": "theme-family-token-value",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:998",
+      "static/ui-kit.css:3439",
+      "static/ui-kit.css:3441"
+    ]
+  },
+  {
     "value": "64748B",
     "verdict": "ui-normalization-candidate",
     "count": 26,
@@ -3411,6 +3503,14 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:1212"
+    ]
+  },
+  {
+    "value": "687780",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3435"
     ]
   },
   {
@@ -3965,6 +4065,14 @@
     "count": 1,
     "locations": [
       "static/style-part3.css:1209"
+    ]
+  },
+  {
+    "value": "7CB4D0",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3440"
     ]
   },
   {
@@ -4574,6 +4682,14 @@
     ]
   },
   {
+    "value": "96A4AC",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3429"
+    ]
+  },
+  {
     "value": "96A6B8",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -4725,6 +4841,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:3128"
+    ]
+  },
+  {
+    "value": "9CCDE5",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3436"
     ]
   },
   {
@@ -5422,6 +5546,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:2069"
+    ]
+  },
+  {
+    "value": "C4CCD0",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3428"
     ]
   },
   {
@@ -7985,6 +8117,14 @@
     "locations": [
       "static/style-part2.css:1910",
       "static/style-part2.css:2321"
+    ]
+  },
+  {
+    "value": "F2F5F6",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3427"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1073,22 +1073,22 @@ _17 new unique values (registered in the same commit as the CSS change this time
 
 | HEX | Occurrences | Locations |
 |---|---|---|
-| `#0C0E0F` | 2 | static/ui-kit.css:996, static/ui-kit.css:3418 |
-| `#090B0C` | 1 | static/ui-kit.css:3421 |
-| `#101417` | 1 | static/ui-kit.css:3430 |
-| `#121516` | 1 | static/ui-kit.css:3419 |
-| `#181C1E` | 2 | static/ui-kit.css:997, static/ui-kit.css:3420 |
-| `#1D2225` | 1 | static/ui-kit.css:3422 |
-| `#23292D` | 1 | static/ui-kit.css:3423 |
-| `#2F373C` | 1 | static/ui-kit.css:3433 |
-| `#353E43` | 1 | static/ui-kit.css:3424 |
-| `#47535A` | 1 | static/ui-kit.css:3434 |
-| `#63A1C2` | 3 | static/ui-kit.css:998, static/ui-kit.css:3439, static/ui-kit.css:3441 |
-| `#687780` | 1 | static/ui-kit.css:3435 |
-| `#7CB4D0` | 1 | static/ui-kit.css:3440 |
-| `#96A4AC` | 1 | static/ui-kit.css:3429 |
-| `#9CCDE5` | 1 | static/ui-kit.css:3436 |
-| `#C4CCD0` | 1 | static/ui-kit.css:3428 |
-| `#F2F5F6` | 1 | static/ui-kit.css:3427 |
+| `#0C0E0F` | 2 | static/ui-kit.css:1066, static/ui-kit.css:3855 |
+| `#090B0C` | 1 | static/ui-kit.css:3858 |
+| `#101417` | 1 | static/ui-kit.css:3867 |
+| `#121516` | 1 | static/ui-kit.css:3856 |
+| `#181C1E` | 2 | static/ui-kit.css:1067, static/ui-kit.css:3857 |
+| `#1D2225` | 1 | static/ui-kit.css:3859 |
+| `#23292D` | 1 | static/ui-kit.css:3860 |
+| `#2F373C` | 1 | static/ui-kit.css:3870 |
+| `#353E43` | 1 | static/ui-kit.css:3861 |
+| `#47535A` | 1 | static/ui-kit.css:3871 |
+| `#63A1C2` | 3 | static/ui-kit.css:1068, static/ui-kit.css:3876, static/ui-kit.css:3878 |
+| `#687780` | 1 | static/ui-kit.css:3872 |
+| `#7CB4D0` | 1 | static/ui-kit.css:3877 |
+| `#96A4AC` | 1 | static/ui-kit.css:3866 |
+| `#9CCDE5` | 1 | static/ui-kit.css:3873 |
+| `#C4CCD0` | 1 | static/ui-kit.css:3865 |
+| `#F2F5F6` | 1 | static/ui-kit.css:3864 |
 
 Not registered: none new this time - unlike Sharp, all three of Gunmetal's accent roles (`accent-reference`/`action-fill`/`accent-graphic`) share one value (`#63A1C2`), so there was no unmapped role to document as a gap. The swatch preview's warning slot reuses `#F0C86A` (dark's current `--mc-warning`, already registered from the Stage 0 baseline) - not a new value, since Gunmetal has no warning override yet (that's Stage 5.2).

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1066,3 +1066,29 @@ _2 new unique values (success/danger foreground+surface reuse 4.1's already-regi
 | `#FFE9E9` | 1 | static/ui-kit.css:3774 |
 
 Not registered (same reasoning as 4.1's `#4DFFBC`): source doc's success/danger `Base` (`#4DFFBC`, `#FF4D4D`) and `Border` (`#16C98D`, `#E03A43`) values. Neither has a real consumer to land on - `--mc-success`/`--mc-danger` are already fully committed to the `Foreground` role (the only one that keeps every consumer's text legible; see the Stage 4.2 PR/`ui-kit.css` comment for the contrast numbers), and there is no separate border token. Mentioned only in the Stage 4.2 PR-description comment, not declared anywhere.
+
+### Theme-family token value (Stage 5.1 - MeshCenter Gunmetal, base tokens)
+
+_17 new unique values (registered in the same commit as the CSS change this time, not a follow-up - see Stage 4.1's own follow-up PR for why that matters)_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#0C0E0F` | 2 | static/ui-kit.css:996, static/ui-kit.css:3418 |
+| `#090B0C` | 1 | static/ui-kit.css:3421 |
+| `#101417` | 1 | static/ui-kit.css:3430 |
+| `#121516` | 1 | static/ui-kit.css:3419 |
+| `#181C1E` | 2 | static/ui-kit.css:997, static/ui-kit.css:3420 |
+| `#1D2225` | 1 | static/ui-kit.css:3422 |
+| `#23292D` | 1 | static/ui-kit.css:3423 |
+| `#2F373C` | 1 | static/ui-kit.css:3433 |
+| `#353E43` | 1 | static/ui-kit.css:3424 |
+| `#47535A` | 1 | static/ui-kit.css:3434 |
+| `#63A1C2` | 3 | static/ui-kit.css:998, static/ui-kit.css:3439, static/ui-kit.css:3441 |
+| `#687780` | 1 | static/ui-kit.css:3435 |
+| `#7CB4D0` | 1 | static/ui-kit.css:3440 |
+| `#96A4AC` | 1 | static/ui-kit.css:3429 |
+| `#9CCDE5` | 1 | static/ui-kit.css:3436 |
+| `#C4CCD0` | 1 | static/ui-kit.css:3428 |
+| `#F2F5F6` | 1 | static/ui-kit.css:3427 |
+
+Not registered: none new this time - unlike Sharp, all three of Gunmetal's accent roles (`accent-reference`/`action-fill`/`accent-graphic`) share one value (`#63A1C2`), so there was no unmapped role to document as a gap. The swatch preview's warning slot reuses `#F0C86A` (dark's current `--mc-warning`, already registered from the Stage 0 baseline) - not a new value, since Gunmetal has no warning override yet (that's Stage 5.2).

--- a/static/chat.js
+++ b/static/chat.js
@@ -8019,7 +8019,10 @@ const WORKSPACE_THEME_FAMILIES = Object.freeze([
     Object.freeze({ id: 'original', kind: 'paired' }),
     // theme-registry Stage 4.1: Sharp is a 'fixed', light-only family - its
     // token overrides live in ui-kit.css under html[data-theme-family="sharp"].
-    Object.freeze({ id: 'sharp', kind: 'fixed', mode: 'light' })
+    Object.freeze({ id: 'sharp', kind: 'fixed', mode: 'light' }),
+    // theme-registry Stage 5.1: Gunmetal is a 'fixed', dark-only family - its
+    // token overrides live in ui-kit.css under html[data-theme-family="gunmetal"].
+    Object.freeze({ id: 'gunmetal', kind: 'fixed', mode: 'dark' })
 ]);
 const WORKSPACE_THEME_FAMILY_IDS = WORKSPACE_THEME_FAMILIES.map(family => family.id);
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -19,7 +19,7 @@
     var FALLBACK_LOCALE = 'en';
     // Bumped manually alongside catalog content changes, same convention as
     // the ?v= query strings on <script>/<link> tags in index.html.
-    var CATALOG_VERSION = '20260904-theme-stage4-1';
+    var CATALOG_VERSION = '20260904-theme-stage5-1';
 
     var catalogs = {};      // locale -> flattened {dottedKey: value}
     var loadPromises = {};  // locale -> in-flight/completed fetch promise

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1150,6 +1150,7 @@
     "theme_family_group_label": "Themenfamilie",
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
+    "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Hell",
     "theme_mode_dark": "Dunkel",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1150,6 +1150,7 @@
     "theme_family_group_label": "Theme family",
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
+    "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Light",
     "theme_mode_dark": "Dark",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -1150,6 +1150,7 @@
     "theme_family_group_label": "Семейство тем",
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
+    "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Светлая",
     "theme_mode_dark": "Тёмная",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -1150,6 +1150,7 @@
     "theme_family_group_label": "Сімейство тем",
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
+    "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Світла",
     "theme_mode_dark": "Темна",

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1056,6 +1056,18 @@ a:focus-visible,
 .workspace-theme-family-option[data-family="sharp"] .workspace-theme-swatch--primary { background: #2e2e2e; }
 .workspace-theme-family-option[data-family="sharp"] .workspace-theme-swatch--warning { background: #e6ad22; }
 
+/* theme-registry Stage 5.1: same reasoning as Sharp's swatch override
+   above - Gunmetal's card needs its own literal-hex swatch since the
+   generic .workspace-theme-swatch--* rules track whatever family is
+   currently active, not each card's own family. Warning uses dark's
+   current inherited value (#f0c86a, html[data-theme="dark"]'s --mc-warning)
+   since Gunmetal has no warning override yet - that lands in Stage 5.2;
+   the swatch reflects what's actually rendered today, not a future value. */
+.workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--bg { background: #0c0e0f; }
+.workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--panel { background: #181c1e; }
+.workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--primary { background: #63a1c2; }
+.workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--warning { background: #f0c86a; }
+
 .workspace-theme-family-label {
     font-size: 12px;
     font-weight: 700;
@@ -3772,5 +3784,97 @@ html[data-theme-family="sharp"] {
     --mc-success-soft: #d9fff1;
     --mc-danger: #b42332;
     --mc-danger-soft: #ffe9e9;
+}
+
+/* theme-registry Stage 5.1: MeshCenter Gunmetal - a 'fixed', DARK-only
+   family (WORKSPACE_THEME_FAMILIES in chat.js: { id: 'gunmetal', kind:
+   'fixed', mode: 'dark' }). Same same-element cascade mechanism as Sharp
+   (Stage 4.1), just layered on the dark side: applyTheme() sets
+   data-theme="dark" (family.mode) AND data-theme-family="gunmetal"
+   together on <html>, so this block needs to win over BOTH :root's light
+   values and the canonical html[data-theme="dark"] block above (~line
+   3496) - it does, by source order (this block comes later) with equal
+   selector specificity to html[data-theme="dark"], the same rule Stage
+   3.3 verified for Sharp. Only LEAF tokens are redeclared; aliases
+   (--mc-surface, --mc-accent-soft, --mc-chat-bg, etc.) resolve through
+   whichever leaf they reference and don't need repeating - reconfirmed
+   here for the dark cascade specifically, not just assumed from Sharp's
+   light-side result.
+
+   Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
+   (owner-approved, hex values copied verbatim - do not adjust). Only the
+   21 surface/text/border/accent roles are covered; state colors (Gunmetal
+   has one exception, warning, section 8.3) are Stage 5.2 - left unset here
+   so they inherit html[data-theme="dark"]'s existing values by cascade.
+
+   Token mapping: identical role -> token assignments as Sharp (Stage 4.1's
+   big comment above, ~line 3600) - re-verified against dark-mode consumers
+   specifically, not just carried over blind:
+     surface-app/-workspace/-panel  -> --mc-bg-app/-workspace/-panel
+     surface-card                   -> --mc-card-bg (explicit override -
+                                        NOT "breaking an alias" here like
+                                        Sharp's light-side case: dark
+                                        already gives --mc-card-bg its own
+                                        literal, #162433, distinct from
+                                        --mc-bg-panel's #1b2837 - this is a
+                                        plain leaf override to Gunmetal's
+                                        own #1d2225, not an alias fix)
+     surface-control                -> --mc-button-secondary-bg
+     surface-media                  -> --mc-bg-media-stage
+     surface-selected               -> --mc-primary-soft (--mc-accent-soft
+                                        follows via the SAME alias
+                                        confirmed still present in the dark
+                                        block: --mc-accent-soft:
+                                        var(--mc-primary-soft))
+     text-primary/-secondary/-muted/-inverse -> the matching --mc-text-*
+     border-soft/-default           -> --mc-border-soft/--mc-border
+     border-control                 -> --mc-button-secondary-border
+                                        (same --mc-dark-control-border
+                                        alias reasoning as Sharp)
+     focus-ring                     -> --mc-border-focus
+     action-fill/-hover             -> --mc-primary/--mc-primary-hover
+     accent-graphic                 -> --mc-accent
+
+   Unlike Sharp, accent-reference/action-fill/accent-graphic are all the
+   SAME value here (#63a1c2) - no 3-way split judgment call needed; all
+   land on the one --mc-primary value action-fill already claims, and
+   --mc-accent gets the identical literal for accent-graphic's own
+   consumers (.btn:focus-visible outline, About-page accent). No unmapped
+   role this stage - Gunmetal's palette doesn't have a Sharp-style
+   accent-reference/mint situation.
+
+   surface-hover: re-checked against actual consumers for the dark cascade
+   specifically (not assumed from Sharp's light-side conclusion) - same
+   result: hover backgrounds are still per-component in the rules that
+   apply under dark (--mc-button-secondary-bg-hover, --mc-dark-control-bg-hover,
+   --mc-popover-item-hover, --mc-tab-bg-hover, all declared separately in
+   the dark block, ~line 3496+), no single shared token exists for either
+   cascade. Left unmapped, same as Sharp. */
+html[data-theme-family="gunmetal"] {
+    /* Application surfaces */
+    --mc-bg-app: #0c0e0f;
+    --mc-bg-workspace: #121516;
+    --mc-bg-panel: #181c1e;
+    --mc-bg-media-stage: #090b0c;
+    --mc-card-bg: #1d2225;
+    --mc-button-secondary-bg: #23292d;
+    --mc-primary-soft: #353e43;
+
+    /* Text */
+    --mc-text-primary: #f2f5f6;
+    --mc-text-secondary: #c4ccd0;
+    --mc-text-muted: #96a4ac;
+    --mc-text-inverse: #101417;
+
+    /* Borders */
+    --mc-border-soft: #2f373c;
+    --mc-border: #47535a;
+    --mc-button-secondary-border: #687780;
+    --mc-border-focus: #9ccde5;
+
+    /* Primary accent */
+    --mc-primary: #63a1c2;
+    --mc-primary-hover: #7cb4d0;
+    --mc-accent: #63a1c2;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage4-2">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage5-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
@@ -1947,6 +1947,18 @@
                                 <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_sharp">MeshCenter Sharp</span>
                             </span>
                         </label>
+                        <label class="workspace-theme-family-option" data-family="gunmetal">
+                            <input type="radio" name="workspaceThemeFamily" value="gunmetal">
+                            <span class="workspace-theme-family-card">
+                                <span class="workspace-theme-swatches" aria-hidden="true">
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--bg"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--panel"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--primary"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--warning"></span>
+                                </span>
+                                <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_gunmetal">MeshCenter Gunmetal</span>
+                            </span>
+                        </label>
                     </div>
                     <!-- Level 2: Auto/Light/Dark for a paired family, or a single
                          fixed-mode label for a fixed one - rendered by
@@ -2230,7 +2242,7 @@
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/chart.umd.min.js"></script>
-<script src="/static/i18n.js?v=20260904-theme-stage4-1"></script>
+<script src="/static/i18n.js?v=20260904-theme-stage5-1"></script>
 <script>
     // Server already resolved "auto" (stored ui.language, or an
     // Accept-Language guess) to a concrete locale for <html lang> above —
@@ -2246,7 +2258,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260904-theme-stage4-3"></script>
+<script src="/static/chat.js?v=20260904-theme-stage5-1"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary

Adds **MeshCenter Gunmetal** as a new theme family: `kind: 'fixed', mode: 'dark'` — the first *dark* fixed family, same three-stage shape as Sharp (4.1-4.3, merged). This stage covers only the 21 surface/text/border/accent roles; state colors are Stage 5.2.

- `static/ui-kit.css`: `html[data-theme-family="gunmetal"]` override block, placed after the canonical `html[data-theme="dark"]` block so it wins by source order at equal specificity (same mechanism Stage 3.3 verified for Sharp, just the dark side) + a Gunmetal-scoped swatch preview override.
- `static/chat.js`: `WORKSPACE_THEME_FAMILIES` gets a `gunmetal` entry.
- `templates/index.html`: new family `<label>` card.
- `static/i18n/{en,de,ru,uk}.json`: `workspace.theme_family_gunmetal` = "MeshCenter Gunmetal".
- `?v=` bumped for `ui-kit.css`, `chat.js`, `i18n.js`/`CATALOG_VERSION`.

## Token mapping

Reused Stage 4.1's role → token mapping rather than re-deriving it, but re-verified against the actual dark-mode consumers instead of assuming it carries over blind:

| Source role | Token | Note |
|---|---|---|
| surface-app/-workspace/-panel | `--mc-bg-app`/`-workspace`/`-panel` | direct |
| surface-card | `--mc-card-bg` | explicit override — **not** an alias-break like Sharp's case: dark already gives `--mc-card-bg` its own literal (`#162433`, distinct from `--mc-bg-panel`'s `#1b2837`), so this is a plain leaf override to Gunmetal's own `#1d2225`, not fixing a conflation |
| surface-control | `--mc-button-secondary-bg` | same reasoning as Sharp |
| surface-media | `--mc-bg-media-stage` | direct |
| surface-selected | `--mc-primary-soft` | `--mc-accent-soft` follows via the same alias, reconfirmed present in the dark block too |
| text-* | matching `--mc-text-*` | direct |
| border-soft/-default | `--mc-border-soft`/`--mc-border` | direct |
| border-control | `--mc-button-secondary-border` | same `--mc-dark-control-border` alias reasoning as Sharp |
| focus-ring | `--mc-border-focus` | direct |
| action-fill/-hover | `--mc-primary`/`--mc-primary-hover` | direct |
| accent-graphic | `--mc-accent` | direct |

**Unlike Sharp, no 3-way accent split needed**: `accent-reference`/`action-fill`/`accent-graphic` are all the same value (`#63A1C2`) in Gunmetal's palette, so there's no unmapped role this stage.

**surface-hover**: re-checked against the dark cascade's actual consumers specifically, not assumed from Sharp's light-side conclusion — same result, hover backgrounds are still per-component (`--mc-button-secondary-bg-hover`, `--mc-dark-control-bg-hover`, `--mc-popover-item-hover`, `--mc-tab-bg-hover`, all separately declared in the dark block). Left unmapped.

## Contrast self-check

All 5 targets from the source doc's section 9 (Gunmetal column) reproduce exactly against this mapping:

| Pair | Recomputed | Target |
|---|---|---:|
| text-muted vs surface-card | 6.27:1 | 6.27 |
| text-inverse vs action-fill | 6.53:1 | 6.53 |
| accent-graphic vs surface-panel | 6.05:1 | 6.05 |
| border-control vs surface-panel | 3.71:1 | 3.71 |
| focus-ring vs surface-control | 8.61:1 | 8.61 |

## Registry

Registered all 17 new hex values in `hex_registry.json` under `theme-family-token-value` **in this same commit**, with a Stage 5.1 sub-section in `raw-hex-audit.md` — avoiding the Stage 4.1 follow-up gap this time. The swatch preview's warning slot reuses `#F0C86A` (dark's current inherited `--mc-warning`, already registered from the Stage 0 baseline) since Gunmetal has no warning override yet — that's Stage 5.2.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean, 1001 known values.
- `check_new_hex.py --diff main...<branch>`: clean too this time — no unmapped-role comment mentions to trip the known multi-line-comment limitation, unlike Sharp's `#4DFFBC`/danger-Base-Border cases.
- `node --check`, `python -m compileall .`, `python scripts/check-i18n.py` — all clean.
- `pytest` — 509 passed, 25 skipped (unrelated platform skips).

No dev live-check this stage — that's Stage 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)