### PR TITLE
Theme registry Stage 2.4: MeshCenter Light camera/video/media normalization

### DIFF
--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -2257,6 +2257,31 @@ body {
     flex-direction: column;
 }
 
+/* theme-registry Stage 2.4: this section's background/border/text colors are
+   DEAD, shadowed by a later, already-tokenized "shared workspace shell"
+   system spanning Camera/Media/Devices/System/Settings - confirmed live on
+   dev, not assumed:
+   - .video-panel: the real DOM element also carries .mc-workspace-panel,
+     matched by ui-kit.css's .video-panel.mc-workspace-panel /
+     .mc-workspace-panel rules (background: var(--mc-workspace-panel-bg,
+     var(--mc-bg-panel)); border-color: var(--mc-workspace-border,
+     var(--mc-border));) - same 0,2,0 specificity, later file, wins.
+   - .video-header: the real element also carries .mc-workspace-header,
+     matched by ui-kit.css's .video-header.mc-workspace-header rule
+     (background: var(--mc-workspace-header-bg); border-color:
+     var(--mc-workspace-header-border);) for the same reason.
+   - .video-title: the real element also carries .workspace-page-title;
+     style-part3.css's later ".workspace-page-title, .video-title, ..."
+     rule (color: var(--mc-text);) wins by source order at equal (0,1,0)
+     specificity.
+   - .video-subtitle: also hidden entirely by a later
+     ".video-subtitle { display: none; }" override further down this file
+     (VIDEO COMPACT HEADER OVERRIDES) - its color is doubly moot.
+   - .video-refresh-btn(:hover): orphaned markup - grepped every
+     static/*.js template and templates/index.html, this class is never
+     rendered by the current camera UI.
+   None of these are tokenized here since none of it renders; left as raw
+   hex so this isn't re-investigated as a live bug. */
 .video-panel {
     display: flex;
     flex-direction: column;
@@ -2307,6 +2332,11 @@ body {
     transform: translateY(-1px);
 }
 
+/* theme-registry Stage 2.4: dead - this declaration always loses to the
+   later ".video-frame-wrap { background: #e8eaed !important; }" override
+   in this same file (see "СВЕТЛЫЙ ФОН ПОД ВИДЕО" below), which itself is
+   the one normalized in this stage. #important always beats a
+   non-important declaration regardless of specificity or source order. */
 .video-frame-wrap {
     flex: 1;
     min-height: 0;
@@ -2317,6 +2347,12 @@ body {
     padding: 12px;
 }
 
+/* theme-registry Stage 2.4: #000 checked - no shadowing rule found (unlike
+   .video-frame-wrap above), genuinely live. Left raw: a pure-black stream
+   backdrop is a deliberate, theme-invariant convention (confirmed no
+   [data-theme="dark"] override exists for it either - it's simply always
+   black, the same way a <video>/<img> letterbox area commonly is on the
+   web), not a --mc-* semantic role. */
 .camera-stream {
     max-width: 100%;
     max-height: 100%;
@@ -2327,6 +2363,9 @@ body {
     object-fit: contain;
 }
 
+/* theme-registry Stage 2.4: .video-footer is orphaned markup - never
+   rendered by any current template (grepped every static/*.js and
+   templates/index.html), same as .video-refresh-btn above. */
 .video-footer {
     display: flex;
     justify-content: space-between;
@@ -2357,6 +2396,10 @@ body {
 }
 
 /* ===== VIDEO CONTROLS ===== */
+/* theme-registry Stage 2.4: background/border-top-color are dead, shadowed
+   by ui-kit.css's ".video-controls, .video-info-bar, .camera-image-controls,
+   .media-content { background: var(--mc-bg-subtle); border-color:
+   var(--mc-border-soft); }" (same 0,1,0 specificity, later file). */
 .video-controls {
     padding: 10px 14px;
     background: #f5f7fa;
@@ -2376,14 +2419,26 @@ body {
     gap: 4px;
 }
 
+/* theme-registry Stage 2.4: #666 -> --mc-text-secondary (d=44.5), already
+   passes AA (5.44:1 on the live --mc-bg-subtle background above). */
 .control-group label {
     font-size: 11px;
     font-weight: 600;
-    color: #666;
+    color: var(--mc-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
+/* theme-registry Stage 2.4: background/color are dead - shadowed by a later
+   shared selector list in style-part3.css (".map-provider-select,
+   .reference-location-card select, .reference-location-card input,
+   .camera-preset-group select, .control-group select { background-color:
+   #f8fafc; color: #243447; ... }") that spans other, not-yet-normalized
+   domains (map, reference-location settings) - left untouched here since
+   fixing it would reach outside this stage's camera/video/media scope.
+   border-color (unaffected by that rule) is genuinely live but not
+   consolidated: #d5d8dd sits far from every light token (closest
+   --mc-border-soft, d~60+), a distinct value, left raw. */
 .control-group select {
     padding: 6px 8px;
     border: 1px solid #d5d8dd;
@@ -2405,6 +2460,11 @@ body {
     gap: 8px;
 }
 
+/* theme-registry Stage 2.4: checked, left raw - the range track/thumb's
+   #d5d8dd/#1a73e8 aren't close to any light token (track fails even 3:1
+   UI-component contrast pre-existing, same category as the map's signal
+   indicators deferred in Stage 2.3) and this minor slider chrome wasn't
+   named in this stage's scope; not touched. */
 .quality-control input[type="range"] {
     flex: 1;
     height: 4px;
@@ -2432,6 +2492,11 @@ body {
     border: none;
 }
 
+/* theme-registry Stage 2.4: .camera-quality-value is orphaned markup -
+   never rendered by any current template (the live quality-value labels
+   are #videoQualityLabel/#photoQualityLabel below, a different pair of
+   selectors sharing this same declaration block by coincidence). Not
+   tokenized since it never renders. */
 .camera-quality-value{
     display:inline-block;
     min-width:42px;
@@ -2445,6 +2510,8 @@ body {
     font-variant-numeric:tabular-nums;
 }
 
+/* theme-registry Stage 2.4: #1265d6 -> --mc-primary (d=17.1, close),
+   already passes AA (5.44:1 on white). */
 #videoQualityLabel,
 #photoQualityLabel {
     display: inline-block;
@@ -2452,7 +2519,7 @@ body {
 
     text-align: right;
 
-    color: #1265d6;
+    color: var(--mc-primary);
     font-size: 12px;
     font-weight: 600;
     line-height: 1;
@@ -2460,6 +2527,14 @@ body {
     font-variant-numeric: tabular-nums;
 }
 
+/* theme-registry Stage 2.4: .screenshot-btn's background/color are dead,
+   shadowed by ui-kit.css's shared ".screenshot-btn, .primary-btn,
+   .send-btn { background: var(--mc-primary); color: var(--mc-text-inverse);
+   border-color: var(--mc-primary); }" (already tokenized); :hover's
+   background is likewise shadowed by ui-kit's ".screenshot-btn:hover,
+   .primary-btn:hover, .send-btn:hover { background:
+   var(--mc-primary-hover); ... }". .screenshots-btn(:hover) is orphaned -
+   never rendered by any current template. */
 .screenshot-btn, .screenshots-btn {
     padding: 6px 12px;
     border: none;
@@ -2495,6 +2570,8 @@ body {
     background: #d5d0c0;
 }
 
+/* theme-registry Stage 2.4: .camera-info(+span) is orphaned markup - never
+   rendered by any current template, same as .camera-quality-value above. */
 .camera-info {
     display: flex;
     gap: 16px;
@@ -2510,6 +2587,9 @@ body {
     gap: 4px;
 }
 
+/* theme-registry Stage 2.4: orphaned markup - never rendered by any
+   current template (live camera status uses different elements, e.g. the
+   "Camera Online"/"Camera Ready" dock indicator). */
 #cameraStatus {
     color: #4caf50;
     font-weight: 600;
@@ -2611,6 +2691,11 @@ body {
 }
 
 /* ===== ВИДЕО ИНФОРМАЦИОННАЯ СТРОКА ===== */
+/* theme-registry Stage 2.4: background/border-bottom-color are dead, same
+   ui-kit.css shared ".video-controls, .video-info-bar, ..." rule as
+   .video-controls above. color (#333) is NOT touched by that rule and is
+   genuinely live -> --mc-text-primary (d=40.3), already passes AA on the
+   live background (11.98:1). */
 .video-info-bar {
     display: flex;
     justify-content: space-between;
@@ -2618,7 +2703,7 @@ body {
     padding: 6px 14px;
     background: #f0f2f5;
     font-size: 13px;
-    color: #333;
+    color: var(--mc-text-primary);
     border-bottom: 1px solid #e5e8ec;
     flex-shrink: 0;
 }
@@ -2630,19 +2715,30 @@ body {
     font-weight: 600;
 }
 
+/* theme-registry Stage 2.4: #555 -> --mc-text-secondary (d=64.0 - the
+   largest distance consolidated in this stage, but still the closest token
+   and already passes AA, 7.07:1 on the live background). */
 #videoLiveInfo {
-    color: #555;
+    color: var(--mc-text-secondary);
     font-weight: 500;
 }
 
 /* ===== СВЕТЛЫЙ ФОН ПОД ВИДЕО ===== */
+/* theme-registry Stage 2.4: this is the LIVE .video-frame-wrap background -
+   !important always wins over the non-important #101820 declaration
+   earlier in this file (see comment there) and over ui-kit.css's own two
+   (also non-important) attempts to tokenize this exact property with
+   var(--mc-bg-media-stage) (ui-kit.css ~L148 and ~L677) - both lost to
+   this raw-hex !important hack despite being semantically the intended
+   token. #e8eaed -> --mc-bg-media-stage (d=5.9, near-exact) - the fix
+   below finally connects this rule to the token already meant for it. */
 .video-frame-wrap {
     flex: 1;
     min-height: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #e8eaed !important;
+    background: var(--mc-bg-media-stage) !important;
     padding: 12px;
 }
 

--- a/static/style-part2.css
+++ b/static/style-part2.css
@@ -1020,19 +1020,30 @@ body.context-chat-mode .settings-view {
     letter-spacing: .03em;
 }
 
+/* theme-registry Stage 2.4: this is the live light .camera-defaults-btn
+   (the html[data-theme="dark"] .camera-defaults-btn pair in ui-kit.css,
+   tokenized in Stage 1.4, only applies in dark and doesn't shadow this).
+   border #cbd5e1 -> --mc-border (d=18.6). background #f8fafc ->
+   --mc-bg-subtle (d=1.4, near-exact). color #475569 ->
+   --mc-text-secondary (d=49.6, the closest token, already passes AA
+   7.24:1 on the live background). :hover background #eef3f8 ->
+   --mc-bg-muted (d=0.0, exact). :hover border-color #aeb9c8 is left raw -
+   nearest token (--mc-text-muted, d=57.8) is a text role, not a border
+   role, the same "don't force onto an unrelated token" case Stage 2.1
+   flagged for --mc-bg-media-stage. */
 .camera-defaults-btn {
     height: 25px;
     padding: 0 9px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--mc-border);
     border-radius: 6px;
-    background: #f8fafc;
-    color: #475569;
+    background: var(--mc-bg-subtle);
+    color: var(--mc-text-secondary);
     font-size: 11px;
     cursor: pointer;
 }
 
 .camera-defaults-btn:hover {
-    background: #eef3f8;
+    background: var(--mc-bg-muted);
     border-color: #aeb9c8;
 }
 
@@ -1047,20 +1058,25 @@ body.context-chat-mode .settings-view {
     min-width: 0;
 }
 
+/* theme-registry Stage 2.4: #526178 -> --mc-text-secondary (d=28.1, close),
+   same value/role as .camera-white-balance-group label and
+   .camera-preset-group label in style-part3.css. */
 .camera-control-slider label {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
     margin-bottom: 1px;
-    color: #526178;
+    color: var(--mc-text-secondary);
     font-size: 10px;
     line-height: 1.2;
     text-transform: uppercase;
 }
 
+/* theme-registry Stage 2.4: #1265d6 -> --mc-primary (d=17.1, close), same
+   value as #videoQualityLabel/#photoQualityLabel in style-part1.css. */
 .camera-control-slider label span {
-    color: #1265d6;
+    color: var(--mc-primary);
     font-variant-numeric: tabular-nums;
     font-weight: 600;
 }

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -395,6 +395,14 @@
     padding-top: 5px;
 }
 
+/* theme-registry Stage 2.4: .camera-control-tab(:hover/.active)'s colors
+   are DEAD - ui-kit.css already carries a fully tokenized, unscoped
+   ".camera-control-tab, .node-detail-tab { background: var(--mc-tab-bg);
+   color: var(--mc-tab-text); ... }" rule set (~L189-218) at the same
+   specificity, in a later-loaded file - confirmed live on dev (active tab
+   renders var(--mc-primary) text, inactive renders var(--mc-tab-bg)/
+   var(--mc-tab-text), neither matches the raw values below). Left
+   un-normalized since none of it renders. */
 .camera-control-tab {
     min-width: 92px;
     height: 37px;
@@ -435,8 +443,14 @@
     white-space: nowrap;
 }
 
+/* theme-registry Stage 2.4: #9aa8ba -> --mc-text-muted (d=28.0, closest
+   token), but both the original and --mc-text-muted itself fail AA on
+   white (2.42:1 / 2.95:1) - consolidated anyway as the closest semantic
+   match (a subtle separator glyph, not a full text label), not darkened
+   further to fix the pre-existing failure, same scope boundary as the
+   node-card identity-row labels flagged in Stage 2.2. */
 .camera-status-divider {
-    color: #9aa8ba;
+    color: var(--mc-text-muted);
 }
 
 #videoStatus {
@@ -497,24 +511,38 @@
     width: min(220px, 100%);
 }
 
+/* theme-registry Stage 2.4: #526178 -> --mc-text-secondary (d=28.1),
+   already passes AA (6.29:1 on white). */
 .camera-preset-group label,
 .camera-white-balance-group label {
-    color: #526178;
+    color: var(--mc-text-secondary);
     font-size: 10px;
     font-weight: 600;
     letter-spacing: .05em;
     text-transform: uppercase;
 }
 
+/* theme-registry Stage 2.4: .camera-preset-group select's own
+   background/border/color here are dead - a later, unrelated shared
+   selector list further down this file (".map-provider-select,
+   .reference-location-card select, .reference-location-card input,
+   .camera-preset-group select, .control-group select { background-color:
+   #f8fafc; color: #243447; ... }") wins for that class specifically,
+   spanning map/settings domains not yet normalized - left untouched, same
+   reasoning as .control-group select in style-part1.css. This rule IS
+   still live for .camera-white-balance-group select (not listed in that
+   other selector) - #ffffff -> --mc-bg-panel (d=0, exact), #243b5a ->
+   --mc-text-primary (d=41.3, already passes AA 11.36:1), #cfd8e5 ->
+   --mc-border (d=12.4). */
 .camera-preset-group select,
 .camera-white-balance-group select {
     width: 100%;
     height: 34px;
     padding: 5px 9px;
-    border: 1px solid #cfd8e5;
+    border: 1px solid var(--mc-border);
     border-radius: 7px;
-    background: #ffffff;
-    color: #243b5a;
+    background: var(--mc-bg-panel);
+    color: var(--mc-text-primary);
     font-size: 12px;
 }
 
@@ -622,6 +650,24 @@
     flex-direction: column;
 }
 
+/* theme-registry Stage 2.4: every var(--color-*, fallback) in this block
+   (.media-panel/.media-header/.media-title/.media-subtitle, and
+   .media-view above at ~L649) references a custom property that is never
+   defined anywhere in this codebase (grepped every static/*.css) - the
+   fallback literal is unconditionally what would render IF nothing else
+   won, a different, worse situation than the --theme-*/--mc-legacy-*
+   chain waypoint-tools uses (that one is real and out of scope; this one
+   was always broken). It's moot either way here: all four rules are
+   additionally shadowed by real, working --mc-* rules -
+   .media-panel/.media-header by ui-kit.css's tokenized
+   .mc-workspace-panel/.mc-workspace-header shell (same mechanism as
+   .video-panel/.video-header above, confirmed live: the real DOM elements
+   carry .mc-workspace-panel/.mc-workspace-header), .media-title/
+   .media-subtitle by this same file's own later ".workspace-page-title,
+   .video-title, .media-title, ... { color: var(--mc-text); }" /
+   ".workspace-page-subtitle, .video-subtitle, .media-subtitle, ... {
+   color: var(--mc-muted); }" rules ("UI/UX POLISH" section below). Left
+   as-is since none of it renders either way. */
 .media-panel {
     display: flex;
     flex-direction: column;
@@ -657,6 +703,14 @@
     font-size: 12px;
 }
 
+/* theme-registry Stage 2.4: dead - a higher-specificity ".mc-refresh-btn,
+   .media-refresh-btn.mc-refresh-btn, .system-refresh-btn.mc-refresh-btn"
+   rule further down this file (0,2,0, the real DOM element also carries
+   .mc-refresh-btn) wins over this plain 0,1,0 rule for every property,
+   AND is already fully tokenized (var(--mc-button-secondary-bg/-border/
+   -text)) - confirmed live on dev. Left un-normalized since it never
+   renders; :hover follows the same pattern via ui-kit.css's own
+   .media-refresh-btn:hover rule. */
 .media-refresh-btn,
 .media-primary-btn {
     border: 1px solid #cbd8e6;

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -2674,6 +2674,15 @@ html[data-theme="dark"] #nodeDetails .node-detail-radio .radio-param {
     visibility: hidden !important;
 }
 
+/* theme-registry Stage 2.4: already tokenized - these were generic
+   placeholder fallback literals (Tailwind slate-palette values, never
+   calibrated to either MeshCenter theme) that var() never actually
+   reaches since --mc-border/--mc-surface/--mc-text-secondary/
+   --mc-text-primary are always defined at :root. Updated to the real
+   current light values (this rule is unscoped, effectively serving light
+   - dark gets its own values via the html[data-theme="dark"] override
+   below) for documentation accuracy, same as Stage 1.3/2.3's fallback
+   cleanups. Zero visual effect. */
 .camera-loading-placeholder {
     position: absolute;
     inset: 12px;
@@ -2683,10 +2692,10 @@ html[data-theme="dark"] #nodeDetails .node-detail-radio .radio-param {
     align-content: center;
     justify-content: center;
     gap: 9px;
-    border: 1px solid var(--mc-border, #334155);
+    border: 1px solid var(--mc-border, #d7e0ea);
     border-radius: 8px;
-    background: var(--mc-surface, #f8fafc);
-    color: var(--mc-text-secondary, #64748b);
+    background: var(--mc-surface, #ffffff);
+    color: var(--mc-text-secondary, #58708f);
     text-align: center;
     pointer-events: none;
 }
@@ -2695,6 +2704,10 @@ html[data-theme="dark"] #nodeDetails .node-detail-radio .radio-param {
     display: grid;
 }
 
+/* theme-registry Stage 2.4: checked, left raw - #3b82f6 (a blue not equal
+   to --mc-primary, d=43.3) has no [data-theme="dark"] override anywhere,
+   so it's a theme-invariant spinner accent (same category as the map's
+   marker/legend colors in Stage 2.3), not a --mc-* semantic role. */
 .camera-loading-spinner {
     width: 28px;
     height: 28px;
@@ -2705,7 +2718,7 @@ html[data-theme="dark"] #nodeDetails .node-detail-radio .radio-param {
 }
 
 .camera-loading-title {
-    color: var(--mc-text-primary, #1e293b);
+    color: var(--mc-text-primary, #10233f);
     font-size: 13px;
     font-weight: 700;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,11 +6,11 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-2">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-2">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260903-theme-stage1-7">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-4">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-4">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-4">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-4">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Light counterpart of Stage 1.4 (dark, PR #177) for the camera/video/media domain — applies Stage 2.1-2.3's RGB-distance + contrast judgment methodology rather than 1.4's exact-match-only rule.

### Same live-vs-dead lesson as Stage 2.2/2.3, at a larger scale

This domain turned out to be almost entirely shadowed by an already-tokenized "shared workspace shell" system (`ui-kit.css`'s `.mc-workspace-panel`/`.mc-workspace-header`, a marker-class pair the real video/media panel elements already carry) plus a "UI/UX POLISH — SHARED WORKSPACE DESIGN SYSTEM" section later in `style-part3.css` itself. Nearly every "known starting point" named in the brief turned out dead — confirmed live on dev, not assumed:

- `.video-panel`/`.video-header`/`.video-title`/`.media-panel`/`.media-header`/`.media-title`/`.media-subtitle`: all shadowed by the tokenized shared shell/design-system rules.
- `.media-panel`/`.media-header`/`.media-title`/`.media-subtitle` additionally reference `var(--color-*, fallback)` — custom properties that are **never defined anywhere** in this codebase, a different (and worse) situation than the real `--theme-*`/`--mc-legacy-*` chain `waypoint-tools` uses. Moot either way since the tokenized shell wins regardless.
- `.video-frame-wrap`'s dark backdrop (`#101820`, the brief's own "known starting point") is itself dead — shadowed by a raw-hex `!important` override further down the same file (`#e8eaed`). That `!important` rule IS the live one, and turned out to be a near-exact match (d=5.9) for `--mc-bg-media-stage` — a token `ui-kit.css` already tried to apply here **twice**, both attempts losing to the `!important` hack. Fixed by pointing the winning rule at the token instead.
- `.camera-control-tab(:hover/.active)`: dead, shadowed by `ui-kit.css`'s own already-tokenized version (same pattern as Stage 2.2's node-card and Stage 2.3's map-card discoveries).
- `.screenshot-btn(:hover)` and `.media-refresh-btn`/`.media-primary-btn(:hover)`: both dead, shadowed by shared cross-component button rules in `ui-kit.css` that are already fully tokenized.
- `.video-footer`/`.video-refresh-btn(:hover)`/`.camera-info(+span)`/`.camera-quality-value`/`#cameraStatus`/`.screenshots-btn(:hover)`: orphaned markup, never rendered by any current template (grepped every `static/*.js` and `templates/index.html`).
- `.camera-loading-placeholder`/`.camera-loading-title` (`ui-kit.css`) were already tokenized; only their `var()` fallback literals were stale (generic Tailwind slate values, never calibrated to either theme) — fixed for documentation accuracy, zero visual effect, same as Stage 1.3/2.3's fallback cleanups.

### Genuinely live and normalized

| Selector | Raw hex | Token | Contrast |
|---|---|---|---|
| `.video-frame-wrap` (winning `!important` rule) | `#e8eaed` | `--mc-bg-media-stage` | surface, n/a |
| `.camera-white-balance-group select` | `#fff`/`#243b5a`/`#cfd8e5` | `--mc-bg-panel`/`--mc-text-primary`/`--mc-border` | 11.36:1 |
| `.camera-preset-group`/`.camera-white-balance-group label` | `#526178` | `--mc-text-secondary` | 6.29:1 |
| `.camera-defaults-btn` | `#f8fafc`/`#475569`/`#cbd5e1` | `--mc-bg-subtle`/`--mc-text-secondary`/`--mc-border` | 7.24:1 |
| `.camera-defaults-btn:hover` bg | `#eef3f8` | `--mc-bg-muted` (exact) | n/a |
| `.camera-control-slider label` / `span` | `#526178` / `#1265d6` | `--mc-text-secondary` / `--mc-primary` | pass |
| `#videoQualityLabel`/`#photoQualityLabel` | `#1265d6` | `--mc-primary` | 5.44:1 |
| `.control-group label` | `#666` | `--mc-text-secondary` | 5.44:1 |
| `.video-info-bar` color | `#333` | `--mc-text-primary` | 11.98:1 |
| `#videoLiveInfo` | `#555` | `--mc-text-secondary` (d=64.0, largest in this stage) | 7.07:1 |
| `.camera-status-divider` | `#9aa8ba` | `--mc-text-muted` (pre-existing AA gap, not fixed) | 2.42:1 |

Left raw, checked and documented: `.camera-stream`'s `#000` backdrop (theme-invariant, no dark override exists — confirmed the same way Stage 2.3 confirmed the map canvas), `.camera-defaults-btn:hover`'s border-color (`#aeb9c8`, nearest token is a text role not a border role — the same "don't force onto an unrelated token" trap Stage 2.1 flagged), `.control-group select`'s border (`#d5d8dd`, far from every token), `.quality-control` range track/thumb (minor slider chrome, pre-existing contrast gap not in this stage's scope), `.camera-loading-spinner`'s blue accent (theme-invariant, no dark override).

### Out of scope, noted

`.camera-power-btn`/`.camera-source-select`/`.camera-off-*` ("CAMERA POWER CONTROL", a distinct sub-feature not named in this stage's component list, and `.camera-off-*` is explicitly already-tokenized/out-of-scope per Stage 1.4's own PR), and the media gallery toolbar/summary/sort internals (`.media-toolbar`/`.media-summary`/`.media-sort-label`) — only the panel surface (panel/header/title/subtitle/refresh button) matches the domain boundary's "media panel surface" wording, matching Stage 2.3's `dock-map-btn`/`map-layout-popover` exclusion.

No new hex values introduced (`check_new_hex.py`: OK, 1049 known values). No visual redesign — verified via live render comparison in both Light and Dark on dev.

## Test plan

- [x] `check_new_hex.py` on all 4 changed files: OK, no unregistered hex
- [x] `python -m compileall .`: OK
- [x] `scripts/check-i18n.py`: OK, catalogs in sync
- [x] Deployed to dev (192.168.2.104), live-verified computed styles for every changed selector resolve to the intended token (Mode tab, Image tab, loading placeholder in its visible/connecting state)
- [x] Visual check in Light and Dark workspace themes on dev — confirmed dark mode completely unaffected by computed-style inspection (`.video-frame-wrap`, `.camera-defaults-btn`, `.camera-white-balance-group select` all still resolve to Stage 1.4's dark values)
- [x] Dev restored to `main` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)