### PR TITLE
Theme registry Stage 7.1: MeshCenter Teal Dark, base tokens

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -8,6 +8,32 @@
     ]
   },
   {
+    "value": "011112",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4143"
+    ]
+  },
+  {
+    "value": "021818",
+    "verdict": "theme-family-token-value",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1086",
+      "static/ui-kit.css:4140",
+      "static/ui-kit.css:4152"
+    ]
+  },
+  {
+    "value": "032424",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4141"
+    ]
+  },
+  {
     "value": "0369A1",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -16,11 +42,52 @@
     ]
   },
   {
+    "value": "043030",
+    "verdict": "theme-family-token-value",
+    "count": 2,
+    "locations": [
+      "static/ui-kit.css:1087",
+      "static/ui-kit.css:4142"
+    ]
+  },
+  {
+    "value": "053C3C",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4144"
+    ]
+  },
+  {
+    "value": "064747",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4145"
+    ]
+  },
+  {
+    "value": "075454",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4155"
+    ]
+  },
+  {
     "value": "080D13",
     "verdict": "ui-normalization-candidate",
     "count": 1,
     "locations": [
       "static/ui-kit.css:1869"
+    ]
+  },
+  {
+    "value": "086060",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4156"
     ]
   },
   {
@@ -46,6 +113,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:2060"
+    ]
+  },
+  {
+    "value": "096C6C",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4146"
     ]
   },
   {
@@ -81,6 +156,14 @@
     "locations": [
       "static/ui-kit.css:1066",
       "static/ui-kit.css:3855"
+    ]
+  },
+  {
+    "value": "0C9292",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4157"
     ]
   },
   {
@@ -226,6 +309,16 @@
     ]
   },
   {
+    "value": "10C2C2",
+    "verdict": "theme-family-token-value",
+    "count": 3,
+    "locations": [
+      "static/ui-kit.css:1088",
+      "static/ui-kit.css:4161",
+      "static/ui-kit.css:4163"
+    ]
+  },
+  {
     "value": "111821",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -317,6 +410,14 @@
       "static/style-part4.css:3220",
       "static/style-part4.css:3399",
       "static/style-part4.css:4000"
+    ]
+  },
+  {
+    "value": "13EBEB",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4162"
     ]
   },
   {
@@ -3180,6 +3281,14 @@
     ]
   },
   {
+    "value": "51F0F0",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4158"
+    ]
+  },
+  {
     "value": "526174",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -4633,6 +4742,14 @@
     ]
   },
   {
+    "value": "8FC2C2",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4151"
+    ]
+  },
+  {
     "value": "8FC4FF",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -5826,6 +5943,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:3511"
+    ]
+  },
+  {
+    "value": "C9EEEE",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4150"
     ]
   },
   {
@@ -8200,6 +8325,14 @@
     "locations": [
       "static/style-part1.css:204",
       "static/style-part2.css:3984"
+    ]
+  },
+  {
+    "value": "F0FAFA",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4149"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1142,3 +1142,28 @@ _2 new unique values - warning's foreground/surface. Fill (`#A84300`) and border
 | `#FF9A3D` | 2 | static/ui-kit.css:1079, static/ui-kit.css:4058 |
 
 Not registered: `#A84300` (fill/base - fails AA text contrast at 2.03:1 on Alpine's own panel, confirmed via `contrast_check.py`, so it can't safely share `--mc-warning` with the 3 text-role consumers that need it) and `#F08A24` (border - no existing border-role token for warning, grepped and confirmed empty). `#CC5500` (the source doc's palette-anchor "reference" color, fails 3:1 on Alpine's panel per section 8.4, confirmed: 2.84:1) and `#997255` (favorite/secondary-warm-accent role, out of scope same as Gunmetal's `#C2A669`) are both mentioned only in the Stage 6.2 PR-comment explaining why they're unmapped, not declared anywhere.
+
+### Theme-family token value (Stage 7.1 - MeshCenter Teal Dark, base tokens)
+
+_16 new unique values (registered in the same commit as the CSS change, locations taken from `check_new_hex.py`'s own output and cross-verified with a fresh `grep` as the last step before committing)_
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#011112` | 1 | static/ui-kit.css:4143 |
+| `#021818` | 3 | static/ui-kit.css:1086, static/ui-kit.css:4140, static/ui-kit.css:4152 |
+| `#032424` | 1 | static/ui-kit.css:4141 |
+| `#043030` | 2 | static/ui-kit.css:1087, static/ui-kit.css:4142 |
+| `#053C3C` | 1 | static/ui-kit.css:4144 |
+| `#064747` | 1 | static/ui-kit.css:4145 |
+| `#075454` | 1 | static/ui-kit.css:4155 |
+| `#086060` | 1 | static/ui-kit.css:4156 |
+| `#096C6C` | 1 | static/ui-kit.css:4146 |
+| `#0C9292` | 1 | static/ui-kit.css:4157 |
+| `#10C2C2` | 3 | static/ui-kit.css:1088, static/ui-kit.css:4161, static/ui-kit.css:4163 |
+| `#13EBEB` | 1 | static/ui-kit.css:4162 |
+| `#51F0F0` | 1 | static/ui-kit.css:4158 |
+| `#8FC2C2` | 1 | static/ui-kit.css:4151 |
+| `#C9EEEE` | 1 | static/ui-kit.css:4150 |
+| `#F0FAFA` | 1 | static/ui-kit.css:4149 |
+
+Not registered: `accent-reference` (`#096C6C`) has no consumer distinct from `action-fill`/`accent-graphic` (both `--mc-primary`/`--mc-accent`, already mapped) - same category as Sharp's/Alpine's unmapped reference colors. Note this stage is architecturally different from Sharp/Gunmetal/Alpine: Teal has **no state-color exception at all** (confirmed against section 8.3 - no Teal-specific line exists, unlike the other three fixed families which each had one), and is wired provisionally as `kind: 'fixed'` pending Stage 8's Teal Light + Stage 8.2's conversion to `kind: 'paired'` - see the `ui-kit.css`/`chat.js` comments for the full reasoning. No hex was left unregistered due to a fg/fill split judgment call this time (there's no state exception to split).

--- a/static/chat.js
+++ b/static/chat.js
@@ -8025,7 +8025,16 @@ const WORKSPACE_THEME_FAMILIES = Object.freeze([
     Object.freeze({ id: 'gunmetal', kind: 'fixed', mode: 'dark' }),
     // theme-registry Stage 6.1: Alpine is a 'fixed', dark-only family - its
     // token overrides live in ui-kit.css under html[data-theme-family="alpine"].
-    Object.freeze({ id: 'alpine', kind: 'fixed', mode: 'dark' })
+    Object.freeze({ id: 'alpine', kind: 'fixed', mode: 'dark' }),
+    // theme-registry Stage 7.1: Teal Dark, wired provisionally as 'fixed'/
+    // 'dark' - NOT the final shape. Once Teal Light exists (Stage 8), this
+    // becomes a genuine kind: 'paired' entry like 'original' (Stage 8.2).
+    // Every place that assumes a 'fixed' family's kind never changes later
+    // needs to account for this id flipping kind in place - see the
+    // ui-kit.css comment above html[data-theme-family="teal"] for the full
+    // note. Token overrides live in ui-kit.css under
+    // html[data-theme-family="teal"].
+    Object.freeze({ id: 'teal', kind: 'fixed', mode: 'dark' })
 ]);
 const WORKSPACE_THEME_FAMILY_IDS = WORKSPACE_THEME_FAMILIES.map(family => family.id);
 

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -19,7 +19,7 @@
     var FALLBACK_LOCALE = 'en';
     // Bumped manually alongside catalog content changes, same convention as
     // the ?v= query strings on <script>/<link> tags in index.html.
-    var CATALOG_VERSION = '20260904-theme-stage6-1';
+    var CATALOG_VERSION = '20260904-theme-stage7-1';
 
     var catalogs = {};      // locale -> flattened {dottedKey: value}
     var loadPromises = {};  // locale -> in-flight/completed fetch promise

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -1152,6 +1152,7 @@
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_family_alpine": "MeshCenter Alpine",
+    "theme_family_teal": "MeshCenter Teal",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Hell",
     "theme_mode_dark": "Dunkel",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1152,6 +1152,7 @@
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_family_alpine": "MeshCenter Alpine",
+    "theme_family_teal": "MeshCenter Teal",
     "theme_mode_auto": "Auto",
     "theme_mode_light": "Light",
     "theme_mode_dark": "Dark",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -1152,6 +1152,7 @@
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_family_alpine": "MeshCenter Alpine",
+    "theme_family_teal": "MeshCenter Teal",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Светлая",
     "theme_mode_dark": "Тёмная",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -1152,6 +1152,7 @@
     "theme_family_sharp": "MeshCenter Sharp",
     "theme_family_gunmetal": "MeshCenter Gunmetal",
     "theme_family_alpine": "MeshCenter Alpine",
+    "theme_family_teal": "MeshCenter Teal",
     "theme_mode_auto": "Авто",
     "theme_mode_light": "Світла",
     "theme_mode_dark": "Темна",

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1078,6 +1078,16 @@ a:focus-visible,
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--primary { background: #426077; }
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--warning { background: #ff9a3d; }
 
+/* theme-registry Stage 7.1: same reasoning as the prior fixed families'
+   swatch overrides above. Warning uses dark's current inherited value
+   (#f0c86a) PERMANENTLY, not a placeholder - Teal has no warning
+   exception at all (section 8.3), unlike Gunmetal/Alpine's swatches
+   which were provisional pending their own 6.2/6.2-shaped stage. */
+.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--bg { background: #021818; }
+.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--panel { background: #043030; }
+.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--primary { background: #10c2c2; }
+.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--warning { background: #f0c86a; }
+
 .workspace-theme-family-label {
     font-size: 12px;
     font-weight: 700;
@@ -4057,5 +4067,99 @@ html[data-theme-family="alpine"] {
        success/danger/info exception for Alpine. */
     --mc-warning: #ff9a3d;
     --mc-warning-soft: #3a281a;
+}
+
+/* theme-registry Stage 7.1: MeshCenter Teal Dark - wired provisionally as
+   a 'fixed', DARK-only family (WORKSPACE_THEME_FAMILIES in chat.js:
+   { id: 'teal', kind: 'fixed', mode: 'dark' }), same as Sharp/Gunmetal/
+   Alpine were during their own single-mode stages. This is NOT the final
+   shape: per the source doc (section 11.1) and stage plan (section 12,
+   Stage 8), Teal is meant to become a genuine kind: 'paired' family once
+   Teal Light exists too (Stage 8), matching 'original'. Converting kind
+   from 'fixed' to 'paired' - and whatever downstream logic keys off
+   kind/mode for the family picker's Auto/Light/Dark second-level UI - is
+   Stage 8.2's job, not this one. Flagging here for that stage: every
+   place that currently assumes a 'fixed' family's kind never changes
+   later (resolveTheme(), renderWorkspaceThemeModeRow(), the
+   WORKSPACE_THEME_FAMILIES entry shape itself) will need to handle an
+   existing family id switching from 'fixed' to 'paired' in place, not
+   just a new family being added.
+
+   Third dark fixed family after Gunmetal/Alpine - same same-element
+   cascade mechanism, needs to win over both :root and the canonical
+   html[data-theme="dark"] block by source order at equal specificity.
+
+   Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
+   (owner-approved, hex values copied verbatim - do not adjust).
+
+   State colors: confirmed no Teal exception exists in section 8.3 at all
+   (unlike Sharp/Gunmetal/Alpine, which each had one) - all four
+   (success/warning/danger/info) stay fully unset, inheriting
+   html[data-theme="dark"]'s existing values by cascade. Worth calling
+   out explicitly: this means Teal's own bright cyan primary
+   (--mc-primary/--mc-accent: #10c2c2) and the base dark scheme's
+   success green (--mc-success: #72d69a) have no state-specific
+   differentiation to lean on - both read as "bright, saturated, cool"
+   at a glance. Stage 7.2's actual job (source doc section 12, Stage 7:
+   verify distinguishability by shape/label, not just color) - not
+   solved here, deliberately not touching --mc-success for anything
+   outside its own role in this stage so 7.2 starts from a clean baseline.
+
+   Token mapping: re-verified against consumers, not carried over blind:
+     surface-app/-workspace/-panel  -> --mc-bg-app/-workspace/-panel
+     surface-card                   -> --mc-card-bg (explicit leaf
+                                        override, same reasoning as
+                                        Gunmetal/Alpine)
+     surface-control                -> --mc-button-secondary-bg
+     surface-media                  -> --mc-bg-media-stage
+     surface-selected               -> --mc-primary-soft (--mc-accent-soft
+                                        follows via the same alias)
+     text-primary/-secondary/-muted/-inverse -> the matching --mc-text-*
+     border-soft/-default           -> --mc-border-soft/--mc-border
+     border-control                 -> --mc-button-secondary-border
+     focus-ring                     -> --mc-border-focus
+     action-fill/-hover             -> --mc-primary/--mc-primary-hover
+     accent-graphic                 -> --mc-accent
+
+   Unlike Sharp/Alpine's full 3-way accent split or Gunmetal's full
+   collapse, Teal's shape is in between: action-fill and accent-graphic
+   share one value (#10c2c2) but accent-reference (#096c6c) is a third,
+   distinct value. Re-grepped --mc-primary/--mc-primary-hover/--mc-accent's
+   consumers rather than assuming from the value pattern alone - same
+   consumer set every prior stage found (primary button fill/active tab
+   underline for --mc-primary; .btn:focus-visible outline + About-page
+   accent for --mc-accent). accent-reference has no consumer distinct
+   from those two - same category as Sharp's/Alpine's unmapped reference
+   color. Left unmapped.
+
+   surface-hover: re-checked a fourth time (Sharp, Gunmetal, Alpine, now
+   Teal Dark) - same result, hover backgrounds are still per-component,
+   no single shared token. Left unmapped. */
+html[data-theme-family="teal"] {
+    /* Application surfaces */
+    --mc-bg-app: #021818;
+    --mc-bg-workspace: #032424;
+    --mc-bg-panel: #043030;
+    --mc-bg-media-stage: #011112;
+    --mc-card-bg: #053c3c;
+    --mc-button-secondary-bg: #064747;
+    --mc-primary-soft: #096c6c;
+
+    /* Text */
+    --mc-text-primary: #f0fafa;
+    --mc-text-secondary: #c9eeee;
+    --mc-text-muted: #8fc2c2;
+    --mc-text-inverse: #021818;
+
+    /* Borders */
+    --mc-border-soft: #075454;
+    --mc-border: #086060;
+    --mc-button-secondary-border: #0c9292;
+    --mc-border-focus: #51f0f0;
+
+    /* Primary accent */
+    --mc-primary: #10c2c2;
+    --mc-primary-hover: #13ebeb;
+    --mc-accent: #10c2c2;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage6-2">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage7-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
@@ -1971,6 +1971,26 @@
                                 <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_alpine">MeshCenter Alpine</span>
                             </span>
                         </label>
+                        <!-- theme-registry Stage 7.1: label reads "MeshCenter Teal", not
+                             "MeshCenter Teal Dark" - once Teal Light lands and Stage 8.2
+                             flips this family to kind: 'paired', one label needs to cover
+                             all three modes (Auto/Light/Dark), same as "MeshCenter
+                             Original" already does for 'original'. Naming it "Teal Dark"
+                             now would need renaming (and an i18n key change across all 4
+                             catalogs) once Stage 8 lands - avoided by picking the
+                             mode-agnostic name from the start. -->
+                        <label class="workspace-theme-family-option" data-family="teal">
+                            <input type="radio" name="workspaceThemeFamily" value="teal">
+                            <span class="workspace-theme-family-card">
+                                <span class="workspace-theme-swatches" aria-hidden="true">
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--bg"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--panel"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--primary"></span>
+                                    <span class="workspace-theme-swatch workspace-theme-swatch--warning"></span>
+                                </span>
+                                <span class="workspace-theme-family-label" data-i18n="workspace.theme_family_teal">MeshCenter Teal</span>
+                            </span>
+                        </label>
                     </div>
                     <!-- Level 2: Auto/Light/Dark for a paired family, or a single
                          fixed-mode label for a fixed one - rendered by
@@ -2254,7 +2274,7 @@
 
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/chart.umd.min.js"></script>
-<script src="/static/i18n.js?v=20260904-theme-stage6-1"></script>
+<script src="/static/i18n.js?v=20260904-theme-stage7-1"></script>
 <script>
     // Server already resolved "auto" (stored ui.language, or an
     // Accept-Language guess) to a concrete locale for <html lang> above —
@@ -2270,7 +2290,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260904-theme-stage6-1"></script>
+<script src="/static/chat.js?v=20260904-theme-stage7-1"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary

Adds **MeshCenter Teal Dark** as a new theme family, wired provisionally as `kind: 'fixed', mode: 'dark'` — same shape Sharp/Gunmetal/Alpine used during their own single-mode stages, **not** the final shape. This stage covers only the 21 surface/text/border/accent roles.

## Architecture note: this is temporary

Per the source doc, Teal is meant to become a genuine `kind: 'paired'` family once Teal Light exists too (Stage 8), matching `original`. Flagged the conversion point clearly for Stage 8.2:

- `chat.js`: comment on the `WORKSPACE_THEME_FAMILIES` entry explaining the eventual flip.
- `ui-kit.css`: a longer comment above the override block with the same reasoning.
- **Checked whether any code actually assumes a `'fixed'` family's `kind` never changes**: `resolveTheme()` and `renderWorkspaceThemeModeRow()` both re-derive `family.kind`/`family.mode` fresh from the live `WORKSPACE_THEME_FAMILIES` array on every call — neither caches or hardcodes anything. So flipping `teal`'s entry to `kind: 'paired'` in Stage 8.2 should just work with zero changes to either function. Documented this finding for Stage 8.2's benefit rather than leaving it to be rediscovered.

**Naming**: labeled it "MeshCenter Teal" (not "Teal Dark") in the i18n key and markup — once Stage 8.2 lands, one label needs to cover Auto/Light/Dark, same as "MeshCenter Original" already does for all three of its modes. Picking the mode-agnostic name now avoids a rename (and an i18n key change across all 4 catalogs) later.

## No state-color exception — confirmed, not assumed

Re-checked the source doc's section 8.3 specifically for a Teal line: **none exists**, unlike Sharp/Gunmetal/Alpine which each had one. All four state colors (success/warning/danger/info) stay fully unset, inheriting `html[data-theme="dark"]`.

Calling this out explicitly since it has a real consequence: Teal's own bright cyan primary (`--mc-primary`/`--mc-accent`: `#10C2C2`) and the base dark scheme's success green (`--mc-success`: `#72D69A`) have no state-specific differentiation to lean on — both read as "bright, saturated, cool" at a glance. That's Stage 7.2's actual job (the source doc's own stage plan calls for checking distinguishability by shape/label, not just color) — not solved here, and this stage deliberately avoids touching `--mc-success` for anything outside its own role so 7.2 starts clean.

## Token mapping

Re-verified against real consumers rather than assumed to carry over:

| Source role | Token | Note |
|---|---|---|
| surface-app/-workspace/-panel | `--mc-bg-app`/`-workspace`/`-panel` | direct |
| surface-card | `--mc-card-bg` | explicit leaf override |
| surface-control | `--mc-button-secondary-bg` | direct |
| surface-media | `--mc-bg-media-stage` | direct |
| surface-selected | `--mc-primary-soft` | `--mc-accent-soft` follows via the existing alias |
| text-* | matching `--mc-text-*` | direct |
| border-soft/-default | `--mc-border-soft`/`--mc-border` | direct |
| border-control | `--mc-button-secondary-border` | direct |
| focus-ring | `--mc-border-focus` | direct |
| action-fill/-hover | `--mc-primary`/`--mc-primary-hover` | grepped: primary button fill + active tab underline |
| accent-graphic | `--mc-accent` | grepped: `.btn:focus-visible` outline + About-page accent |

Teal's shape is neither Sharp/Alpine's full 3-way split nor Gunmetal's full collapse: `action-fill` and `accent-graphic` share one value (`#10C2C2`), but `accent-reference` (`#096C6C`) is a third, distinct value with no consumer to land on — same category as Sharp's/Alpine's unmapped reference colors.

**`surface-hover`**: re-checked a fourth time (Sharp, Gunmetal, Alpine, now Teal Dark) — same result, hover backgrounds are still per-component, no single shared token. Left unmapped.

## Contrast self-check

All 5 targets from the source doc's section 9 (Teal Dark column) reproduce exactly:

| Pair | Recomputed | Target |
|---|---|---:|
| text-muted vs surface-card | 6.21:1 | 6.21 |
| text-inverse vs action-fill | 8.30:1 | 8.30 |
| accent-graphic vs surface-panel | 6.47:1 | 6.47 |
| border-control vs surface-panel | 3.77:1 | 3.77 |
| focus-ring vs surface-control | 7.54:1 | 7.54 |

## Swatch preview note

Warning slot uses dark's current inherited `#F0C86A` — **permanently**, not a placeholder like Gunmetal's/Alpine's swatches were before their own warning-exception stage, since Teal has no such stage coming (no exception exists at all).

## Registry

Registered all 16 new hex values in `hex_registry.json` under `theme-family-token-value` in this same commit, locations cross-verified against a fresh `grep`.

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean, 1036 known values.
- `check_new_hex.py --diff main...<branch>`: clean too — no unmapped-role comment mentions to trip the known multi-line-comment limitation this time.
- `node --check`, `python -m compileall .`, `python scripts/check-i18n.py`, `pytest` (509 passed, 25 skipped) — all clean.

No dev live-check this stage — that's Stage 7.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)