### PR TITLE
Theme registry Stage 2.7: MeshCenter Light dialogs/popover/toast normalization

### DIFF
--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -1578,8 +1578,13 @@ body {
     z-index: 1000;
 }
 
+/* theme-registry Stage 2.7: confirmed genuinely live - no override exists
+   anywhere for .modal-content/.modal-header/.modal-close/.confirm-text
+   (grepped ui-kit.css, style-part2/3/4.css for unscoped or light-scoped
+   rules; only style-part4.css's already-handled [data-theme="dark"]
+   versions exist). background: white -> --mc-bg-panel (d=0, exact). */
 .modal-content {
-    background: white;
+    background: var(--mc-bg-panel);
     border-radius: 14px;
     min-width: 280px;
     max-width: 380px;
@@ -1587,30 +1592,48 @@ body {
     overflow: hidden;
 }
 
+/* theme-registry Stage 2.7: #e8e8e8 -> --mc-border-soft (d=10.0, close). */
 .modal-header {
     padding: 14px 18px;
-    border-bottom: 1px solid #e8e8e8;
+    border-bottom: 1px solid var(--mc-border-soft);
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
 
-.modal-header span { font-size: 15px; font-weight: 600; color: #3a4a5a; }
+/* theme-registry Stage 2.7: dark's counterpart matched --mc-tab-text-active
+   exactly (Stage 1.7); light's does NOT (--mc-tab-text-active is #102f5c,
+   d=50.0 - not exact, so that precedent doesn't transfer). Consolidated
+   instead to --mc-text-primary (d=63.4, already passes AA 9.10:1) as the
+   semantically correct "modal title text" role, matching every other
+   title-text consolidation this session (.video-title, .node-card-title,
+   .map-popup-name, etc.). */
+.modal-header span { font-size: 15px; font-weight: 600; color: var(--mc-text-primary); }
 
+/* theme-registry Stage 2.7: #999 failed AA (2.85:1) - the nearest token,
+   --mc-text-muted, also fails (2.95:1) on white. Darkened instead to
+   --mc-text-secondary (5.09:1, PASS) - a real, meaningfully large visual
+   shift (this glyph was a plain neutral gray, --mc-text-secondary has a
+   blue tint), but no closer passing option exists and a modal close
+   button needs to clear AA like any other interactive control, same
+   precedent as Stage 2.3's .map-popup-close-btn fix. */
 .modal-close {
     background: none;
     border: none;
     font-size: 20px;
     cursor: pointer;
-    color: #999;
+    color: var(--mc-text-secondary);
     padding: 0 4px;
 }
 
 .modal-body { padding: 14px 18px; }
 
+/* theme-registry Stage 2.7: #444 -> --mc-text-primary (d=61.8), already
+   passes AA (9.74:1). Semantically this is dialog body text, the same
+   "primary text" role as .modal-header span above. */
 .confirm-text {
     font-size: 15px;
-    color: #444;
+    color: var(--mc-text-primary);
     text-align: center;
     margin-bottom: 20px;
     line-height: 1.5;

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -3751,6 +3751,12 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
     flex: 0 0 auto;
 }
 
+/* theme-registry Stage 2.7: .dock-notification-btn(:hover) is orphaned -
+   grepped every static/*.js template and templates/index.html, this
+   class is never rendered by the current dock UI (a different
+   .dock-notification-wrap/.dock-notification-status/-text/-chevron row
+   is what actually renders). Left as documented raw var()-with-fallback
+   since it never paints either way. */
 .dock-notification-btn {
     position: relative;
     width: 27px;
@@ -3771,6 +3777,15 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
 }
 
 
+/* theme-registry Stage 2.7: border-color/background/color/box-shadow
+   below are dead - confirmed live on dev via CSSOM matching: computed
+   border-color is #d7dee8 (--mc-popover-border's real value), not #d8dee6
+   (this rule's own var(--mc-border, ...) fallback, and not #d7e0ea,
+   --mc-border's real value either) - proof the "UNIFIED POPOVER SURFACES"
+   shared shell in ui-kit.css (~L3316, same reasoning as
+   .workspace-popover there) is the actual winner, at equal (0,1,0)
+   specificity, later-loaded file. Layout-only properties (position/
+   width/max-height/z-index) are untouched and stay live. */
 .notification-popover {
     position: absolute;
     left: 0;
@@ -3786,6 +3801,11 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
     z-index: 1600;
 }
 
+/* theme-registry Stage 2.7: background/border-bottom-color dead, same
+   shared-shell reasoning (ui-kit.css's ".workspace-popover-header,
+   .notification-popover-header { background: var(--mc-popover-header-bg);
+   border-bottom-color: var(--mc-popover-divider); }", same specificity,
+   later file). Layout-only properties stay live. */
 .notification-popover-header {
     display: flex;
     align-items: center;
@@ -3802,6 +3822,14 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
 }
 
 .notification-popover-header strong { font-size: 13px; }
+/* theme-registry Stage 2.7: dead - confirmed live via CSSOM matching,
+   computed color is #7a8798 (--mc-popover-muted), not #58708f (this
+   rule's own var(--mc-muted, ...) real value if it were winning) - the
+   shared shell's ".workspace-popover-header span, .notification-popover-header
+   span, .notification-item-copy small, .notification-empty { color:
+   var(--mc-popover-muted); }" wins instead, same reasoning as
+   .notification-popover above. Same fate for .notification-item-copy
+   small and .notification-empty further down this block. */
 .notification-popover-header span { color: var(--mc-muted, #7b8796); font-size: 9px; }
 
 /* Specificity note: `.notification-popover-header > div` above (meant for
@@ -3853,6 +3881,9 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
     cursor: pointer;
 }
 .notification-item:last-child { border-bottom: 0; }
+/* theme-registry Stage 2.7: dead - ui-kit.css's shared-shell
+   ".notification-item:hover { background: var(--mc-popover-item-hover);
+   }" is the exact same selector, later file, wins the tie. */
 .notification-item:hover { background: var(--mc-surface-alt, #f4f7fa); }
 .notification-item.is-read { opacity: .72; }
 .notification-item-icon {
@@ -3864,12 +3895,28 @@ html[data-theme="dark"] .node-info-panel .node-metrics-grid .sensor-unit {
     border-radius: 6px;
     font-weight: 800;
 }
-.notification-success .notification-item-icon { color: #217648; background: #e7f5ec; }
-.notification-warning .notification-item-icon { color: #946316; background: #fff3d8; }
-.notification-error .notification-item-icon { color: #a43d45; background: #fde9eb; }
-.notification-info .notification-item-icon { color: #23699f; background: #e6f1fa; }
+/* theme-registry Stage 2.7: genuinely live (no override exists anywhere
+   for any of these four selectors). The background halves are real
+   near-duplicates of the light -soft tokens: #e7f5ec -> --mc-success-soft
+   (d=5.4), #fff3d8 -> --mc-warning-soft (d=8.1), #fde9eb -> --mc-danger-soft
+   (d=4.2), #e6f1fa -> --mc-info-soft (d=6.7) - all consolidated. The
+   foreground icon colors are NOT consolidated to the obvious semantic
+   token (--mc-success/-warning/-danger/-info) despite matching hue,
+   because those tokens all FAIL AA against these exact soft backgrounds
+   (e.g. --mc-success #27b96f on #e7f5ec: 2.26:1; --mc-danger #e6505d on
+   #fde9eb: 3.18:1) while the current raw values all PASS (#217648 on
+   #e7f5ec: 4.98:1; #946316 on #fff3d8: 4.70:1; #a43d45 on #fde9eb: 5.41:1;
+   #23699f on #e6f1fa: 5.10:1) - these are deliberately darkened,
+   AA-driven variants of the semantic colors, not an oversight, left raw
+   with this reasoning documented. */
+.notification-success .notification-item-icon { color: #217648; background: var(--mc-success-soft); }
+.notification-warning .notification-item-icon { color: #946316; background: var(--mc-warning-soft); }
+.notification-error .notification-item-icon { color: #a43d45; background: var(--mc-danger-soft); }
+.notification-info .notification-item-icon { color: #23699f; background: var(--mc-info-soft); }
 .notification-item-copy { min-width: 0; display: flex; flex-direction: column; gap: 3px; }
 .notification-item-copy strong { overflow-wrap: anywhere; font-size: 11px; font-weight: 650; line-height: 1.3; }
+/* theme-registry Stage 2.7: dead, same reasoning as
+   .notification-popover-header span above (shared shell wins). */
 .notification-item-copy small { color: var(--mc-muted, #7b8796); font-size: 9px; }
 .notification-empty { padding: 30px 16px; color: var(--mc-muted, #7b8796); font-size: 11px; text-align: center; }
 

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -897,18 +897,26 @@
    ============================================================ */
 .dock-map-wrap { position: relative; flex: 0 0 auto; }
 .dock-map-btn.map-active { color: var(--mc-primary, #1f6fdb); background: rgba(31,111,219,.12); }
+/* theme-registry Stage 2.7: stale var() fallback literals, fixed for
+   documentation accuracy (zero visual effect, var() always resolves to
+   the live property) - --mc-border, #d8e0e8 -> #d7e0ea (current real
+   value); --mc-text, #17283a -> #10233f (current --mc-text-primary
+   value, off by 7,5,5 from the stale literal). Same cleanup on
+   .map-split-position's border-top below. */
 .map-layout-popover {
     position: absolute; left: 0; bottom: 34px; width: 250px; z-index: 1000;
-    border: 1px solid var(--mc-border, #d8e0e8); border-radius: 12px;
-    background: var(--mc-surface, #fff); color: var(--mc-text, #17283a);
+    border: 1px solid var(--mc-border, #d7e0ea); border-radius: 12px;
+    background: var(--mc-surface, #fff); color: var(--mc-text, #10233f);
     box-shadow: 0 12px 32px rgba(0,0,0,.22); overflow: hidden;
 }
 .map-layout-popover[hidden] { display:none !important; }
 .map-layout-options, .map-split-position { padding: 8px; }
-.map-split-position { border-top: 1px solid var(--mc-border, #d8e0e8); }
+.map-split-position { border-top: 1px solid var(--mc-border, #d7e0ea); }
 .map-split-position.disabled { opacity:.48; pointer-events:none; }
 .map-layout-option { display:flex; align-items:center; gap:8px; padding:8px 9px; border-radius:8px; cursor:pointer; }
-.map-layout-option:hover { background: var(--mc-surface-alt, #eef4fa); }
+/* theme-registry Stage 2.7: stale fallback, --mc-surface-alt, #eef4fa ->
+   #f7f9fc (current real value, off by 9,5,2). */
+.map-layout-option:hover { background: var(--mc-surface-alt, #f7f9fc); }
 .map-layout-option input { margin:0; }
 /* raw: map layout popover surface + hover (theme-registry Stage 1.7) - no
    exact --mc-* match yet (closest: color #eef6fc vs --mc-chat-text
@@ -3035,16 +3043,22 @@ body[data-theme="dark"] .node-manager-detect-radio-btn:hover {
     transform: translate(-50%, 0);
 }
 
+/* theme-registry Stage 2.7: .sending uses the legacy --theme-* family
+   (same debt as the base .waypoint-action-toast rule above), out of
+   scope, not touched. .success/.error are separate, non-legacy rules -
+   in scope. #2a9a60 -> --mc-success (d=34.6, correct semantic role).
+   #d34f5d -> --mc-danger (d=19.0, correct semantic role). Both are
+   border-colors (a UI-component role, not text), consolidated. */
 .waypoint-action-toast.sending {
     border-color: var(--theme-focus, #4f8cff);
 }
 
 .waypoint-action-toast.success {
-    border-color: #2a9a60;
+    border-color: var(--mc-success);
 }
 
 .waypoint-action-toast.error {
-    border-color: #d34f5d;
+    border-color: var(--mc-danger);
 }
 
 .waypoint-action-toast-icon {

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -826,6 +826,22 @@ a:focus-visible,
     display: none;
 }
 
+/* theme-registry Stage 2.7: dead code, confirmed via computed styles on
+   dev - not deleted, out of scope to clean up dead CSS here. The "UNIFIED
+   POPOVER SURFACES" shared shell further down this file (~L3316,
+   ".workspace-popover, .notification-popover { border-color:
+   var(--mc-popover-border); background: var(--mc-popover-bg); color:
+   var(--mc-popover-text); box-shadow: var(--mc-popover-shadow); }") is
+   unscoped (not theme-gated) and equal specificity (0,1,0) to every rule
+   below, later in file order, so it wins for border-color/background/
+   color/box-shadow on all of them. Unlike Stage 1.7's dark-mode finding,
+   this isn't just "the numbers happen to match" - the raw fallback
+   literals in nearby rules (e.g. .notification-popover's
+   var(--mc-border, #d8dee6)) provably differ from what actually renders
+   (--mc-popover-border's real value, #d7dee8), confirming the shell rule
+   is the true winner, not a coincidental tie. Layout-only properties
+   (position/width/border-right-width/etc.) are untouched by the shell and
+   stay live. */
 .workspace-popover {
     position: absolute;
     left: 70px;
@@ -873,6 +889,13 @@ a:focus-visible,
     font-size: 14px;
 }
 
+/* theme-registry Stage 2.7: also dead, same shared-shell reasoning as
+   above (".workspace-popover-header span, .notification-popover-header
+   span, ... { color: var(--mc-popover-muted); }", ~L3331, same 0,2,0
+   specificity, later in file). Unlike Stage 1.7's dark finding (where a
+   higher-specificity html[data-theme="dark"] override made this
+   selector's dark counterpart genuinely live), no such override exists
+   for light - the asymmetry the task brief flagged as worth checking. */
 .workspace-popover-header span {
     margin-top: 2px;
     color: #7a8798;

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,10 +6,10 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-5">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-5">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-5">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-3">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-7">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-7">
     <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-6">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">


### PR DESCRIPTION
## Summary

Light counterpart of Stage 1.7 (dark, PR #181) for the modal/popover/notification/toast domain across `ui-kit.css`, `style-part1.css`, `style-part3.css`, `style-part4.css` — applies Stage 2.1-2.6's RGB-distance + contrast judgment methodology rather than 1.7's exact-match-only filter.

### Live/dead cascade findings

The "UNIFIED POPOVER SURFACES" shared shell (`ui-kit.css`, unscoped, not theme-gated) shadows almost every base `workspace-popover`/`notification-*` rule for light, at equal specificity and later file order — confirmed via CSSOM matching, not assumed:

- `.workspace-popover`/`.workspace-popover::after`/`.workspace-popover-header`: dead (border-color/background/color/box-shadow).
- **`.workspace-popover-header span`: ALSO dead for light, unlike its dark counterpart** — Stage 1.7 found this genuinely live for dark because a higher-specificity `html[data-theme="dark"]` override existed; no such override exists for light, so the shared shell wins the tie instead. This is the exact asymmetry the task brief flagged as worth checking, and it holds up.
- `.dock-notification-btn(:hover)`: orphaned (never rendered by any current template — a different `.dock-notification-status/-text/-chevron` row renders instead) — not just shadowed, dead by absence too.
- `.notification-popover`/`-header`/`-header span`, `.notification-item:hover`, `.notification-item-copy small`, `.notification-empty`: all dead for the same shared-shell reason — confirmed via CSSOM (computed `border-color` is `#d7dee8`, matching `--mc-popover-border`'s real value, not this rule's own `var(--mc-border, #d8dee6)` fallback nor `--mc-border`'s real value `#d7e0ea` — proof, not coincidence).

### Genuinely live and normalized

- `.notification-success/-warning/-error/-info .notification-item-icon` **backgrounds**: `#e7f5ec`/`#fff3d8`/`#fde9eb`/`#e6f1fa` → `--mc-success-soft`/`--mc-warning-soft`/`--mc-danger-soft`/`--mc-info-soft` (d=4.2-8.1, all near-exact). **Foreground icon colors deliberately NOT consolidated** to the obvious `--mc-success`/`-warning`/`-danger`/`-info` tokens despite matching hue — those tokens all **fail AA** against these exact soft backgrounds (e.g. `--mc-success` `#27b96f` on `#e7f5ec`: 2.26:1) while the current raw values all **pass** (`#217648` on `#e7f5ec`: 4.98:1) — genuinely distinct, AA-driven darkened variants, left raw with the numbers documented.
- `.waypoint-action-toast.success`/`.error` border-color (separate, non-legacy rules from the legacy-bundled base `.waypoint-action-toast`, same as Stage 1.7's dark finding): `#2a9a60`/`#d34f5d` → `--mc-success`/`--mc-danger` (d=34.6/19.0, correct semantic role).
- `.modal-content`/`.modal-header`/`.modal-header span`/`.modal-close`/`.confirm-text` (`style-part1.css`, confirmed live, no override exists anywhere): background white → `--mc-bg-panel` (exact); border `#e8e8e8` → `--mc-border-soft` (d=10.0); header span `#3a4a5a` → `--mc-text-primary` (d=63.4, PASS 9.10:1 — **dark's exact match to `--mc-tab-text-active` does NOT transfer to light**, that token is `#102f5c` here, d=50.0, not exact, so the semantically-correct title-text token is used instead); `confirm-text` `#444` → `--mc-text-primary` (d=61.8, PASS 9.74:1); `modal-close` `#999` failed AA (2.85:1, `--mc-text-muted` also fails at 2.95:1) — darkened to `--mc-text-secondary` (5.09:1, PASS), a real fix, same precedent as Stage 2.3's `.map-popup-close-btn`.

### Stale `var()` fallback cleanup (`style-part4.css`, zero visual effect)

`.map-layout-popover`/`.map-split-position`'s `--mc-border` fallback (`#d8e0e8` → `#d7e0ea`) and `--mc-text` fallback (`#17283a` → `#10233f`, off by 7,5,5); `.map-layout-option:hover`'s `--mc-surface-alt` fallback (`#eef4fa` → `#f7f9fc`, off by 9,5,2).

### Out of scope, unchanged

`.waypoint-action-toast`'s base rule and `.sending` state stay on the legacy `--theme-*` family (same debt as `.camera-panel`/`.devices-panel`/`.media-panel`), not touched.

`ui-kit.css` changes are comments-only (dead-code documentation, no color values changed) — no cache-bust needed for it, matching Stage 1.7's own precedent for the same file.

No new hex values introduced (`check_new_hex.py`: OK, 1049 known values). No visual redesign — verified via live render comparison in both Light and Dark on dev.

## Test plan

- [x] `check_new_hex.py` on all 4 changed files: OK, no unregistered hex
- [x] `python -m compileall .`: OK
- [x] `scripts/check-i18n.py`: OK, catalogs in sync (no labels touched)
- [x] Deployed to dev (192.168.2.104), live-verified computed styles for the notification popover (opened for real), and for the modal/map-layout-popover chrome (temporarily rendered via DOM injection, since neither has a currently-live trigger on this dev node) — all resolve to the intended tokens
- [x] Visual check in Light and Dark workspace themes on dev — dark mode confirmed unaffected (`.modal-content`/`.modal-header span` still resolve to Stage 1.7's dark values)
- [x] Dev restored to `main` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)