### PR TITLE
Theme registry Stage 2.6: MeshCenter Light devices/hardware normalization

### DIFF
--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -2852,6 +2852,17 @@ html[data-theme="dark"] .chat-item .chat-time {
     overflow: hidden;
 }
 
+/* theme-registry Stage 2.6: dead code, confirmed via computed styles on
+   dev (not deleted - out of scope to clean up dead CSS here). The later,
+   already-tokenized .devices-panel rule further down this file (~line
+   3082, under "align with standard MeshCenter pages") wins at equal
+   (0,1,0) specificity - the real live .devices-panel border/background
+   come from there (and from .devices-panel.mc-workspace-panel's shared
+   shell rule), confirmed live: white background/`--mc-border` outline.
+   No legacy style-part4.css !important interaction exists for light
+   (unlike dark's Stage 1.6 finding) - grepped, style-part4.css's
+   .devices-panel rule there is unscoped and only sets min-height, and its
+   !important panel-shell override is [data-theme="dark"]-scoped only. */
 .devices-panel {
     width: 100%;
     min-height: 100%;
@@ -2875,6 +2886,11 @@ html[data-theme="dark"] .chat-item .chat-time {
     padding: 28px;
 }
 
+/* theme-registry Stage 2.6: dead code, same reasoning as .devices-panel
+   above - shadowed by the later, already-tokenized .devices-empty-state
+   rule further down this file (~line 3149: border-color:
+   var(--mc-border-soft); background: var(--mc-bg-subtle);). No legacy
+   override exists for this selector either. */
 .devices-empty-state {
     width: min(520px, 100%);
     padding: 36px 28px;
@@ -2889,16 +2905,23 @@ html[data-theme="dark"] .chat-item .chat-time {
     font-size: 40px;
 }
 
+/* theme-registry Stage 2.6: genuinely live - no second, tokenized
+   override exists for h3/p/.devices-empty-tags span anywhere in this
+   file, unlike .devices-panel/.devices-empty-state above. #17365f ->
+   --mc-text-primary (d=37.9), already passes AA (11.51:1 on the live
+   --mc-bg-subtle background). */
 .devices-empty-state h3 {
     margin: 0 0 7px;
-    color: #17365f;
+    color: var(--mc-text-primary);
     font-size: 20px;
 }
 
+/* theme-registry Stage 2.6: #718198 failed AA on the live background
+   (3.76:1) - darkened to --mc-text-secondary (4.82:1, PASS, d=31.5). */
 .devices-empty-state p {
     margin: 0 auto;
     max-width: 430px;
-    color: #718198;
+    color: var(--mc-text-secondary);
     font-size: 12px;
     line-height: 1.55;
 }
@@ -2911,12 +2934,15 @@ html[data-theme="dark"] .chat-item .chat-time {
     gap: 7px;
 }
 
+/* theme-registry Stage 2.6: border #cfdae8 -> --mc-border (d=10.2).
+   background #fff -> --mc-bg-panel (d=0, exact). color #48617e ->
+   --mc-text-secondary (d=27.7), already passes AA (6.39:1 on white). */
 .devices-empty-tags span {
     padding: 4px 9px;
-    border: 1px solid #cfdae8;
+    border: 1px solid var(--mc-border);
     border-radius: 999px;
-    background: #fff;
-    color: #48617e;
+    background: var(--mc-bg-panel);
+    color: var(--mc-text-secondary);
     font-size: 10px;
     font-weight: 700;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-5">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-5">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-3">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-4">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-6">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Light counterpart of Stage 1.6 (dark, PR #180) for the narrow, non-legacy `.devices-panel`/`.devices-empty-state`/`.devices-empty-tags` residue in `static/ui-kit.css` — applies Stage 2.1-2.5's RGB-distance + contrast judgment methodology rather than 1.6's exact-match-only filter.

### Live/dead map confirmed

Same duplicate-block shape Stage 1.6 found for dark, confirmed on the light side:

- `.devices-panel`'s raw-hex-with-fallback rule (~L2855) is dead — the later, already-tokenized `.devices-panel` rule (~L3082) wins at equal specificity, confirmed live on dev (white background/`--mc-border` outline). Unlike dark, **no legacy `style-part4.css` `!important` interaction exists for light** — grepped, `style-part4.css`'s own `.devices-panel` rule is unscoped and only sets `min-height`, and its panel-shell `!important` override is `[data-theme="dark"]`-scoped only.
- `.devices-empty-state`'s raw-hex rule (~L2878) is likewise dead, shadowed by the later, already-tokenized rule (~L3149).
- `.devices-panel.mc-workspace-panel`'s dark-only `#0a121c !important` border override (flagged by Stage 1.6) confirmed to have no light equivalent — nothing to do there.

### Genuinely live and normalized

No second, tokenized override exists for these three selectors anywhere in the file (unlike `.devices-panel`/`.devices-empty-state` above) — confirmed by temporarily rendering the empty-state markup on dev and reading computed styles:

| Selector | Raw hex | Token | Contrast |
|---|---|---|---|
| `.devices-empty-state h3` | `#17365f` | `--mc-text-primary` (d=37.9) | 11.51:1 |
| `.devices-empty-state p` | `#718198` | `--mc-text-secondary` (d=31.5, fixed: 3.76→4.82:1) | pass |
| `.devices-empty-tags span` border | `#cfdae8` | `--mc-border` (d=10.2) | n/a |
| `.devices-empty-tags span` background | `#ffffff` | `--mc-bg-panel` (d=0, exact) | n/a |
| `.devices-empty-tags span` color | `#48617e` | `--mc-text-secondary` (d=27.7) | 6.39:1 |

One real contrast fix (`p`), the rest were already-passing near-duplicates.

### Out of scope, unchanged

The main devices/hardware dashboard (`.device-hero-card`/`.device-info-card`/`.peripheral-card`/`.node-profile-card`/etc.) remains entirely on the legacy `--theme-*` token family — same "out of scope until a dedicated legacy-migration pass" boundary as `.waypoint-tools-*` in Stage 2.3. Dead-code blocks documented, not deleted, per every prior stage's practice.

No new hex values introduced (`check_new_hex.py`: OK, 1049 known values). No visual redesign — verified via live render comparison in both Light and Dark on dev.

## Test plan

- [x] `check_new_hex.py`: OK, no unregistered hex
- [x] `python -m compileall .`: OK
- [x] `scripts/check-i18n.py`: OK, catalogs in sync (no labels touched)
- [x] Deployed to dev (192.168.2.104), live-verified `.devices-panel`'s computed styles resolve to the intended (already-tokenized) live rule
- [x] Temporarily rendered `.devices-empty-state` markup on dev to verify h3/p/tag-span computed styles resolve to the intended tokens (this dev node currently has devices attached, so the empty state doesn't render naturally)
- [x] Visual check in Light and Dark workspace themes on dev — dark mode confirmed unaffected (`.devices-panel` still resolves to Stage 1.6's `#0a121c` border override)
- [x] Dev restored to `main` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)