### PR TITLE
Theme registry Stage 8.2: enable Teal Auto (convert to kind: 'paired')

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -8026,15 +8026,17 @@ const WORKSPACE_THEME_FAMILIES = Object.freeze([
     // theme-registry Stage 6.1: Alpine is a 'fixed', dark-only family - its
     // token overrides live in ui-kit.css under html[data-theme-family="alpine"].
     Object.freeze({ id: 'alpine', kind: 'fixed', mode: 'dark' }),
-    // theme-registry Stage 7.1: Teal Dark, wired provisionally as 'fixed'/
-    // 'dark' - NOT the final shape. Once Teal Light exists (Stage 8), this
-    // becomes a genuine kind: 'paired' entry like 'original' (Stage 8.2).
-    // Every place that assumes a 'fixed' family's kind never changes later
-    // needs to account for this id flipping kind in place - see the
-    // ui-kit.css comment above html[data-theme-family="teal"] for the full
-    // note. Token overrides live in ui-kit.css under
-    // html[data-theme-family="teal"].
-    Object.freeze({ id: 'teal', kind: 'fixed', mode: 'dark' })
+    // theme-registry Stage 7.1/8.1: Teal shipped 'fixed'/'dark', then grew
+    // a Light half (Stage 8.1, html[data-theme-family="teal"][data-theme=
+    // "light"/"dark"]). Stage 8.2 flips this to a genuine 'paired' entry,
+    // same shape as 'original' - no mode field. Verified (not just
+    // trusted from the Stage 7.1 comment) that resolveTheme() and
+    // renderWorkspaceThemeModeRow() both branch on family.kind fresh on
+    // every call and needed zero code changes for this flip; grepped the
+    // whole codebase for any other kind/'teal'-assuming code and found
+    // none. See Workspace.migrateTealFixedToPaired() below for the
+    // one real behavior-change risk this flip has for existing users.
+    Object.freeze({ id: 'teal', kind: 'paired' })
 ]);
 const WORKSPACE_THEME_FAMILY_IDS = WORKSPACE_THEME_FAMILIES.map(family => family.id);
 
@@ -8268,6 +8270,7 @@ const Workspace = {
             this.state = this.sanitize(stored);
             this.migrateLegacyPanelSettings();
             this.migrateLegacyThemeField(stored);
+            this.migrateTealFixedToPaired();
         } catch (error) {
             console.warn('[WORKSPACE] Unable to load preferences:', error);
             this.state = { ...WORKSPACE_DEFAULTS };
@@ -8319,6 +8322,43 @@ const Workspace = {
             this.save();
         } catch (error) {
             console.warn('[WORKSPACE] Theme field migration failed:', error);
+        }
+    },
+
+    // theme-registry Stage 8.2: real behavior-change risk, not incidental.
+    // Before this stage, 'teal' was kind: 'fixed'/'dark', so themeMode was
+    // stored but functionally inert for it - every existing Teal user was
+    // always seeing Teal Dark regardless of whatever themeMode happened to
+    // be sitting in storage (most likely 'auto', the default, since
+    // nothing before this stage ever surfaced a Light/Dark/Auto picker for
+    // Teal to deliberately set it away from that). Now that 'teal' is
+    // kind: 'paired', resolveTheme() actually reads themeMode for it -
+    // an existing user with themeFamily: 'teal' and themeMode: 'auto'
+    // stored would, without this migration, have their theme silently
+    // flip from Teal Dark to Teal Light the moment this deploys, purely
+    // because their OS happens to be in light mode - no click, no
+    // notification. Runs exactly once per browser (guarded by a dedicated
+    // one-time flag, not by presence/absence of a field, since the stored
+    // shape doesn't otherwise distinguish "themeMode never mattered yet"
+    // from "themeMode was a deliberate choice made after Teal went
+    // paired"): if themeFamily is 'teal' at that one moment, pins
+    // themeMode to 'dark' - exactly what every existing Teal user was
+    // already seeing - regardless of whatever themeMode value happened to
+    // be stored, not just when it's 'auto' (a stored 'light'/'dark' was
+    // equally inert and equally wrong to trust). Any later, real switch to
+    // Teal (by this user or a new one) goes through normal resolution,
+    // unaffected - this only ever fires once, ever, per browser.
+    migrateTealFixedToPaired() {
+        try {
+            const MIGRATION_KEY = 'meshcenter.tealPairedMigrationDone';
+            if (localStorage.getItem(MIGRATION_KEY) !== null) return;
+            localStorage.setItem(MIGRATION_KEY, '1');
+            if (this.state.themeFamily === 'teal') {
+                this.state.themeMode = 'dark';
+                this.save();
+            }
+        } catch (error) {
+            console.warn('[WORKSPACE] Teal paired migration failed:', error);
         }
     },
 

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -1078,24 +1078,33 @@ a:focus-visible,
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--primary { background: #426077; }
 .workspace-theme-family-option[data-family="alpine"] .workspace-theme-swatch--warning { background: #ff9a3d; }
 
-/* theme-registry Stage 7.1: same reasoning as the prior fixed families'
-   swatch overrides above. Warning uses dark's current inherited value
-   (#f0c86a) PERMANENTLY, not a placeholder - Teal has no warning
-   exception at all (section 8.3), unlike Gunmetal/Alpine's swatches
-   which were provisional pending their own 6.2/6.2-shaped stage.
+/* theme-registry Stage 7.1/8.1: Teal had its own hardcoded swatch
+   override here (always showing Teal Dark's 4 colors, #021818/#043030/
+   #10c2c2/#f0c86a), needed while Teal was 'fixed'/'dark' since nothing
+   else would show it correctly.
 
-   Stage 8.1 note: left as-is, still shows only Teal Dark's 4 colors -
-   Teal is still 'fixed'/'dark' until Stage 8.2, so this is still the
-   only Teal state a user can actually pick. Flagging for Stage 8.2: once
-   Teal becomes 'paired', this swatch will need to become mode-aware
-   (reading whichever of dark/light is actually resolved, the way the
-   generic .workspace-theme-swatch--* rules already do for 'original' -
-   or possibly switching to always show one fixed representative mode,
-   your call for that stage) - not built here. */
-.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--bg { background: #021818; }
-.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--panel { background: #043030; }
-.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--primary { background: #10c2c2; }
-.workspace-theme-family-option[data-family="teal"] .workspace-theme-swatch--warning { background: #f0c86a; }
+   Stage 8.2: removed. Now that Teal is kind: 'paired' (chat.js), it
+   needs a mode-aware swatch - reading whichever of light/dark is
+   actually resolved, not frozen to one. Decided to let it fall through
+   to the generic .workspace-theme-swatch--* rules above (same as
+   'original', which never had a family-specific override at all) rather
+   than write a new mode-aware ruleset from scratch: those generic rules
+   already read the live --mc-* custom properties, so while Teal is the
+   active family they correctly reflect whichever mode Teal has actually
+   resolved to (Light or Dark), for free.
+
+   Trade-off, accepted deliberately: this also makes Teal's card join
+   'original's existing, already-documented swatch-preview gap (Stage
+   4.1's PR, re-confirmed in every live-verification stage since) - while
+   a DIFFERENT family is active, Teal's card will show that other
+   family's colors instead of its own, same as 'original's card already
+   does. Sharp/Gunmetal/Alpine keep their own dedicated overrides and
+   don't have this gap, because they're still 'fixed' - only the 2
+   'paired' families (original, now teal) share this trade-off. Judged
+   correct-while-active to be more valuable than always-correct-when-
+   inactive for a family whose whole point is having two live-switchable
+   modes; not extending the existing gap to Sharp/Gunmetal/Alpine, which
+   don't have this problem and don't need this trade-off. */
 
 .workspace-theme-family-label {
     font-size: 12px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260901-dock-uptime">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260903-theme-stage3-1">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage8-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage8-2">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
@@ -2290,7 +2290,7 @@
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>
-<script src="/static/chat.js?v=20260904-theme-stage7-1"></script>
+<script src="/static/chat.js?v=20260904-theme-stage8-2"></script>
 <script src="/static/media.js?v=20260818-xss-fix-delete-onclick"></script>
 <script src="/static/weather.js?v=20260815-weather-provider"></script>
 


### PR DESCRIPTION
## Summary

Flips `WORKSPACE_THEME_FAMILIES`'s `teal` entry from `{ kind: 'fixed', mode: 'dark' }` to `{ kind: 'paired' }` (matching `original`'s shape) and enables the Auto/Light/Dark picker, using the Stage 8.1 CSS that's been sitting inert until now.

## Mechanism verification — live-checked, not just trusted from the Stage 7.1/8.1 comments

- Grepped the whole codebase for `kind === 'fixed'` / `kind: 'fixed'` / hardcoded `'teal'` logic beyond `resolveTheme()`/`renderWorkspaceThemeModeRow()`: found nothing else.
- Deployed to dev and verified live:
  - Selecting Teal now renders the full Auto/Light/Dark radiogroup (not the old "Fixed Dark" label) — `#workspaceThemeModeRow` confirmed rendering all 3 options with correct i18n labels ("Auto"/"Light"/"Dark", same shared UI code as `original`'s picker).
  - Explicit Light/Dark selections resolve to the correct Stage 8.1 token blocks: Light → `--mc-bg-app: #eef8f8`, Dark → `--mc-bg-app: #021818`, both exact matches.
  - Auto correctly follows the OS preference for a genuinely new choice (confirmed after the one-time migration below already ran).

## Real migration risk — found, confirmed, and fixed

Before this stage, `themeMode` was stored but functionally inert for Teal (always `kind: 'fixed'/'dark'`). An existing Teal user's stored `themeMode` — most likely `'auto'`, the default, since nothing ever surfaced a picker to change it away from that — would silently start mattering the moment this deploys. **Reproduced live**: seeded `localStorage` with `{themeFamily: 'teal', themeMode: 'auto'}` (simulating an existing user) on a dev instance with the OS in light mode, reloaded — without a fix this resolves to Teal *Light*, a theme flip with no click and no notification.

**Fix**: `Workspace.migrateTealFixedToPaired()`, guarded by a dedicated one-time flag (`meshcenter.tealPairedMigrationDone`) rather than a field-presence check, since the stored shape can't otherwise distinguish "themeMode was inert" from "a deliberate post-8.2 choice." Pins `themeMode` to `'dark'` for any user who had `themeFamily: 'teal'` at that one moment — regardless of what `themeMode` happened to be stored, not just `'auto'` (a stored `'light'`/`'dark'` was equally inert and equally untrustworthy) — exactly preserving what they were already seeing.

**Verified both directions live**:
- Simulated the exact "existing user" scenario above → confirmed the user stays on Teal Dark (`data-theme: "dark"`), `themeMode` gets rewritten to `"dark"` in storage, migration flag gets set.
- Confirmed the fix doesn't over-apply: after the one-time migration already ran, a fresh `Workspace.update({ themeFamily: 'teal', themeMode: 'auto' })` correctly follows the OS preference (resolved to `"light"` in the light-OS dev environment) — Auto genuinely works for real, new choices.

## Swatch preview decision

Removed Teal's hardcoded family-specific swatch override (Stage 7.1/8.1, always showed Dark's 4 colors) so it falls through to the generic `.workspace-theme-swatch--*` rules — same as `original`, which never had a family-specific override at all. This makes Teal's card correctly mode-aware while Teal is the active family, for free, via the live `--mc-*` values.

**Trade-off, accepted deliberately**: this also means Teal's card joins `original`'s existing, already-documented swatch-preview gap — while a *different* family is active, Teal's card will show that other family's colors instead of its own. Sharp/Gunmetal/Alpine keep their own dedicated overrides and don't have this gap, since they're staying `'fixed'`. Judged "correct while active" more valuable than "always correct when inactive" for a family whose whole point is having two live-switchable modes — not extending this trade-off to the 3 families that don't need it.

**Verified live**: swatch background switched from `#021818` (Teal Dark) to `#eef8f8` (Teal Light) as `themeMode` changed, confirming mode-awareness works.

## Checks run

- `node --check static/chat.js` — clean.
- `check_new_hex.py static/ui-kit.css` (whole-file): clean — this stage only *removes* hex (the swatch override), introduces none.
- `python -m compileall .`, `python scripts/check-i18n.py` (no i18n changes — `theme_mode_auto`/`-light`/`-dark` keys already exist and confirmed rendering correctly for Teal), `pytest` (509 passed, 25 skipped) — all clean.
- `?v=` bumped for both `chat.js` and `ui-kit.css`.
- Live-verified on dev (`192.168.2.104`), restored to `main` afterward.

No live dev *acceptance-criteria* writeup this stage (that's Stage 8.3) — the live checking above was to verify the mechanism itself works, a narrower scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)