### PR TITLE
Theme registry Stage 8.1: MeshCenter Teal Light, base tokens (paired version)

### DIFF
--- a/docs/theme-registry/hex_registry.json
+++ b/docs/theme-registry/hex_registry.json
@@ -75,6 +75,14 @@
     ]
   },
   {
+    "value": "075656",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4268"
+    ]
+  },
+  {
     "value": "080D13",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -381,6 +389,14 @@
     "count": 1,
     "locations": [
       "static/style-part3.css:3060"
+    ]
+  },
+  {
+    "value": "123536",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4255"
     ]
   },
   {
@@ -2626,6 +2642,14 @@
     ]
   },
   {
+    "value": "365E60",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4256"
+    ]
+  },
+  {
     "value": "374151",
     "verdict": "ui-normalization-candidate",
     "count": 5,
@@ -3344,6 +3368,14 @@
     ]
   },
   {
+    "value": "527476",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4257"
+    ]
+  },
+  {
     "value": "53657B",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -3535,6 +3567,14 @@
     "count": 1,
     "locations": [
       "static/style-part2.css:3106"
+    ]
+  },
+  {
+    "value": "628E8E",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4263"
     ]
   },
   {
@@ -5295,6 +5335,14 @@
     ]
   },
   {
+    "value": "A8CACA",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4262"
+    ]
+  },
+  {
     "value": "A93E46",
     "verdict": "semantic-status-candidate",
     "count": 1,
@@ -6130,6 +6178,14 @@
     ]
   },
   {
+    "value": "D0E4E4",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4261"
+    ]
+  },
+  {
     "value": "D0E8D0",
     "verdict": "semantic-status-candidate",
     "count": 1,
@@ -6703,6 +6759,14 @@
     ]
   },
   {
+    "value": "D9F5F5",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4252"
+    ]
+  },
+  {
     "value": "D9FFF1",
     "verdict": "theme-family-token-value",
     "count": 1,
@@ -7157,6 +7221,14 @@
     ]
   },
   {
+    "value": "E1EEEE",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4249"
+    ]
+  },
+  {
     "value": "E2BD45",
     "verdict": "ui-normalization-candidate",
     "count": 1,
@@ -7224,6 +7296,14 @@
     "locations": [
       "static/ui-kit.css:1146",
       "static/ui-kit.css:3009"
+    ]
+  },
+  {
+    "value": "E4F1F1",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4251"
     ]
   },
   {
@@ -8161,6 +8241,14 @@
     ]
   },
   {
+    "value": "EEF8F8",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4246"
+    ]
+  },
+  {
     "value": "EEF9F1",
     "verdict": "ui-normalization-candidate",
     "count": 2,
@@ -8325,6 +8413,14 @@
     "locations": [
       "static/style-part1.css:204",
       "static/style-part2.css:3984"
+    ]
+  },
+  {
+    "value": "F0F7F7",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4250"
     ]
   },
   {
@@ -8715,6 +8811,14 @@
     "count": 1,
     "locations": [
       "static/style-part4.css:892"
+    ]
+  },
+  {
+    "value": "F5FAFA",
+    "verdict": "theme-family-token-value",
+    "count": 1,
+    "locations": [
+      "static/ui-kit.css:4247"
     ]
   },
   {

--- a/docs/theme-registry/raw-hex-audit.md
+++ b/docs/theme-registry/raw-hex-audit.md
@@ -1167,3 +1167,25 @@ _16 new unique values (registered in the same commit as the CSS change, location
 | `#F0FAFA` | 1 | static/ui-kit.css:4149 |
 
 Not registered: `accent-reference` (`#096C6C`) has no consumer distinct from `action-fill`/`accent-graphic` (both `--mc-primary`/`--mc-accent`, already mapped) - same category as Sharp's/Alpine's unmapped reference colors. Note this stage is architecturally different from Sharp/Gunmetal/Alpine: Teal has **no state-color exception at all** (confirmed against section 8.3 - no Teal-specific line exists, unlike the other three fixed families which each had one), and is wired provisionally as `kind: 'fixed'` pending Stage 8's Teal Light + Stage 8.2's conversion to `kind: 'paired'` - see the `ui-kit.css`/`chat.js` comments for the full reasoning. No hex was left unregistered due to a fg/fill split judgment call this time (there's no state exception to split).
+
+### Theme-family token value (Stage 8.1 - MeshCenter Teal Light, base tokens)
+
+_13 new unique values (registered in the same commit as the CSS change, locations taken from `check_new_hex.py`'s own output and cross-verified with a fresh `grep` as the last step before committing). This stage also restructured Teal Dark's existing block into `[data-theme-family="teal"][data-theme="dark"]` - a pure selector-scoping change, no value changes, confirmed via `git diff` that every dark-block declaration line was recognized as unchanged, not deleted+re-added - so none of Stage 7.1's already-registered 16 values needed re-registering._
+
+| HEX | Occurrences | Locations |
+|---|---|---|
+| `#123536` | 1 | static/ui-kit.css:4255 |
+| `#365E60` | 1 | static/ui-kit.css:4256 |
+| `#527476` | 1 | static/ui-kit.css:4257 |
+| `#075656` | 1 | static/ui-kit.css:4268 |
+| `#628E8E` | 1 | static/ui-kit.css:4263 |
+| `#A8CACA` | 1 | static/ui-kit.css:4262 |
+| `#D0E4E4` | 1 | static/ui-kit.css:4261 |
+| `#D9F5F5` | 1 | static/ui-kit.css:4252 |
+| `#E1EEEE` | 1 | static/ui-kit.css:4249 |
+| `#E4F1F1` | 1 | static/ui-kit.css:4251 |
+| `#EEF8F8` | 1 | static/ui-kit.css:4246 |
+| `#F0F7F7` | 1 | static/ui-kit.css:4250 |
+| `#F5FAFA` | 1 | static/ui-kit.css:4247 |
+
+Not registered: none new this time - Teal Light is a full accent collapse (`accent-reference`/`action-fill`/`accent-graphic` all share `#096C6C`, same shape as Gunmetal), and `#096C6C`/`#FFFFFF` were already registered (from Teal Dark's `--mc-primary-soft` in Stage 7.1, and the Stage 0 baseline, respectively) - so no unmapped-role hex this stage. No state-color exception either (re-confirmed for Light specifically, not just assumed from Dark - section 8.3 lists exceptions by family, not mode, so Teal's single "no exception" absence covers both halves).

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1082,7 +1082,16 @@ a:focus-visible,
    swatch overrides above. Warning uses dark's current inherited value
    (#f0c86a) PERMANENTLY, not a placeholder - Teal has no warning
    exception at all (section 8.3), unlike Gunmetal/Alpine's swatches
-   which were provisional pending their own 6.2/6.2-shaped stage. */
+   which were provisional pending their own 6.2/6.2-shaped stage.
+
+   Stage 8.1 note: left as-is, still shows only Teal Dark's 4 colors -
+   Teal is still 'fixed'/'dark' until Stage 8.2, so this is still the
+   only Teal state a user can actually pick. Flagging for Stage 8.2: once
+   Teal becomes 'paired', this swatch will need to become mode-aware
+   (reading whichever of dark/light is actually resolved, the way the
+   generic .workspace-theme-swatch--* rules already do for 'original' -
+   or possibly switching to always show one fixed representative mode,
+   your call for that stage) - not built here. */
 .workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--bg { background: #021818; }
 .workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--panel { background: #043030; }
 .workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--primary { background: #10c2c2; }
@@ -4134,8 +4143,20 @@ html[data-theme-family="alpine"] {
 
    surface-hover: re-checked a fourth time (Sharp, Gunmetal, Alpine, now
    Teal Dark) - same result, hover backgrounds are still per-component,
-   no single shared token. Left unmapped. */
-html[data-theme-family="teal"] {
+   no single shared token. Left unmapped.
+
+   Stage 8.1 addendum: adding Teal Light means Teal now needs different
+   tokens depending on MODE, not just family, so this block gained
+   [data-theme="dark"] to scope it - selector changed from
+   html[data-theme-family="teal"] to
+   html[data-theme-family="teal"][data-theme="dark"]. Every declaration
+   below is byte-identical to what shipped in Stage 7.1/7.2/7.3 - this is
+   a pure selector-scoping change, not a value change. kind stays 'fixed'/
+   'dark' in chat.js until Stage 8.2, so data-theme is never actually
+   "light" while data-theme-family is "teal" yet - the new light block
+   below is real CSS that exists but is currently unreachable in the live
+   app, activating for free once Stage 8.2 flips kind to 'paired'. */
+html[data-theme-family="teal"][data-theme="dark"] {
     /* Application surfaces */
     --mc-bg-app: #021818;
     --mc-bg-workspace: #032424;
@@ -4161,5 +4182,90 @@ html[data-theme-family="teal"] {
     --mc-primary: #10c2c2;
     --mc-primary-hover: #13ebeb;
     --mc-accent: #10c2c2;
+}
+
+/* theme-registry Stage 8.1: MeshCenter Teal Light - the second half of
+   Teal, currently inert (see the addendum above the dark block: kind
+   stays 'fixed'/'dark' until Stage 8.2, so data-theme="light" never
+   coexists with data-theme-family="teal" in the live app yet). Scoped
+   the same way as the dark half, against :root instead of
+   html[data-theme="dark"] - needs to win over :root by source order at
+   equal specificity, same reasoning Stage 3.3 established, and will need
+   to win over html[data-theme="dark"] too once reachable (it does, same
+   specificity, later in source order).
+
+   Palette source: MeshCenterthemeregistryplanv0.1.md section 5/6/7/8.1/9
+   (owner-approved, hex values copied verbatim - do not adjust).
+
+   State colors: re-confirmed no Teal exception exists in section 8.3 for
+   Light either - section 8.3 lists exceptions by family name, not by
+   mode, so Teal's single "no exception" absence (already confirmed twice
+   for the family as a whole, Stages 7.1/7.2) necessarily covers both
+   halves, not just Dark. All four stay unset, inheriting :root's base
+   light values by cascade.
+
+   Token mapping: re-verified against :root's (base light) consumers, not
+   assumed to mirror the dark block:
+     surface-app/-workspace/-panel  -> --mc-bg-app/-workspace/-panel
+     surface-card                   -> --mc-card-bg. Unlike the dark
+                                        block (where --mc-card-bg is
+                                        already its own literal), :root
+                                        aliases it to var(--mc-bg-panel) -
+                                        confirmed still true (ui-kit.css
+                                        :root block). This override
+                                        genuinely breaks that alias for
+                                        Teal Light, same framing Sharp
+                                        used on the light side, not
+                                        Gunmetal/Alpine's "plain leaf
+                                        override" framing (that framing
+                                        was dark-specific).
+     surface-control                -> --mc-button-secondary-bg
+     surface-media                  -> --mc-bg-media-stage
+     surface-selected               -> --mc-primary-soft (--mc-accent-soft
+                                        follows via the same alias)
+     text-primary/-secondary/-muted/-inverse -> the matching --mc-text-*
+     border-soft/-default           -> --mc-border-soft/--mc-border
+     border-control                 -> --mc-button-secondary-border
+     focus-ring                     -> --mc-border-focus
+     action-fill/-hover             -> --mc-primary/--mc-primary-hover
+     accent-graphic                 -> --mc-accent
+
+   Unlike Teal Dark's partial split, Teal Light is a full collapse - all
+   three non-hover accent roles (accent-reference/action-fill/
+   accent-graphic) share one value (#096c6c), same shape as Gunmetal.
+   accent-reference lands on the same tokens as action-fill/accent-graphic
+   by value coincidence, not a separate mapping decision - no unmapped
+   role this time, unlike Teal Dark's distinct accent-reference.
+
+   surface-hover: checked a fifth time (Sharp, Gunmetal, Alpine, Teal
+   Dark, now Teal Light) - same result on the light cascade too, hover
+   backgrounds are still per-component, no single shared token. Left
+   unmapped. */
+html[data-theme-family="teal"][data-theme="light"] {
+    /* Application surfaces */
+    --mc-bg-app: #eef8f8;
+    --mc-bg-workspace: #f5fafa;
+    --mc-bg-panel: #ffffff;
+    --mc-bg-media-stage: #e1eeee;
+    --mc-card-bg: #f0f7f7;
+    --mc-button-secondary-bg: #e4f1f1;
+    --mc-primary-soft: #d9f5f5;
+
+    /* Text */
+    --mc-text-primary: #123536;
+    --mc-text-secondary: #365e60;
+    --mc-text-muted: #527476;
+    --mc-text-inverse: #ffffff;
+
+    /* Borders */
+    --mc-border-soft: #d0e4e4;
+    --mc-border: #a8caca;
+    --mc-button-secondary-border: #628e8e;
+    --mc-border-focus: #096c6c;
+
+    /* Primary accent */
+    --mc-primary: #096c6c;
+    --mc-primary-hover: #075656;
+    --mc-accent: #096c6c;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage7-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage8-1">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Adds Teal Light's base tokens and restructures Teal Dark's existing block into a mode-scoped shape, since Teal now needs different tokens depending on *mode*, not just family:

```css
html[data-theme-family="teal"] { ... }
```
becomes
```css
html[data-theme-family="teal"][data-theme="dark"] { ... }   /* Teal Dark, unchanged values */
html[data-theme-family="teal"][data-theme="light"] { ... }  /* Teal Light, new this stage */
```

**No JS changes this stage** — `WORKSPACE_THEME_FAMILIES` still says `{ id: 'teal', kind: 'fixed', mode: 'dark' }`. Since `family.mode` stays hardcoded `'dark'`, the new light block is real CSS that exists in the file but is currently unreachable in the live app — it activates for free once Stage 8.2 flips `kind` to `'paired'`.

## Regression safety — confirmed explicitly, not implied

This stage restructures working Teal Dark code, so this needed real verification, not just "tests pass":

- **Value identity**: confirmed via `git diff` that every one of the dark block's 18 `--mc-*` declaration lines was recognized by git as **unchanged** (not deleted-and-re-added) — only the selector line itself shows as changed. This is the strongest signal available that the restructuring is a pure selector-scoping change with zero value drift.
- **Selector-matching equivalence**: logically airtight independent of the diff. `Workspace.applyTheme()` sets `data-theme` and `data-theme-family` together, synchronously, in one function call, and `resolveTheme()` returns `family.mode` unconditionally for a `'fixed'` family. Since `family.mode` is still hardcoded `'dark'` for `teal` (no JS change this stage), `data-theme-family="teal"` **never** coexists with any `data-theme` value other than `"dark"` in the live app today — so adding the `[data-theme="dark"]` qualifier never changes which real application states the block matches.

## Token mapping — re-verified against `:root` (light), not assumed to mirror the dark block

- **`--mc-card-bg`**: confirmed `:root` still aliases it (`var(--mc-bg-panel)`), unlike the dark block's own literal — so Teal Light's override genuinely *breaks* that alias (Sharp's framing), not a "plain leaf override" (Gunmetal's/Alpine's framing, which was dark-specific).
- **Accent roles**: unlike Teal Dark's partial split (`action-fill`/`accent-graphic` shared, `accent-reference` distinct), Teal Light is a **full collapse** — all three non-hover roles share `#096C6C`, same shape as Gunmetal. No unmapped role this time.
- **State colors**: re-confirmed no Teal exception exists for Light specifically, not just assumed from Dark's own confirmation — section 8.3 lists exceptions by family name, not by mode, so the single "no exception" absence already established for Teal (Stages 7.1/7.2) necessarily covers both halves.
- **`surface-hover`**: re-checked a fifth time (Sharp, Gunmetal, Alpine, Teal Dark, now Teal Light) — still no shared token on the light cascade either. Left unmapped.

## Contrast self-check

All 5 targets from the source doc's section 9 (Teal Light column) reproduce exactly:

| Pair | Recomputed | Target |
|---|---|---:|
| text-muted vs surface-card | 4.70:1 | 4.70 |
| text-inverse vs action-fill | 6.23:1 | 6.23 |
| accent-graphic vs surface-panel | 6.23:1 | 6.23 |
| border-control vs surface-panel | 3.63:1 | 3.63 |
| focus-ring vs surface-control | 5.38:1 | 5.38 |

## Swatch preview — flagged, not built

Teal's swatch CSS still shows only Teal Dark's 4 colors, unchanged — correct for this stage, since Teal is still the only pickable state until Stage 8.2. Added a comment flagging that Stage 8.2 will need to make the swatch mode-aware (or deliberately pick one fixed representative mode) — not built here.

## Registry

Registered all 13 new hex values in `hex_registry.json` under `theme-family-token-value` in this same commit, locations cross-verified against a fresh `grep`. None of Teal Dark's already-registered 16 values needed re-registering (confirmed unchanged, see regression-safety section above).

## Checks run

- `check_new_hex.py static/ui-kit.css` (whole-file): clean, 1049 known values.
- `check_new_hex.py --diff main...<branch>`: clean too.
- `python -m compileall .`, `python scripts/check-i18n.py` (no i18n changes — `workspace.theme_family_teal` already exists from Stage 7.1), `pytest` (509 passed, 25 skipped) — all clean. No JS changed this stage, so `node --check` doesn't apply.
- `?v=` bumped for `ui-kit.css` only.

No live dev verification this stage — that's Stage 8.3. No `kind: 'paired'` conversion — that's Stage 8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)