### PR TITLE
Theme registry Stage 6.2: MeshCenter Alpine, warning exception

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -2589,6 +2589,14 @@
     ]
   },
   {
+    "value": "3A281A",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4059"
+    ]
+  },
+  {
     "value": "3A4A5A",
     "verdict": "ui-normalization-candidate",
     "count": 5,
@@ -8962,6 +8970,15 @@
     "locations": [
       "static/style-part3.css:3738",
       "static/style-part4.css:4017"
+    ]
+  },
+  {
+    "value": "FF9A3D",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1079",
+      "static/ui-kit.css:4058"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1129,3 +1129,16 @@ _16 new unique values (registered in the same commit as the CSS change, location
 | `#F4F7F9` | 1 | static/ui-kit.css:3998 |
 
 Not registered: `accent-reference` (`#557C99`) - same category as Sharp's `#4DFFBC` and Gunmetal-vs-Sharp's accent-split gaps - no existing token reads a role distinct from `action-fill`/`accent-graphic`, both already mapped. Mentioned only in the Stage 6.1 PR-comment explaining why it's unmapped, not declared anywhere. `#4C6E88` (`action-hover`/`border-default`) is intentionally the same hex for two roles per the source doc's own allowance (section 4.1) - registered once, both consumers checked for visual collision (none found, documented in the `ui-kit.css` comment).
+
+_Note (added Stage 6.2): the line numbers in the table above are now stale - Stage 6.2 inserted new comment/declaration lines above and within this region of `ui-kit.css`. This is the same known, pre-existing, non-blocking drift called out in Stage 4.1/5.1's own follow-ups (the HEX values and their identity are what this registry actually tracks; exact line numbers are a best-effort pointer, not re-verified retroactively every time a later stage shifts them). Not fixed here - out of scope for a Stage 6.2 PR._
+
+### Theme-family token value (Stage 6.2 - MeshCenter Alpine, warning exception)
+
+_2 new unique values - warning's foreground/surface. Fill (`#A84300`) and border (`#F08A24`) have no consumer to land on, same category as Sharp's success/danger Base/Border gap (Stage 4.2) - re-checked specifically for warning rather than assumed, confirmed no separate border-role consumer exists_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#3A281A` | 1 | static/ui-kit.css:4059 |
+| `#FF9A3D` | 2 | static/ui-kit.css:1079, static/ui-kit.css:4058 |
+
+Not registered: `#A84300` (fill/base - fails AA text contrast at 2.03:1 on Alpine's own panel, confirmed via `contrast_check.py`, so it can't safely share `--mc-warning` with the 3 text-role consumers that need it) and `#F08A24` (border - no existing border-role token for warning, grepped and confirmed empty). `#CC5500` (the source doc's palette-anchor "reference" color, fails 3:1 on Alpine's panel per section 8.4, confirmed: 2.84:1) and `#997255` (favorite/secondary-warm-accent role, out of scope same as Gunmetal's `#C2A669`) are both mentioned only in the Stage 6.2 PR-comment explaining why they're unmapped, not declared anywhere.

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1069,12 +1069,14 @@ a:focus-visible,
 .workspace-theme-family-option[data-family="gunmetal"] .workspace-theme-swatch--warning { background: #f0c86a; }
 
 /* theme-registry Stage 6.1: same reasoning as Sharp's/Gunmetal's swatch
-   overrides above. Warning uses dark's current inherited value (#f0c86a)
-   since Alpine's own warning exception isn't live until Stage 6.2. */
+   overrides above. Warning updated in Stage 6.2 to Alpine's own
+   --mc-warning value (#ff9a3d, the foreground role - see the Stage 6.2
+   comment above html[data-theme-family="alpine"]) once that exception
+   landed; was dark's inherited #f0c86a before that. */
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--bg { background: #131c22; }
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--panel { background: #263744; }
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--primary { background: #426077; }
-.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--warning { background: #f0c86a; }
+.workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--warning { background: #ff9a3d; }
 
 .workspace-theme-family-label {
     font-size: 12px;
@@ -3933,11 +3935,11 @@ html[data-theme-family="gunmetal"] {
    specificity, same as Gunmetal.
 
    Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
-   (owner-approved, hex values copied verbatim - do not adjust). Only the
-   21 surface/text/border/accent roles are covered; Alpine's warning
-   exception (a full 4-value one, unlike Gunmetal's surface-only tweak) is
-   Stage 6.2 - left unset here so success/warning/danger/info all inherit
-   html[data-theme="dark"]'s existing values by cascade.
+   (owner-approved, hex values copied verbatim - do not adjust).
+
+   Stage 6.2 addendum: Alpine's one state-color exception - warning
+   (section 8.3). Success/danger/info get no Alpine exception and stay
+   unset.
 
    Token mapping: re-verified against dark-mode consumers, not carried
    over blind from Gunmetal (which happened to collapse the 3 accent roles
@@ -3983,7 +3985,47 @@ html[data-theme-family="gunmetal"] {
    same result, hover backgrounds are still per-component
    (--mc-button-secondary-bg-hover, --mc-dark-control-bg-hover,
    --mc-popover-item-hover, --mc-tab-bg-hover), no single shared token.
-   Left unmapped. */
+   Left unmapped.
+
+   Stage 6.2 - warning exception. Unlike Gunmetal's single-value surface
+   tweak (5.2), Alpine's source values are a genuine 4-way split
+   (foreground #ff9a3d, fill #a84300, surface #3a281a, border #f08a24) and
+   foreground != fill this time - so the fg/fill conflation Stage 5.2 could
+   ignore (Gunmetal's fg and fill were identical) becomes a real judgment
+   call here, same shape as Stage 4.2's success/danger split for Sharp.
+
+   Grepped every real --mc-warning consumer under the dark cascade:
+     - foreground/text role (3 of 4 consumers): .text-warning/
+       .status-warning (ui-kit.css ~431), html[data-theme="dark"]
+       .settings-card-note--warning (style-part1.css:3017-3019), the dark
+       notification-warning icon color (style-part3.css:3782)
+     - fill role (1 of 4): .node-detail-activity.activity-away
+       (style-part3.css:20) - a small solid-color indicator bar, no text
+   Verified with contrast_check.py rather than trusting the source doc's
+   own section 8.4 numbers blindly (they matched exactly once recomputed
+   against Alpine's actual panel #263744): fill/base #a84300 fails badly
+   as text (2.03:1, both AA thresholds), while foreground #ff9a3d passes
+   comfortably everywhere it's used (5.81:1 on panel, 6.64:1 on the
+   warning surface itself). Same reasoning as Stage 4.2: --mc-warning maps
+   to Foreground since it's the only one that keeps every text-role
+   consumer legible; the one fill-role consumer (a decorative indicator
+   bar, no legibility requirement) renders a slightly-off-source orange
+   instead of the literal fill color - a known, deliberate miss, not an
+   oversight. --mc-warning-soft maps cleanly to Surface (only ever used as
+   a soft background wash - ui-kit.css:270 .node-card.favorite,
+   ui-kit.css:1896 the dark-mode !important restore from Stage 5.3).
+
+   Border (#f08a24) and fill/base (#a84300, the value --mc-warning did NOT
+   take) have no existing token to land on - re-checked specifically for
+   warning (grepped for any warning-adjacent border-color consumer; found
+   none) rather than assuming Stage 4.2's success/danger conclusion
+   carries over unchecked. Left both unmapped.
+
+   #cc5500 ("reference") and #997255 (favorite/secondary-warm-accent role)
+   are deliberately not used anywhere in this block - #cc5500 is the
+   palette's background-only anchor color (fails 3:1 on Alpine's own panel
+   per the source doc's own section 8.4, confirmed: 2.84:1), and #997255
+   is out of scope the same way Gunmetal's #c2a669 was in Stage 5.2. */
 html[data-theme-family="alpine"] {
     /* Application surfaces */
     --mc-bg-app: #131c22;
@@ -4010,5 +4052,10 @@ html[data-theme-family="alpine"] {
     --mc-primary: #426077;
     --mc-primary-hover: #4c6e88;
     --mc-accent: #85a4bb;
+
+    /* Semantic states (Stage 6.2) - warning exception only; no
+       success/danger/info exception for Alpine. */
+    --mc-warning: #ff9a3d;
+    --mc-warning-soft: #3a281a;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage6-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage6-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Adds Alpine's one state-color exception (warning, section 8.3) to the existing `html[data-theme-family="alpine"]` block from Stage 6.1 (`2fc2580`). No success/danger/info exception for Alpine.

## The real complication: foreground ≠ fill this time

Unlike Gunmetal's single-value surface tweak (Stage 5.2), Alpine's source values are a genuine 4-way split:

| Role | Hex |
|---|---|
| foreground | `#FF9A3D` |
| fill (base) | `#A84300` |
| surface | `#3A281A` |
| border | `#F08A24` |

Stage 5.2 found `--mc-warning` drives both a foreground/text role **and** a small fill role — fine for Gunmetal since both were the same value. Alpine breaks that: foreground and fill are genuinely different. Grepped every real `--mc-warning` consumer under the dark cascade:

- **Foreground/text (3 of 4 consumers)**: `.text-warning`/`.status-warning` (`ui-kit.css` ~431), `html[data-theme="dark"] .settings-card-note--warning` (`style-part1.css:3017-3019`), the dark-mode `.notification-warning` icon color (`style-part3.css:3782`)
- **Fill (1 of 4)**: `.node-detail-activity.activity-away` (`style-part3.css:20`) — a small solid-color indicator bar, no text on it

Verified with `contrast_check.py` rather than trusting the source doc's own section 8.4 numbers blindly (they matched exactly once recomputed against Alpine's actual panel `#263744`): fill `#A84300` fails badly as text (**2.03:1**, both AA thresholds), while foreground `#FF9A3D` passes comfortably everywhere it's used (5.81:1 on panel, 6.64:1 on the warning surface itself). Same reasoning Stage 4.2 used for Sharp's success/danger — `--mc-warning` maps to **Foreground**, `--mc-warning-soft` maps cleanly to **Surface** (`#3A281A`, only ever used as a soft background wash).

**Border** (`#F08A24`) and the unmapped **fill** (`#A84300`) have no existing token — re-checked specifically for warning rather than assuming Stage 4.2's success/danger conclusion carries over: grepped for any warning-adjacent border-color consumer, found none. Left both unmapped.

`#CC5500` (the source doc's palette-anchor "reference" color — fails 3:1 on Alpine's own panel per section 8.4, confirmed: 2.84:1) and `#997255` (favorite/secondary-warm-accent role) are both deliberately not used — same treatment as Sharp's `#4DFFBC` and Gunmetal's `#C2A669`.

## Small follow-through: swatch preview

Updated Alpine's swatch preview warning slot from `#F0C86A` (dark's inherited value, used as a placeholder in 6.1) to `#FF9A3D` — Alpine now has its own real `--mc-warning`, so the swatch needed updating to stay accurate. Gunmetal's own swatch didn't need this in 5.2 since its `--mc-warning` never moved (only `-soft` did).

## Registry

Registered the 2 new hex values (`#FF9A3D`, `#3A281A`) in `hex_registry.json` under `theme-family-token-value` in this same commit — locations taken from `check_new_hex.py`'s own output and cross-verified with a fresh `grep`.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean, 1020 known values.
- `check_new_hex.py --diff main...<branch>`: 10 known false positives, all comment-only mentions of the intentionally-unmapped fill/border/reference/favorite-accent values — the pre-existing `--diff`-mode multi-line-comment limitation, unrelated to the Stage 5.2 line-counting fix.
- `python -m compileall .`, `python scripts/check-i18n.py` (no i18n changes), `pytest` (509 passed, 25 skipped) — all clean.
- `?v=` bumped for `ui-kit.css` only.

No dev live-check this stage — that's Stage 6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)