### PR TITLE
Theme registry Stage 6.1: MeshCenter Alpine, base tokens (dark, fixed)

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -301,6 +301,15 @@
     ]
   },
   {
+    "value": "131C22",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1074",
+      "static/ui-kit.css:3989"
+    ]
+  },
+  {
     "value": "132334",
     "verdict": "ui-normalization-candidate",
     "count": 3,
@@ -940,6 +949,14 @@
       "static/style-part4.css:3361",
       "static/style-part4.css:3368",
       "static/style-part4.css:3432"
+    ]
+  },
+  {
+    "value": "1C2933",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3990"
     ]
   },
   {
@@ -1680,6 +1697,15 @@
     ]
   },
   {
+    "value": "263744",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1075",
+      "static/ui-kit.css:3991"
+    ]
+  },
+  {
     "value": "26394D",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -2090,6 +2116,14 @@
     ]
   },
   {
+    "value": "2F2F2F",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3992"
+    ]
+  },
+  {
     "value": "2F373C",
     "verdict": "theme-family-token-value",
     "count": 1,
@@ -2128,6 +2162,14 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:2640"
+    ]
+  },
+  {
+    "value": "2F4555",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3993"
     ]
   },
   {
@@ -2206,6 +2248,14 @@
       "static/style-part4.css:851",
       "static/style-part4.css:856",
       "static/style-part4.css:856"
+    ]
+  },
+  {
+    "value": "314F64",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3995"
     ]
   },
   {
@@ -2420,6 +2470,14 @@
     ]
   },
   {
+    "value": "354D5E",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3994"
+    ]
+  },
+  {
     "value": "364253",
     "verdict": "ui-normalization-candidate",
     "count": 8,
@@ -2520,6 +2578,14 @@
     "locations": [
       "static/style-part4.css:612",
       "static/style-part4.css:629"
+    ]
+  },
+  {
+    "value": "395366",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4004"
     ]
   },
   {
@@ -2764,6 +2830,15 @@
     ]
   },
   {
+    "value": "426077",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1076",
+      "static/ui-kit.css:4010"
+    ]
+  },
+  {
     "value": "433719",
     "verdict": "semantic-status-candidate",
     "count": 1,
@@ -2981,6 +3056,15 @@
     "count": 1,
     "locations": [
       "static/style-part3.css:3025"
+    ]
+  },
+  {
+    "value": "4C6E88",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:4005",
+      "static/ui-kit.css:4011"
     ]
   },
   {
@@ -3817,6 +3901,14 @@
     ]
   },
   {
+    "value": "7397B1",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4006"
+    ]
+  },
+  {
     "value": "73ADFF",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -4214,6 +4306,14 @@
       "static/style-part2.css:2710",
       "static/style-part2.css:2750",
       "static/style-part2.css:2771"
+    ]
+  },
+  {
+    "value": "85A4BB",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4012"
     ]
   },
   {
@@ -5062,6 +5162,14 @@
     ]
   },
   {
+    "value": "A8BECF",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4000"
+    ]
+  },
+  {
     "value": "A93E46",
     "verdict": "semantic-status-candidate",
     "count": 1,
@@ -5428,6 +5536,14 @@
     "count": 1,
     "locations": [
       "static/style-part3.css:1294"
+    ]
+  },
+  {
+    "value": "BACBD9",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4007"
     ]
   },
   {
@@ -5804,6 +5920,14 @@
       "static/style-part4.css:2930",
       "static/ui-kit.css:2040",
       "static/ui-kit.css:3120"
+    ]
+  },
+  {
+    "value": "CBD9E2",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3999"
     ]
   },
   {
@@ -8209,6 +8333,14 @@
     "count": 1,
     "locations": [
       "static/ui-kit.css:2650"
+    ]
+  },
+  {
+    "value": "F4F7F9",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:3998"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1104,3 +1104,28 @@ _1 new unique value - Gunmetal's warning exception only changes the surface; for
 Not registered: `#C2A669` - the source doc's "favorite/calm accent" role, explicitly *not* part of Gunmetal's warning exception (section 8.3 quote: reserved for favorite/calm accent, not the warning error surface). Not declared anywhere in this stage; flagged in the Stage 5.2 PR as a possible future backlog item if a real favorite-state consumer is ever found, not invented here.
 
 **Tooling fix, same commit:** `check_new_hex.py`'s `strip_comment_spans()` had a real bug (not a workflow-timing issue like the prior two follow-ups were assumed to be) - it blanked out `/* ... */` comment spans by replacing every character, *including embedded newlines*, with a single space. In whole-file mode (`check_files()`, which operates on the full file text before splitting into lines), this silently collapsed a multi-line comment's line count to effectively zero once `.splitlines()` ran, undercounting every line number reported after it by roughly that comment's own line count. This is very likely the real root cause of both Stage 4.2's (`#188`) and Stage 5.1's (`#190`) stale line-number follow-ups - not the "grepped mid-draft" explanation given at the time. Confirmed live in this stage: the tool reported `#473529` at line 3444 (a blank line, nowhere near the actual declaration) before the fix, and the correct 3899 after. Fixed by preserving embedded newlines as newlines instead of collapsing them to spaces. Diff mode (`check_diff()`) is unaffected - it already applies `strip_comment_spans()` per individual added line, never across a multi-line span.
+
+### Theme-family token value (Stage 6.1 - MeshCenter Alpine, base tokens)
+
+_16 new unique values (registered in the same commit as the CSS change, locations taken directly from `check_new_hex.py`'s own output and cross-verified with a fresh `grep` - the tool's line-numbering bug is fixed as of Stage 5.2, confirmed still accurate here)_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#131C22` | 2 | static/ui-kit.css:1074, static/ui-kit.css:3989 |
+| `#1C2933` | 1 | static/ui-kit.css:3990 |
+| `#263744` | 2 | static/ui-kit.css:1075, static/ui-kit.css:3991 |
+| `#2F2F2F` | 1 | static/ui-kit.css:3992 |
+| `#2F4555` | 1 | static/ui-kit.css:3993 |
+| `#314F64` | 1 | static/ui-kit.css:3995 |
+| `#354D5E` | 1 | static/ui-kit.css:3994 |
+| `#395366` | 1 | static/ui-kit.css:4004 |
+| `#426077` | 2 | static/ui-kit.css:1076, static/ui-kit.css:4010 |
+| `#4C6E88` | 2 | static/ui-kit.css:4005, static/ui-kit.css:4011 |
+| `#7397B1` | 1 | static/ui-kit.css:4006 |
+| `#85A4BB` | 1 | static/ui-kit.css:4012 |
+| `#A8BECF` | 1 | static/ui-kit.css:4000 |
+| `#BACBD9` | 1 | static/ui-kit.css:4007 |
+| `#CBD9E2` | 1 | static/ui-kit.css:3999 |
+| `#F4F7F9` | 1 | static/ui-kit.css:3998 |
+
+Not registered: `accent-reference` (`#557C99`) - same category as Sharp's `#4DFFBC` and Gunmetal-vs-Sharp's accent-split gaps - no existing token reads a role distinct from `action-fill`/`accent-graphic`, both already mapped. Mentioned only in the Stage 6.1 PR-comment explaining why it's unmapped, not declared anywhere. `#4C6E88` (`action-hover`/`border-default`) is intentionally the same hex for two roles per the source doc's own allowance (section 4.1) - registered once, both consumers checked for visual collision (none found, documented in the `ui-kit.css` comment).

--- a/static/chat.js
+++ b/static/chat.js
@@ -8022,7 +8022,10 @@ const WORKSPACE_THEME_FAMILIES = Object.freeze([
     Object.freeze({ id: 'sharp', kind: 'fixed', mode: 'light' }),
     // theme-registry Stage 5.1: Gunmetal is a 'fixed', dark-only family - its
     // token overrides live in ui-kit.css under html[data-theme-family="gunmetal"].
-    Object.freeze({ id: 'gunmetal', kind: 'fixed', mode: 'dark' })
+    Object.freeze({ id: 'gunmetal', kind: 'fixed', mode: 'dark' }),
+    // theme-registry Stage 6.1: Alpine is a 'fixed', dark-only family - its
+    // token overrides live in ui-kit.css under html[data-theme-family="alpine"].
+    Object.freeze({ id: 'alpine', kind: 'fixed', mode: 'dark' })
 ]);
 const WORKSPACE_THEME_FAMILY_IDS = WORKSPACE_THEME_FAMILIES.map(family => family.id);
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -19,7 +19,7 @@
     var FALLBACK_LOCALE = 'en';
     // Bumped manually alongside catalog content changes, same convention as
     // the ?v= query strings on <script>/<link> tags in index.html.
-    var CATALOG_VERSION = '20260904-theme-stage5-1';
+    var CATALOG_VERSION = '20260904-theme-stage6-1';
 
     var catalogs = {};      // locale -> flattened {dottedKey: value}
     var loadPromises = {};  // locale -> in-flight/completed fetch promise

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1151,6 +1151,7 @@
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
+    "theme_family_alpine": "MeshCenter Alpine",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Hell",
     "theme_mode_dark": "Dunkel",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1151,6 +1151,7 @@
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
+    "theme_family_alpine": "MeshCenter Alpine",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Light",
     "theme_mode_dark": "Dark",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -1151,6 +1151,7 @@
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
+    "theme_family_alpine": "MeshCenter Alpine",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Светлая",
     "theme_mode_dark": "Тёмная",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -1151,6 +1151,7 @@
     "theme_family_original": "MeshCenter Original",
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
+    "theme_family_alpine": "MeshCenter Alpine",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Світла",
     "theme_mode_dark": "Темна",

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1068,6 +1068,14 @@ a:focus-visible,
 .workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--primary { background: #63a1c2; }
 .workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--warning { background: #f0c86a; }
 
+/* theme-registry Stage 6.1: same reasoning as Sharp's/Gunmetal's swatch
+   overrides above. Warning uses dark's current inherited value (#f0c86a)
+   since Alpine's own warning exception isn't live until Stage 6.2. */
+.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--bg { background: #131c22; }
+.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--panel { background: #263744; }
+.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--primary { background: #426077; }
+.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--warning { background: #f0c86a; }
+
 .workspace-theme-family-label {
     font-size: 12px;
     font-weight: 700;
@@ -3915,5 +3923,92 @@ html[data-theme-family="gunmetal"] {
        are identical to the inherited dark value and need no override.
        No success/danger/info exception for Gunmetal. */
     --mc-warning-soft: #473529;
+}
+
+/* theme-registry Stage 6.1: MeshCenter Alpine - a 'fixed', DARK-only
+   family (WORKSPACE_THEME_FAMILIES in chat.js: { id: 'alpine', kind:
+   'fixed', mode: 'dark' }). Second dark fixed family after Gunmetal - same
+   same-element cascade mechanism, needs to win over both :root and the
+   canonical html[data-theme="dark"] block by source order at equal
+   specificity, same as Gunmetal.
+
+   Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
+   (owner-approved, hex values copied verbatim - do not adjust). Only the
+   21 surface/text/border/accent roles are covered; Alpine's warning
+   exception (a full 4-value one, unlike Gunmetal's surface-only tweak) is
+   Stage 6.2 - left unset here so success/warning/danger/info all inherit
+   html[data-theme="dark"]'s existing values by cascade.
+
+   Token mapping: re-verified against dark-mode consumers, not carried
+   over blind from Gunmetal (which happened to collapse the 3 accent roles
+   into one - Alpine doesn't, it's a 3-way split like Sharp):
+     surface-app/-workspace/-panel  -> --mc-bg-app/-workspace/-panel
+     surface-card                   -> --mc-card-bg (explicit leaf
+                                        override, same as Gunmetal - dark's
+                                        --mc-card-bg is its own literal,
+                                        not an alias, so this isn't
+                                        "breaking" anything)
+     surface-control                -> --mc-button-secondary-bg
+     surface-media                  -> --mc-bg-media-stage
+     surface-selected               -> --mc-primary-soft (--mc-accent-soft
+                                        follows via the same alias)
+     text-primary/-secondary/-muted/-inverse -> the matching --mc-text-*
+     border-soft/-default           -> --mc-border-soft/--mc-border
+     border-control                 -> --mc-button-secondary-border
+     focus-ring                     -> --mc-border-focus
+     action-fill/-hover             -> --mc-primary/--mc-primary-hover
+                                        (grepped: drives the primary button
+                                        fill + active tab underline, same
+                                        consumers Sharp/Gunmetal found)
+     accent-graphic                 -> --mc-accent (grepped: .btn:focus-
+                                        visible outline + About-page
+                                        accent card/link)
+
+   accent-reference (#557c99) has no existing token to land on, same
+   category as Sharp's mint - nothing reads a role that isn't already
+   claimed by action-fill or accent-graphic. Left unmapped.
+
+   action-hover (#4c6e88) and border-default (#4c6e88) are the identical
+   hex - checked whether any component uses both close enough together to
+   look wrong (the specific risk: a hover state reading the same as a
+   resting border). --mc-primary-hover has only 4 consumers, all narrow
+   button/chat-sender-text roles (ui-kit.css ~404/418-419/2176); --mc-border
+   is used in 40+ generic panel/divider borders across the whole file.
+   None of --mc-primary-hover's 4 sites sit adjacent to a --mc-border
+   consumer in the same component - no visual collision found. Treating
+   this as intentional per the source doc's own "one hex, multiple roles"
+   allowance (section 4.1), not a copy-paste error.
+
+   surface-hover: re-checked a third time (Sharp, Gunmetal, now Alpine) -
+   same result, hover backgrounds are still per-component
+   (--mc-button-secondary-bg-hover, --mc-dark-control-bg-hover,
+   --mc-popover-item-hover, --mc-tab-bg-hover), no single shared token.
+   Left unmapped. */
+html[data-theme-family="alpine"] {
+    /* Application surfaces */
+    --mc-bg-app: #131c22;
+    --mc-bg-workspace: #1c2933;
+    --mc-bg-panel: #263744;
+    --mc-bg-media-stage: #2f2f2f;
+    --mc-card-bg: #2f4555;
+    --mc-button-secondary-bg: #354d5e;
+    --mc-primary-soft: #314f64;
+
+    /* Text */
+    --mc-text-primary: #f4f7f9;
+    --mc-text-secondary: #cbd9e2;
+    --mc-text-muted: #a8becf;
+    --mc-text-inverse: #ffffff;
+
+    /* Borders */
+    --mc-border-soft: #395366;
+    --mc-border: #4c6e88;
+    --mc-button-secondary-border: #7397b1;
+    --mc-border-focus: #bacbd9;
+
+    /* Primary accent */
+    --mc-primary: #426077;
+    --mc-primary-hover: #4c6e88;
+    --mc-accent: #85a4bb;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage5-3">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage6-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
@@ -1959,6 +1959,18 @@
                                 <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_gunmetal">MeshCenter Gunmetal</span>
                             </span>
                         </label>
+                        <label class="workspace-theme-family-option" data-family="alpine">
+                            <input type="radio" name="workspaceThemeFamily" value="alpine">
+                            <span class="workspace-theme-family-card">
+                                <span class="workspace-theme-swatches" aria-hidden="true">
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--bg"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--panel"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--primary"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--warning"></span>
+                                </span>
+                                <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_alpine">MeshCenter Alpine</span>
+                            </span>
+                        </label>
                     </div>
                     <!-- Level 2: Auto/Light/Dark for a paired family, or a single
                          fixed-mode label for a fixed one - rendered by
@@ -2242,7 +2254,7 @@
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/chart.umd.min.js"></script>
-<script src="/static/i18n.js?v=20260904-theme-stage5-1"></script>
+<script src="/static/i18n.js?v=20260904-theme-stage6-1"></script>
 <script>
     // Server already resolved "auto" (stored ui.language, or an
     // Accept-Language guess) to a concrete locale for <html lang> above —
@@ -2258,7 +2270,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260904-theme-stage5-1"></script>
+<script src="/static/chat.js?v=20260904-theme-stage6-1"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary

Adds **MeshCenter Alpine** as a new theme family: `kind: 'fixed', mode: 'dark'` — the second dark fixed family, same three-stage shape as Sharp (4.1-4.3) and Gunmetal (5.1-5.3, both merged). This stage covers only the 21 surface/text/border/accent roles; Alpine's warning exception is Stage 6.2.

- `static/ui-kit.css`: `html[data-theme-family="alpine"]` override block, placed after Gunmetal's block (itself after the canonical `html[data-theme="dark"]` block) + an Alpine-scoped swatch preview override.
- `static/chat.js`: `WORKSPACE_THEME_FAMILIES` gets an `alpine` entry.
- `templates/index.html`: new family `<label>` card.
- `static/i18n/{en,de,ru,uk}.json`: `workspace.theme_family_alpine` = "MeshCenter Alpine".
- `?v=` bumped for `ui-kit.css`, `chat.js`, `i18n.js`/`CATALOG_VERSION`.

## Token mapping

Re-verified against dark-mode consumers rather than assuming it carries over from Gunmetal blind — important here because Alpine's accent roles are a **3-way split** like Sharp, unlike Gunmetal where all three collapsed to one value:

| Source role | Token | Note |
|---|---|---|
| surface-app/-workspace/-panel | `--mc-bg-app`/`-workspace`/`-panel` | direct |
| surface-card | `--mc-card-bg` | explicit leaf override, same as Gunmetal |
| surface-control | `--mc-button-secondary-bg` | direct |
| surface-media | `--mc-bg-media-stage` | direct |
| surface-selected | `--mc-primary-soft` | `--mc-accent-soft` follows via the existing alias |
| text-* | matching `--mc-text-*` | direct |
| border-soft/-default | `--mc-border-soft`/`--mc-border` | direct |
| border-control | `--mc-button-secondary-border` | direct |
| focus-ring | `--mc-border-focus` | direct |
| action-fill/-hover | `--mc-primary`/`--mc-primary-hover` | grepped: primary button fill + active tab underline, same consumers Sharp/Gunmetal found |
| accent-graphic | `--mc-accent` | grepped: `.btn:focus-visible` outline + About-page accent |

**`accent-reference`** (`#557C99`) has no existing token to land on — same category as Sharp's mint gap. Left unmapped.

## The action-hover / border-default coincidence

`action-hover` (`#4C6E88`) and `border-default` (`#4C6E88`) share the exact same hex — checked whether any component uses both close enough together to look wrong (a hover state reading identical to a resting border). `--mc-primary-hover` has only 4 narrow consumers (primary/send/screenshot button hover, one chat-sender-text color); `--mc-border` drives 40+ generic panel/divider borders across the file. None of the 4 `--mc-primary-hover` sites sit adjacent to a `--mc-border` consumer in the same component — no visual collision found. Treated as intentional per the source doc's own "one hex, multiple roles" allowance, not a copy-paste error.

## surface-hover: confirmed a third time

Same conclusion as Sharp and Gunmetal — hover backgrounds are still per-component (`--mc-button-secondary-bg-hover`, `--mc-dark-control-bg-hover`, `--mc-popover-item-hover`, `--mc-tab-bg-hover`), no single shared token exists. Left unmapped.

## Contrast self-check

All 5 targets from the source doc's section 9 (Alpine column) reproduce exactly against this mapping:

| Pair | Recomputed | Target |
|---|---|---:|
| text-muted vs surface-card | 5.20:1 | 5.20 |
| text-inverse vs action-fill | 6.62:1 | 6.62 |
| accent-graphic vs surface-panel | 4.69:1 | 4.69 |
| border-control vs surface-panel | 3.97:1 | 3.97 |
| focus-ring vs surface-control | 5.32:1 | 5.32 |

## Registry

Registered all 16 new hex values in `hex_registry.json` under `theme-family-token-value` in this same commit. Locations taken from `check_new_hex.py`'s own output and cross-verified with a fresh `grep` — the tool's line-numbering bug (found and fixed in Stage 5.2/#191) held up correctly here.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean, 1018 known values.
- `check_new_hex.py --diff main...<branch>`: 1 known false positive (`#557C99`, mentioned only in the new multi-line PR-comment, never declared — the pre-existing `--diff`-mode multi-line-comment limitation, unrelated to the Stage 5.2 line-counting bug).
- `node --check`, `python -m compileall .`, `python scripts/check-i18n.py`, `pytest` (509 passed, 25 skipped) — all clean.

No dev live-check this stage — that's Stage 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)