### PR TITLE
Theme registry Stage 2.5: MeshCenter Light telemetry/CPU/battery normalization

### DIFF
--- a/static/chat-telemetry.js
+++ b/static/chat-telemetry.js
@@ -674,24 +674,21 @@ function renderTelemetryChart(container, records, type) {
     // per-series line/fill colors (SENSOR_COLORS/SENSOR_BG_COLORS) already
     // work on a dark background and are left untouched.
     //
-    // theme-registry Stage 1.5b: every dark-mode literal below (tickColor,
-    // the legend label color, and the four tooltip colors further down)
-    // was checked individually against the full --mc-* dark token table in
-    // ui-kit.css's html[data-theme="dark"] block - none of them are an
-    // exact match for any token (closest misses: tickColor #a0aec0 vs
-    // --mc-chat-muted #9fb0c3 off by 1-3 per channel, tooltip background
-    // #0f1923 vs --mc-bg-media-stage #101923 off by 1 on red only), so
-    // they stay hardcoded literals rather than being wired through
-    // getComputedStyle(document.documentElement).getPropertyValue('--mc-*')
-    // - there's no existing token to read. Candidates for a dedicated
-    // chart-chrome token set in Stage 3.1, same category as the raw
-    // telemetry-card/battery colors from Stage 1.5a. (No getComputedStyle
-    // precedent exists anywhere else in this codebase for reading --mc-*
-    // from JS either, for what it's worth - moot here since nothing
-    // matched, but noted in case Stage 3.1 wants to establish one.)
+    // theme-registry Stage 1.5b checked every dark-mode literal below
+    // against the dark --mc-* table (no exact match, left raw). Stage 2.5
+    // now checks the LIGHT literals (tickColor, legend label color, and
+    // the four tooltip colors further down) against the light --mc-* table
+    // for the first time - same RGB-distance/contrast rigor as the CSS
+    // side of this stage. No getComputedStyle(--mc-*) precedent exists
+    // anywhere in this codebase (confirmed again), so matches are
+    // hardcoded as the token's plain literal value rather than read at
+    // runtime, same style every other chart-chrome literal here already
+    // uses. tickColor #666 -> --mc-text-secondary (d=44.5) - same literal
+    // Stage 2.4 already consolidated for .control-group label, hardcoded
+    // here as its resolved hex (#58708f) since JS can't read the token.
     const isDark = document.documentElement.dataset.theme === 'dark';
     const gridColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
-    const tickColor = isDark ? '#a0aec0' : '#666';
+    const tickColor = isDark ? '#a0aec0' : '#58708f';
 
     const labels = records.map(r => {
         const t = new Date(r.timestamp * 1000);
@@ -900,19 +897,28 @@ function renderTelemetryChart(container, records, type) {
                         position: 'top',
                         // raw: no exact --mc-* match, see the Stage 1.5b
                         // comment near isDark/tickColor above
-                        labels: { usePointStyle: true, padding: 15, font: { size: 11 }, color: isDark ? '#cbd5e0' : '#333' }
+                        // theme-registry Stage 2.5: light #333 -> --mc-text-primary
+                        // (d=40.3), same literal Stage 2.4 already consolidated
+                        // for .video-info-bar's color, hardcoded here as its
+                        // resolved hex (#10233f) since JS can't read the token.
+                        labels: { usePointStyle: true, padding: 15, font: { size: 11 }, color: isDark ? '#cbd5e0' : '#10233f' }
                     },
                     tooltip: {
-                        // raw: no exact --mc-* match for any of these four
-                        // (bodyColor intentionally reuses the same literal
-                        // as the legend label color above - both were
-                        // '#cbd5e0' already, kept as one shared shade for
-                        // now rather than split into two independent
-                        // copies); see the Stage 1.5b comment near
-                        // isDark/tickColor above
+                        // theme-registry Stage 2.5: light backgroundColor/borderColor
+                        // stay raw - both are semi-transparent rgba() (a floating
+                        // tooltip deliberately lets a hint of the chart show
+                        // through), and --mc-* tokens are opaque hex, no direct
+                        // equivalent to hardcode. titleColor light #333 ->
+                        // --mc-text-primary (same as the legend color above,
+                        // #10233f). bodyColor light #666 -> --mc-text-secondary
+                        // (same as tickColor above, #58708f) - intentionally kept
+                        // as the same shared shade as before (bodyColor reused
+                        // tickColor/legend's un-tokenized literal already), not
+                        // split into independent copies now that they resolve to
+                        // two different tokens rather than one shared literal.
                         backgroundColor: isDark ? '#0f1923' : 'rgba(255,255,255,0.95)',
-                        titleColor: isDark ? '#e2e8f0' : '#333',
-                        bodyColor: isDark ? '#cbd5e0' : '#666',
+                        titleColor: isDark ? '#e2e8f0' : '#10233f',
+                        bodyColor: isDark ? '#cbd5e0' : '#58708f',
                         borderColor: isDark ? '#263c52' : 'rgba(0,0,0,0.1)',
                         borderWidth: 1,
                         callbacks: {

--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -666,6 +666,22 @@ body {
 .sidebar.hidden { display: none; }
 
 /* ===== BASE CARD ===== */
+/* theme-registry Stage 2.5: this whole block's background/text colors are
+   dead - confirmed live on dev. .base-card/.sensors-card's own background
+   is reset to transparent by style-part3.css's higher-specificity
+   ".node-info-panel > .base-card, .node-info-panel > .sensors-card,
+   .node-info-panel > .telemetry-section { background: transparent; ... }"
+   (0,2,0 vs this rule's 0,1,0) - the real card chrome now comes from the
+   shared .node-info-panel wrapper itself (see style-part3.css). Sensor
+   text colors (.sensors-title/.sensor-label/.sensor-value/.sensor-unit/
+   .sensor-update) are separately shadowed by style-part3.css's
+   .node-info-panel-scoped versions (same specificity, later file/later in
+   cascade - the live winners, normalized in this stage, are documented
+   there). .base-card-title/.base-status-line are orphaned entirely -
+   grepped every static/*.js template, the live .base-card only ever
+   renders a node-manager-entry button (.base-node-avatar/
+   .base-node-name-stack/#baseNodeName), never these classes. Left as raw
+   hex since none of it renders. */
 .base-card {
     background: linear-gradient(135deg, #e8f0f8, #d5e0ec);
     padding: 8px 14px;
@@ -724,12 +740,23 @@ body {
 .sensor-value { font-weight: 600; color: #1a3a2a; }
 .sensor-unit { color: #aaa; font-size: 9px; }
 
+/* theme-registry Stage 2.5: border-top-color is dead - style-part2.css's
+   ".battery-indicator, .base-reference-location" rule sets the full
+   border shorthand (all four sides) at equal specificity, later file,
+   overriding this top-only declaration for the top side too - and that
+   rule is itself dead for .battery-indicator (shadowed again by
+   style-part3.css's .node-info-panel .battery-indicator, higher
+   specificity - see that comment). margin-top/padding-top are untouched
+   by either and stay live. */
 .battery-indicator {
     margin-top: 6px;
     padding-top: 6px;
     border-top: 1px solid #d5d8dd;
 }
 
+/* theme-registry Stage 2.5: dead - style-part3.css's later, equal-
+   specificity .battery-bar wins (normalized in this stage, see that
+   comment). */
 .battery-bar {
     width: 100%;
     height: 6px;
@@ -738,6 +765,9 @@ body {
     overflow: hidden;
 }
 
+/* theme-registry Stage 2.5: genuinely live (no shadowing rule found) but
+   out of scope - a battery charge-level status color, see the comment on
+   style-part3.css's .battery-fill rule for the full reasoning. */
 .battery-fill {
     height: 100%;
     background: linear-gradient(90deg, #4caf50, #8bc34a);
@@ -745,6 +775,9 @@ body {
     border-radius: 4px;
 }
 
+/* theme-registry Stage 2.5: dead - shadowed by style-part3.css's
+   .node-info-panel .sensors-title .sensor-update (normalized in this
+   stage, see that comment). */
 .sensor-update { font-size: 9px; color: #aaa; margin-top: 4px; }
 
 /* ===== SIDEBAR TABS ===== */
@@ -1776,6 +1809,9 @@ body {
 /* ============================================================
    ТЕЛЕМЕТРИЯ
    ============================================================ */
+/* theme-registry Stage 2.5: background/border-top-color are dead, same
+   .node-info-panel > .telemetry-section reset as .base-card/.sensors-card
+   above. */
 .telemetry-section {
     padding: 4px 10px;
     border-top: 1px solid #d5d8dd;
@@ -1783,6 +1819,11 @@ body {
     background: #f5f7fa;
 }
 
+/* theme-registry Stage 2.5: #3a5a7a is genuinely not overridden by any
+   later rule, but it never actually paints - the live .telemetry-header
+   only ever wraps .telemetry-title/.telemetry-status (both fully covered
+   by their own, more specific colors, normalized in style-part3.css),
+   with no other direct text content of its own. Left raw. */
 .telemetry-header {
     display: flex;
     justify-content: space-between;
@@ -1799,6 +1840,8 @@ body {
     gap: 4px;
 }
 
+/* theme-registry Stage 2.5: dead - shadowed by style-part3.css's
+   .node-info-panel .telemetry-status (normalized in this stage). */
 .telemetry-header .telemetry-status {
     font-size: 9px;
     font-weight: 400;
@@ -1811,6 +1854,13 @@ body {
     padding: 2px 0;
 }
 
+/* theme-registry Stage 2.5: .telemetry-btn's base border/background are
+   live but out of scope - per-category modifier classes further down
+   this file (.telemetry-btn.environment, etc., one per telemetry chart
+   category) recolor each button to match its chart's own data-series
+   color, the same categorical/theme-independent system as
+   SENSOR_COLORS/SENSOR_BG_COLORS in chat.js, explicitly excluded from
+   this stage. */
 .telemetry-btn {
     flex: 1;
     padding: 4px 10px 5px 10px;

--- a/static/style-part2.css
+++ b/static/style-part2.css
@@ -2214,6 +2214,10 @@ body.context-chat-mode .settings-view {
     gap: 8px;
 }
 
+/* theme-registry Stage 2.5: .base-card-name/.base-card-caption are
+   orphaned - never rendered by any current template (the live .base-card
+   only renders a node-manager-entry button, see style-part1.css's
+   comment). */
 .base-card-name {
     min-width: 0;
     overflow: hidden;
@@ -2272,6 +2276,13 @@ body.context-chat-mode .settings-view {
     border-top: 1px solid #d5d8dd;
 }
 
+/* theme-registry Stage 2.5: dead for both consumers - .battery-indicator's
+   border/background are shadowed by style-part3.css's higher-specificity
+   .node-info-panel .battery-indicator (normalized in that file), and
+   .base-reference-location's are overridden by its own more specific
+   rule further down THIS file (same specificity, later in cascade - see
+   .base-reference-location below). Left raw since neither consumer
+   renders this. */
 .battery-indicator,
 .base-reference-location {
     min-width: 0;
@@ -2287,6 +2298,12 @@ body.context-chat-mode .settings-view {
     align-self: stretch;
 }
 
+/* theme-registry Stage 2.5: genuinely live (single, unshadowed
+   declaration), checked, left raw - #315b3d/#216b36 are a distinct
+   "location green" brand accent, the same family as
+   .base-reference-location/.reference-card-name below (d=65.0/74.5 from
+   --mc-text-primary, too far and the wrong hue to force onto a generic
+   text token). */
 .base-mini-card-heading {
     display: flex;
     align-items: center;
@@ -2308,14 +2325,25 @@ body.context-chat-mode .settings-view {
     height: 7px;
 }
 
+/* theme-registry Stage 2.5: this is the live winning declaration for
+   .base-reference-location (later in this file than the shared rule
+   above, same specificity). color #29485d -> --mc-text-primary (d=53.8,
+   same dark-navy family, already passes AA 8.87:1) - consolidated, same
+   category as other stages' d~50-65 body-text consolidations. background
+   #eef8f1 -> --mc-success-soft (d=5.1, near-exact) - consolidated, this
+   card represents an active/set reference location, a positive state
+   --mc-success-soft already models. border-color #9ecbb0 is left raw -
+   d=56.0 from the nearest token (--mc-text-muted, a text role, not a
+   border role) - a distinct "location green" border accent, same family
+   as .reference-card-name/.base-mini-card-heading. */
 .base-reference-location {
     display: flex;
     align-items: center;
     gap: 7px;
     width: 100%;
-    color: #29485d;
+    color: var(--mc-text-primary);
     border-color: #9ecbb0;
-    background: #eef8f1;
+    background: var(--mc-success-soft);
     font-family: inherit;
     text-align: left;
     cursor: pointer;
@@ -2325,16 +2353,27 @@ body.context-chat-mode .settings-view {
         transform 150ms ease;
 }
 
+/* theme-registry Stage 2.5: background #e2f3e7 -> --mc-success-soft
+   (d=12.4) - consolidated, same reasoning as the base state above.
+   border-color #6fac88 left raw - same "location green" border family as
+   the base state's #9ecbb0 (a darkened hover variant of it), not a
+   generic token role. */
 .base-reference-location:hover {
     border-color: #6fac88;
-    background: #e2f3e7;
+    background: var(--mc-success-soft);
     transform: translateY(-1px);
 }
 
+/* theme-registry Stage 2.5: this is the disabled state - deliberately
+   neutral/gray, not part of the "location green" family above. color
+   #687585 failed AA on the live background (4.26:1) - darkened to
+   --mc-text-secondary (4.62:1, PASS, d=19.5). border-color #ccd3dc ->
+   --mc-border (d=22.0). background #f2f4f7 -> --mc-bg-muted (d=4.2,
+   near-exact). */
 .base-reference-location.reference-is-disabled {
-    color: #687585;
-    border-color: #ccd3dc;
-    background: #f2f4f7;
+    color: var(--mc-text-secondary);
+    border-color: var(--mc-border);
+    background: var(--mc-bg-muted);
 }
 
 .reference-card-icon {
@@ -2350,8 +2389,10 @@ body.context-chat-mode .settings-view {
     gap: 1px;
 }
 
+/* theme-registry Stage 2.5: #617184 -> --mc-text-secondary (d=14.2),
+   already passes AA (4.60:1 on the live #eef8f1 background). */
 .reference-card-title {
-    color: #617184;
+    color: var(--mc-text-secondary);
     font-size: 8px;
     font-weight: 700;
     line-height: 1.15;
@@ -2359,6 +2400,10 @@ body.context-chat-mode .settings-view {
     letter-spacing: .04em;
 }
 
+/* theme-registry Stage 2.5: checked, left raw - #214d35 is the same
+   "location green" brand family as .base-mini-card-heading/
+   .base-reference-location's border above (d=46.4 from --mc-text-primary,
+   the wrong hue to force onto a generic text token). */
 .reference-card-name {
     overflow: hidden;
     color: #214d35;
@@ -2369,13 +2414,18 @@ body.context-chat-mode .settings-view {
     white-space: nowrap;
 }
 
+/* theme-registry Stage 2.5: this is the disabled-state name color,
+   deliberately neutral (not green) like .reference-is-disabled above.
+   #596675 -> --mc-text-secondary (d=27.9), already passes AA (5.32:1). */
 .reference-is-disabled .reference-card-name {
-    color: #596675;
+    color: var(--mc-text-secondary);
 }
 
+/* theme-registry Stage 2.5: #718198 failed AA on the live background
+   (3.65:1) - darkened to --mc-text-secondary (4.68:1, PASS, d=31.5). */
 .reference-card-coordinates {
     overflow: hidden;
-    color: #718198;
+    color: var(--mc-text-secondary);
     font-size: 8px;
     line-height: 1.2;
     text-overflow: ellipsis;
@@ -2383,6 +2433,11 @@ body.context-chat-mode .settings-view {
     font-variant-numeric: tabular-nums;
 }
 
+/* theme-registry Stage 2.5: a decorative arrow glyph, not a text label -
+   judged against the 3:1 large-scale/UI-component floor rather than 4.5:1,
+   which #6b8976 already clears (3.54:1) - not a contrast failure, so not
+   darkened. d=40.1 from --mc-text-secondary (the closest token) - left
+   raw, distinct enough not to force. */
 .reference-card-arrow {
     flex-shrink: 0;
     color: #6b8976;

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -1198,14 +1198,17 @@
     transition: transform 0.15s;
 }
 
+/* theme-registry Stage 2.5: single, unshadowed declaration, genuinely
+   live. #dce4ed -> --mc-border (d=7.1). Gradient stops #f8fbff/#eef4fa ->
+   --mc-bg-subtle (d=3.7) / --mc-bg-muted (d=2.2), both near-exact. */
 .weather-card {
     flex: 0 0 auto;
     /* margin-bottom-only, see .time-card comment above. */
     margin: 0 10px 6px;
     overflow: hidden;
-    border: 1px solid #dce4ed;
+    border: 1px solid var(--mc-border);
     border-radius: 11px;
-    background: linear-gradient(160deg, #f8fbff 0%, #eef4fa 100%);
+    background: linear-gradient(160deg, var(--mc-bg-subtle) 0%, var(--mc-bg-muted) 100%);
     box-shadow: 0 3px 10px rgba(37, 56, 78, 0.06);
 }
 
@@ -2297,16 +2300,28 @@ html[data-theme="dark"] .system-log-panel {
    Base status, live sensors, battery and telemetry history share
    one visual container while preserving their existing IDs/API.
    ============================================================ */
+/* theme-registry Stage 2.5: this is the LIVE card chrome for the whole
+   base/sensors/telemetry stack - confirmed on dev via computed style and
+   CSSOM rule matching. #ccd6e2 -> --mc-border (d=16.9). #f5f8fb ->
+   --mc-bg-workspace (d=1.4, near-exact). */
 .node-info-panel {
     margin: 0 10px 6px;
     overflow: hidden;
     flex: 0 0 auto;
-    border: 1px solid #ccd6e2;
+    border: 1px solid var(--mc-border);
     border-radius: 11px;
-    background: #f5f8fb;
+    background: var(--mc-bg-workspace);
     box-shadow: 0 2px 7px rgba(15, 23, 42, .08);
 }
 
+/* theme-registry Stage 2.5: this rule is why .base-card/.sensors-card/
+   .telemetry-section's own background/border (style-part1.css and this
+   file's earlier duplicate block below) are dead when nested directly
+   under .node-info-panel (the only way they're ever rendered) - reset to
+   transparent/borderless here at higher specificity (0,2,0 vs their
+   0,1,0), so the single .node-info-panel surface above shows through
+   instead of three separately-tinted stacked cards. See the dead-code
+   comments on those original rules for the confirmed-live evidence. */
 .node-info-panel > .base-card,
 .node-info-panel > .sensors-card,
 .node-info-panel > .telemetry-section {
@@ -2374,9 +2389,16 @@ html[data-theme="dark"] .system-log-panel {
     padding-top: 8px;
 }
 
+/* theme-registry Stage 2.5: this is the live winning declaration for
+   .battery-indicator's border/background (confirmed via CSSOM matching -
+   it beats both the style-part1.css border-top-only rule and
+   style-part2.css's shared ".battery-indicator, .base-reference-location"
+   rule, which are both dead here, see their comments). #c2ceda ->
+   --mc-border (d=32.0). background stays raw - a semi-transparent white
+   wash (rgba, not an opaque color) has no direct --mc-* token equivalent. */
 .node-info-panel .battery-indicator {
     min-height: 50px;
-    border-color: #c2ceda;
+    border-color: var(--mc-border);
     background: rgba(255, 255, 255, .72);
 }
 
@@ -2463,21 +2485,31 @@ html[data-theme="dark"] .node-info-panel .battery-indicator {
     white-space: nowrap;
 }
 
+/* theme-registry Stage 2.5: live winner for .sensors-title's color
+   (confirmed via CSSOM matching - style-part1.css's .sensors-title is
+   dead here, see its comment). #5e7388 -> --mc-text-secondary (d=9.7),
+   already passes AA (4.60:1 on the live #f5f8fb panel background). */
 .node-info-panel .sensors-title {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 8px;
     margin-bottom: 8px;
-    color: #5e7388;
+    color: var(--mc-text-secondary);
     font-size: 11px;
     letter-spacing: .045em;
     text-transform: uppercase;
 }
 
+/* theme-registry Stage 2.5: #8293a5 failed AA on the live background
+   (2.96:1) - darkened to --mc-text-secondary (4.77:1, PASS, d=58.9, the
+   largest distance consolidated in this stage but the closest available
+   token, mirroring Stage 2.4's #videoLiveInfo fix). Same value/fix
+   applies to .telemetry-status below - both are "last updated" style
+   meta text in this same panel. */
 .node-info-panel .sensors-title .sensor-update {
     margin: 0;
-    color: #8293a5;
+    color: var(--mc-text-secondary);
     font-size: 10px;
     font-weight: 500;
     letter-spacing: 0;
@@ -2500,6 +2532,10 @@ html[data-theme="dark"] .node-info-panel .battery-indicator {
     text-align: center;
 }
 
+/* theme-registry Stage 2.5: dead - this is one of three same-specificity
+   redesign layers for .sensor-label/.sensor-value/.sensor-unit in this
+   file; the last one (further down, already flagged by Stage 1.5a's own
+   dark-mode comment) wins and is the one normalized in this stage. */
 .node-info-panel .node-metrics-grid .sensor-label {
     margin-bottom: 3px;
     color: #6c8195;
@@ -2549,15 +2585,20 @@ html[data-theme="dark"] .node-info-panel .battery-indicator {
     white-space: nowrap;
 }
 
+/* theme-registry Stage 2.5: #60758a failed AA on the live background
+   (4.47:1, just under the 4.5:1 floor) - darkened to --mc-text-secondary
+   (4.77:1, PASS, d=10.7). */
 .node-info-panel .telemetry-title {
-    color: #60758a;
+    color: var(--mc-text-secondary);
     font-size: 11px;
     letter-spacing: .045em;
     text-transform: uppercase;
 }
 
+/* theme-registry Stage 2.5: same #8293a5 AA failure and fix as
+   .sensors-title .sensor-update above - see that comment. */
 .node-info-panel .telemetry-status {
-    color: #8293a5;
+    color: var(--mc-text-secondary);
     font-size: 10px;
 }
 
@@ -2737,6 +2778,8 @@ html[data-theme="dark"] .settings-number-input {
     border-top: 1px solid #d8e1ea;
 }
 
+/* theme-registry Stage 2.5: dead, same reason as the previous
+   .sensor-label layer above - the final declaration further down wins. */
 .node-info-panel .node-metrics-grid .sensor-label {
     margin-bottom: 3px;
     color: #647b91;
@@ -2781,13 +2824,25 @@ html[data-theme="dark"] .settings-number-input {
     border: 0 !important;
 }
 
+/* theme-registry Stage 2.5: this is the live winning declaration for
+   .battery-bar's background (same specificity as style-part1.css's
+   original, later file wins). #d9e0e7 -> --mc-border (d=3.6, near-exact). */
 .battery-bar {
     height: 8px;
     overflow: hidden;
     border-radius: 999px;
-    background: #d9e0e7;
+    background: var(--mc-border);
 }
 
+/* theme-registry Stage 2.5: .battery-fill's own CSS background (only
+   declared in style-part1.css, a linear-gradient(#4caf50, #8bc34a)) is
+   just the pre-JS fallback - chat.js sets battery-fill's inline
+   background to a dynamic hsl() charge-level color once real data
+   arrives (green-to-red scale), so this CSS value barely renders at all
+   in practice. Either way it's a charge-level status color, the same
+   semantic-status category deferred in Stage 2.2/2.3 (badges, map
+   markers), not plain UI chrome - out of scope for a token-consolidation
+   pass. */
 .battery-fill {
     height: 100%;
     border-radius: inherit;
@@ -3112,9 +3167,15 @@ html[data-theme="dark"] .base-node-avatar {
     text-align: center;
 }
 
+/* theme-registry Stage 2.5: this is the winning declaration for
+   .sensor-label's text color (confirmed via CSSOM matching - the two
+   earlier same-specificity layers above are dead, and this is the exact
+   rule Stage 1.5a's own dark-mode comment already points to as "the
+   winning declaration"). #607a92 failed AA on the live background
+   (4.20:1) - darkened to --mc-text-secondary (4.77:1, PASS, d=13.2). */
 .node-info-panel .node-metrics-grid .sensor-label {
     margin: 0;
-    color: #607a92;
+    color: var(--mc-text-secondary);
     font-size: 11px;
     font-weight: 500;
     line-height: 1.1;
@@ -3130,9 +3191,12 @@ html[data-theme="dark"] .base-node-avatar {
     width: 100%;
 }
 
+/* theme-registry Stage 2.5: winning declaration for .sensor-value/
+   .sensor-unit (same reasoning as .sensor-label above). #122f4a ->
+   --mc-text-primary (d=16.4), already passes AA (12.87:1). */
 .node-info-panel .node-metrics-grid .sensor-value,
 .node-info-panel .node-metrics-grid .sensor-unit {
-    color: #122f4a;
+    color: var(--mc-text-primary);
     font-size: 14px;
     font-weight: 700;
     line-height: 1.15;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,9 +6,9 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-4">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-4">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-4">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-5">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-5">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-5">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-3">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-4">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
@@ -2286,7 +2286,7 @@
 </script>
 <script src="{{ url_for('static', filename='chat-emoji.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-photo.js') }}?v=20260821-domain-split"></script>
-<script src="{{ url_for('static', filename='chat-telemetry.js') }}?v=20260821-domain-split"></script>
+<script src="{{ url_for('static', filename='chat-telemetry.js') }}?v=20260904-theme-stage2-5"></script>
 <script src="{{ url_for('static', filename='chat-camera.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-map.js') }}?v=20260821-domain-split"></script>
 <script src="{{ url_for('static', filename='chat-updates-security.js') }}?v=20260821-domain-split"></script>


### PR DESCRIPTION
## Summary

Light counterpart of Stage 1.5a (CSS, PR #178) and 1.5b (JS chart chrome, PR #179) — applies Stage 2.1-2.4's RGB-distance + contrast judgment methodology rather than 1.5a/b's exact-match-only filter.

### Same live-vs-dead lesson as Stage 2.2/2.4, a third time

`.base-card`/`.sensors-card`/`.telemetry-section`/`.sensor-item`/`.sensor-label`/`.sensor-value`/`.sensor-unit`/`.sensor-update` are each declared 2-4 times across `style-part1.css` and `style-part3.css` (a layered "node-info-panel" redesign, same pattern as node-card's V1/V2 and camera's shared-shell discoveries). Confirmed live on dev via CSSOM rule matching, not assumed:

- `.base-card`/`.sensors-card`/`.telemetry-section`'s own background is entirely dead when nested under `.node-info-panel` (the only way they're ever rendered) — a higher-specificity `.node-info-panel > .base-card, .node-info-panel > .sensors-card, .node-info-panel > .telemetry-section` rule resets them to transparent, so the shared `.node-info-panel` wrapper is the real card chrome now, not three individually-tinted cards.
- `.sensor-label`/`.sensor-value`/`.sensor-unit` each have 2-3 same-specificity redesign layers in `style-part3.css`; the true final winner (the exact rule Stage 1.5a's own dark-mode comment already points to) is the one normalized here.
- `.base-card-title`/`.base-status-line`/`.base-card-name`/`.base-card-caption` are orphaned — the live `.base-card` only ever renders a node-manager-entry button (avatar + name), never these classes.
- `.battery-indicator`'s border/background in `style-part1.css` (border-top only) and `style-part2.css` (shared with `.base-reference-location`) are both dead, shadowed by `style-part3.css`'s `.node-info-panel .battery-indicator` at higher/later specificity.

### Genuinely live and normalized (CSS)

| Selector | Raw hex | Token | Contrast |
|---|---|---|---|
| `.node-info-panel` | `#f5f8fb`/`#ccd6e2` | `--mc-bg-workspace`/`--mc-border` | surface |
| `.node-info-panel .battery-indicator` border | `#c2ceda` | `--mc-border` | n/a |
| `.node-info-panel .sensors-title` | `#5e7388` | `--mc-text-secondary` | 4.60:1 |
| `.sensor-update` / `.telemetry-status` | `#8293a5` | `--mc-text-secondary` (fixed: 2.96→4.77:1) | pass |
| `.sensor-label` | `#607a92` | `--mc-text-secondary` (fixed: 4.20→4.77:1) | pass |
| `.sensor-value` / `.sensor-unit` | `#122f4a` | `--mc-text-primary` | 12.87:1 |
| `.telemetry-title` | `#60758a` | `--mc-text-secondary` (fixed: 4.47→4.77:1) | pass |
| `.battery-bar` | `#d9e0e7` | `--mc-border` | surface |
| `.weather-card` | `#dce4ed` / `#f8fbff→#eef4fa` | `--mc-border` / `--mc-bg-subtle→--mc-bg-muted` | surface |
| `.base-reference-location` | `#29485d`/`#eef8f1` | `--mc-text-primary`/`--mc-success-soft` | 8.87:1 |
| `.base-reference-location.disabled` | `#687585`/`#ccd3dc`/`#f2f4f7` | `--mc-text-secondary`/`--mc-border`/`--mc-bg-muted` (fixed: 4.26→4.62:1) | pass |
| `.reference-card-title` | `#617184` | `--mc-text-secondary` | 4.60:1 |
| `.reference-is-disabled` name | `#596675` | `--mc-text-secondary` | 5.32:1 |
| `.reference-card-coordinates` | `#718198` | `--mc-text-secondary` (fixed: 3.65→4.68:1) | pass |

Left raw, checked and documented: `.battery-fill`'s charge-level gradient (a dynamic `hsl()` status color set by `chat.js`, same category as `SENSOR_COLORS`), `.telemetry-btn`'s per-category modifier colors (same categorical-data-series exclusion as `SENSOR_COLORS`/`SENSOR_BG_COLORS`), the "location green" brand family (`.base-mini-card-heading(+strong)`, `.reference-card-name`, `.base-reference-location`/`:hover`'s border-color) — too far from any token and the wrong hue to force onto the generic palette, same "don't force onto an unrelated token" reasoning as prior stages' brand-accent exceptions, `.reference-card-arrow` (a decorative glyph judged against the 3:1 large-UI floor, which it already clears).

### Part B: `chat-telemetry.js` chart chrome (light literals, checked for the first time)

Stage 1.5b only checked the dark literals; this stage checks the light side of the `isDark` ternaries against light tokens for the first time:

- `tickColor` `#666` → `--mc-text-secondary` (d=44.5, same literal Stage 2.4 already consolidated for `.control-group label`)
- legend `labels.color` / tooltip `titleColor` `#333` → `--mc-text-primary` (d=40.3, same literal Stage 2.4 already consolidated for `.video-info-bar`)
- tooltip `bodyColor` `#666` → `--mc-text-secondary` (same as `tickColor`)

No `getComputedStyle(--mc-*)` precedent exists anywhere in this codebase (confirmed again) — matches are hardcoded as the token's resolved hex literal, the same style every other chart-chrome value here already uses. Tooltip `backgroundColor`/`borderColor` stay raw — both are semi-transparent `rgba()`, and `--mc-*` tokens are opaque hex with no direct rgba equivalent to hardcode.

No new hex values introduced (`check_new_hex.py`: OK, 1049 known values). No visual redesign — verified via live render comparison in both Light and Dark on dev.

## Test plan

- [x] `check_new_hex.py` on all 3 changed CSS files: OK, no unregistered hex
- [x] `node --check static/chat-telemetry.js`: OK
- [x] `python -m compileall .`: OK
- [x] `scripts/check-i18n.py`: OK, catalogs in sync
- [x] Deployed to dev (192.168.2.104), live-verified computed styles for every changed CSS selector resolve to the intended token
- [x] Visual check in Light and Dark workspace themes on dev — dark mode confirmed unaffected by computed-style inspection (`.node-info-panel`, `.sensor-label`, `.sensor-value` all still resolve to Stage 1.5a's dark values)
- [x] Dev restored to `main` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)