### PR TITLE
Theme registry Stage 5.2: MeshCenter Gunmetal, warning exception

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -2832,6 +2832,14 @@
     ]
   },
   {
+    "value": "473529",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3899"
+    ]
+  },
+  {
     "value": "47535A",
     "verdict": "theme-family-token-value",
     "count": 1,

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1092,3 +1092,15 @@ _17 new unique values (registered in the same commit as the CSS change this time
 | `#F2F5F6` | 1 | static/ui-kit.css:3864 |
 
 Not registered: none new this time - unlike Sharp, all three of Gunmetal's accent roles (`accent-reference`/`action-fill`/`accent-graphic`) share one value (`#63A1C2`), so there was no unmapped role to document as a gap. The swatch preview's warning slot reuses `#F0C86A` (dark's current `--mc-warning`, already registered from the Stage 0 baseline) - not a new value, since Gunmetal has no warning override yet (that's Stage 5.2).
+
+### Theme-family token value (Stage 5.2 - MeshCenter Gunmetal, warning exception)
+
+_1 new unique value - Gunmetal's warning exception only changes the surface; foreground/base stay `#F0C86A`, identical to the inherited dark value, so no override needed there_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#473529` | 1 | static/ui-kit.css:3899 |
+
+Not registered: `#C2A669` - the source doc's "favorite/calm accent" role, explicitly *not* part of Gunmetal's warning exception (section 8.3 quote: reserved for favorite/calm accent, not the warning error surface). Not declared anywhere in this stage; flagged in the Stage 5.2 PR as a possible future backlog item if a real favorite-state consumer is ever found, not invented here.
+
+**Tooling fix, same commit:** `check_new_hex.py`'s `strip_comment_spans()` had a real bug (not a workflow-timing issue like the prior two follow-ups were assumed to be) - it blanked out `/* ... */` comment spans by replacing every character, *including embedded newlines*, with a single space. In whole-file mode (`check_files()`, which operates on the full file text before splitting into lines), this silently collapsed a multi-line comment's line count to effectively zero once `.splitlines()` ran, undercounting every line number reported after it by roughly that comment's own line count. This is very likely the real root cause of both Stage 4.2's (`#188`) and Stage 5.1's (`#190`) stale line-number follow-ups - not the "grepped mid-draft" explanation given at the time. Confirmed live in this stage: the tool reported `#473529` at line 3444 (a blank line, nowhere near the actual declaration) before the fix, and the correct 3899 after. Fixed by preserving embedded newlines as newlines instead of collapsing them to spaces. Diff mode (`check_diff()`) is unaffected - it already applies `strip_comment_spans()` per individual added line, never across a multi-line span.

--- a/docs/theme-registry/tools/check_new_hex.py
+++ b/docs/theme-registry/tools/check_new_hex.py
@@ -52,7 +52,17 @@ def load_known_hex() -> set[str]:
 
 def strip_comment_spans(text: str) -> str:
     """Blank out /* ... */ comment contents so HEX inside design-note comments
-    doesn't get flagged as a new live declaration."""
+    doesn't get flagged as a new live declaration.
+
+    Preserves embedded newlines as newlines (not spaces) so line numbers
+    for anything after a multi-line comment stay accurate in whole-file
+    mode's check_files() - blanking them out entirely used to collapse a
+    multi-line comment into effectively zero newlines once the caller
+    splitlines()'d the result, silently shifting every reported line
+    number after it by the comment's own line count. Confirmed live on
+    two real PRs (theme-registry Stage 4.2/#188, Stage 5.1/#190) before
+    being traced to this function specifically in Stage 5.2.
+    """
     out = []
     i = 0
     n = len(text)
@@ -60,7 +70,8 @@ def strip_comment_spans(text: str) -> str:
         if text[i:i + 2] == "/*":
             j = text.find("*/", i + 2)
             end = j + 2 if j != -1 else n
-            out.append(" " * (end - i))
+            span = text[i:end]
+            out.append("".join("\n" if ch == "\n" else " " for ch in span))
             i = end
         else:
             out.append(text[i])

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -3802,10 +3802,26 @@ html[data-theme-family="sharp"] {
    light-side result.
 
    Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
-   (owner-approved, hex values copied verbatim - do not adjust). Only the
-   21 surface/text/border/accent roles are covered; state colors (Gunmetal
-   has one exception, warning, section 8.3) are Stage 5.2 - left unset here
-   so they inherit html[data-theme="dark"]'s existing values by cascade.
+   (owner-approved, hex values copied verbatim - do not adjust).
+
+   Stage 5.2 addendum: Gunmetal's one state-color exception - warning's
+   surface only (section 8.3). Narrower than Sharp's two-state exception
+   (4.2): foreground and base both stay #f0c86a, identical to the
+   inherited html[data-theme="dark"] value, so only --mc-warning-soft
+   needs overriding, not --mc-warning itself. Grepped --mc-warning's real
+   consumers to confirm there's no separate foreground/fg token to worry
+   about - there isn't, same as Stage 4.2 found for success/danger:
+   --mc-warning alone drives both the foreground role (ui-kit.css:433
+   .text-warning, style-part1.css:3018, the dark-mode notification-warning
+   icon color at style-part3.css:3782) and a small solid-fill role
+   (.node-detail-activity.activity-away, style-part3.css:20) - and it's
+   already correct for both since fg/base don't change here. --mc-warning-
+   soft is the actual surface token (ui-kit.css:270, .node-card.favorite's
+   background - the only consumer). #c2a669 (the source doc's "favorite/
+   calm accent" color) is explicitly NOT part of this exception - not
+   used anywhere in this block; flagged in the PR as a possible future
+   backlog item for a real favorite-role token, not invented here.
+   Success/danger/info get no Gunmetal exception at all and stay unset.
 
    Token mapping: identical role -> token assignments as Sharp (Stage 4.1's
    big comment above, ~line 3600) - re-verified against dark-mode consumers
@@ -3876,5 +3892,10 @@ html[data-theme-family="gunmetal"] {
     --mc-primary: #63a1c2;
     --mc-primary-hover: #7cb4d0;
     --mc-accent: #63a1c2;
+
+    /* Semantic states (Stage 5.2) - warning surface only; foreground/base
+       are identical to the inherited dark value and need no override.
+       No success/danger/info exception for Gunmetal. */
+    --mc-warning-soft: #473529;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage5-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage5-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Adds Gunmetal's one state-color exception (warning, section 8.3) to the existing `html[data-theme-family="gunmetal"]` block from Stage 5.1 (`03ba2d6`). No success/danger/info exception for Gunmetal.

## Mapping

Grepped `--mc-warning`/`--mc-warning-soft`'s real consumers before assuming anything:

- `--mc-warning` drives both the foreground role (`.text-warning`/`.status-warning`, `style-part1.css:3018`, the dark-mode `.notification-warning` icon color) **and** a small solid-fill role (`.node-detail-activity.activity-away`, `style-part3.css:20`) — same dual-role pattern Stage 4.2 found for success/danger. No separate foreground token exists.
- `--mc-warning-soft` is the actual surface token — its only consumer is `.node-card.favorite`'s background (`ui-kit.css:270`).

Per the source doc, Gunmetal's exception changes **only the surface**, from `#433719` to `#473529` — foreground and base both stay `#F0C86A`, identical to what `html[data-theme="dark"]` already has, so `--mc-warning` itself needs no override at all. Added just:

```css
--mc-warning-soft: #473529;
```

`#C2A669` (the source doc's "favorite/calm accent" role) is deliberately **not** used anywhere in this stage — flagging it here as a possible future backlog item if a real favorite-state consumer is ever found, not inventing the mapping now.

## Tooling fix (same commit)

Found and fixed a real bug in `check_new_hex.py` while registering this stage's one new hex value. `strip_comment_spans()` blanked `/* ... */` spans by replacing **every** character — including embedded newlines — with a plain space. In whole-file mode (`check_files()`, which processes the full file text before splitting into lines), this silently collapsed a multi-line comment's line count to effectively zero, undercounting every subsequent line number by roughly that comment's own length.

This is very likely the actual root cause of both prior stale-line-number follow-ups on this branch of work (Stage 4.2's #188 and Stage 5.1's #190) — both were attributed to "grepped mid-draft" at the time, but this bug alone fully explains the observed offsets. Confirmed live in this stage: before the fix, the tool reported the new `#473529` at line 3444 (a blank line, nowhere near the real declaration); after the fix, 3899 — which matches a direct `grep` exactly.

Fixed by preserving embedded newlines as newlines instead of collapsing them to spaces. Diff mode (`check_diff()`) is unaffected — it already applies comment-stripping per individual added line, never across a multi-line span, so this bug never touched it.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file, post-fix): clean, 1002 known values, correct line number confirmed against a fresh `grep` as the very last step before committing.
- `check_new_hex.py --diff`: flags one known false positive (`#C2A669`, mentioned only in the new multi-line PR-comment explaining why it's out of scope — the pre-existing per-line comment-stripping limitation in diff mode, unrelated to the bug fixed above).
- `python -m compileall .`, `python scripts/check-i18n.py` (no i18n changes, confirmed), `pytest` (509 passed, 25 skipped) — all clean.
- `?v=` bumped for `ui-kit.css` only.

No dev live-check this stage — that's Stage 5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)