### PR TITLE
Theme registry Stage 2.8: MeshCenter Light Settings/Updates/Security/System Log/Instance Identity/Schedules normalization

### DIFF
--- a/static/style-part1.css
+++ b/static/style-part1.css
@@ -3328,6 +3328,14 @@ body {
     background: rgba(31, 111, 229, 0.12);
 }
 
+/* theme-registry Stage 2.8: checked independently against this rule's own
+   real background (.settings-card's confirmed-live --mc-bg-subtle,
+   #f7f9fc) rather than assuming Stage 2.7's identical-literal conclusion
+   transfers - it does: #946316 passes AA here too (4.91:1) while
+   --mc-warning itself fails (1.92:1 on this same background). Same
+   deliberately-darkened-variant reasoning as Stage 2.7's
+   .notification-warning icon and this stage's .identity-mismatch, left
+   raw. */
 .settings-card-note--warning {
     color: #946316;
     font-weight: 600;
@@ -3540,8 +3548,11 @@ html[data-theme="dark"] .settings-card-note--warning {
     font-size: 13px;
 }
 
+/* theme-registry Stage 2.8: same value/fix as .updates-version-row
+   (style-part2.css) - #6b7280 -> --mc-text-secondary (d=24.3), already
+   passes AA (4.83:1 on white). */
 .export-time-sep {
-    color: #6b7280;
+    color: var(--mc-text-secondary);
     font-weight: 600;
 }
 

--- a/static/style-part2.css
+++ b/static/style-part2.css
@@ -2843,23 +2843,31 @@ body.context-chat-mode .settings-view {
     font-size: 10px;
 }
 
+/* theme-registry Stage 2.8: confirmed genuinely live (Stage 1.8 only
+   checked the dark-scoped versions of these; no unscoped/light override
+   was ever added for either). #6b7280 -> --mc-text-secondary (d=24.3),
+   already passes AA (4.83:1 on white). */
 .updates-version-row {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
     font-size: 12px;
-    color: #6b7280;
+    color: var(--mc-text-secondary);
     margin-bottom: 6px;
 }
 
+/* theme-registry Stage 2.8: #1f2937 -> --mc-text-primary (d=18.0),
+   already passes AA (14.68:1). */
 .updates-version-row strong {
     margin-left: 6px;
-    color: #1f2937;
+    color: var(--mc-text-primary);
 }
 
+/* theme-registry Stage 2.8: #34445f -> --mc-text-primary (d=58.4),
+   already passes AA (9.82:1). */
 .updates-status-text {
     font-size: 12px;
-    color: #34445f;
+    color: var(--mc-text-primary);
     margin-bottom: 8px;
 }
 

--- a/static/style-part3.css
+++ b/static/style-part3.css
@@ -958,6 +958,11 @@
     border: 0;
 }
 
+/* theme-registry Stage 2.8: confirmed genuinely live, no shadowing found.
+   Same raw values (border/gradient stops) already normalized for
+   .weather-card in Stage 2.5 - same consolidation reused here rather than
+   re-derived: #dce4ed -> --mc-border (d=7.1); gradient stops #f8fbff/
+   #eef4fa -> --mc-bg-subtle (d=3.7) / --mc-bg-muted (d=2.2). */
 .time-card {
     flex: 0 0 auto;
     /* Left-column module cards use a margin-bottom-only spacing mechanism
@@ -966,9 +971,9 @@
        column's #nodesList exactly (individual margin-bottom, no margin-top). */
     margin: 0 10px 6px;
     overflow: hidden;
-    border: 1px solid #dce4ed;
+    border: 1px solid var(--mc-border);
     border-radius: 11px;
-    background: linear-gradient(160deg, #f8fbff 0%, #eef4fa 100%);
+    background: linear-gradient(160deg, var(--mc-bg-subtle) 0%, var(--mc-bg-muted) 100%);
     box-shadow: 0 3px 10px rgba(37, 56, 78, 0.06);
 }
 
@@ -2095,6 +2100,17 @@
     flex-shrink: 0;
 }
 
+/* theme-registry Stage 2.8: investigated the "System Log/chart well"
+   selectors the task brief pointed at (.chart-container/.system-chart/
+   .system-log-body/.log-container, only ever styled by a dark-scoped
+   rule in ui-kit.css) - all four are orphaned, in BOTH themes, not just
+   unchecked for light. The real live System Log body is this element
+   (.radio-history-panel.system-log-panel - confirmed via live DOM
+   inspection on dev), and its background/border here (this rule wins
+   over style-part2.css's earlier, lower-specificity-losing
+   .radio-history-panel base background) are both semi-transparent
+   rgba() washes over the inherited .system-card background, not solid
+   hex - nothing to tokenize, no hex value to check. */
 .system-log-panel {
     margin-top: 0;
     max-height: 260px;
@@ -2280,13 +2296,19 @@ html[data-theme="dark"] .system-log-panel {
     gap: 12px;
     margin-top: 16px;
 }
+/* theme-registry Stage 2.8: confirmed genuinely live for light (see
+   ui-kit.css's comment near .settings-card for the full asymmetry
+   explanation). Stale var() fallback fixed - --mc-border, #cbd5e1 ->
+   #d7e0ea (current real value); --mc-text, #10233c -> #10233f (current
+   --mc-text-primary value, off by 0,0,3). Zero visual effect, var()
+   always resolves to the live property. */
 .settings-select {
     min-width: 132px;
     padding: 8px 10px;
-    border: 1px solid var(--mc-border, #cbd5e1);
+    border: 1px solid var(--mc-border, #d7e0ea);
     border-radius: 8px;
     background: var(--mc-input-bg, #fff);
-    color: var(--mc-text, #10233c);
+    color: var(--mc-text, #10233f);
     font: inherit;
 }
 

--- a/static/style-part4.css
+++ b/static/style-part4.css
@@ -1279,6 +1279,21 @@
 
 
 /* MeshCenter instance identity */
+/* theme-registry Stage 2.8: confirmed genuinely live (checked against the
+   composited pixel each badge actually renders as - its own text over
+   its own rgba background over the card's white surface, not the raw
+   rgba value in isolation). .identity-match #176b3a (5.82:1 on its
+   composited #e0f7e8), .identity-mismatch #9a5b00 (4.74:1 on #fdeed3),
+   and .identity-not-found/.identity-detection-error/.identity-error's
+   shared #a12b2b (6.05:1 on #fde5e5) all PASS AA, while the obvious
+   semantic tokens (--mc-success/--mc-warning/--mc-danger) all FAIL badly
+   against these same composited backgrounds (2.26:1 / 1.77:1 / 3.09:1) -
+   the same deliberately-darkened-AA-variant pattern Stage 2.7 found for
+   the notification status icons, independently re-confirmed here with
+   this component's own numbers rather than assumed. Left raw. The rgba()
+   backgrounds themselves are a separate non-hex question (not in
+   check_new_hex.py's scope, same as Stage 2.7's notification icon
+   halos) - not tokenized. */
 .identity-status {
     display: inline-flex;
     align-items: center;
@@ -1294,7 +1309,18 @@
 .identity-mismatch { color: #9a5b00; background: rgba(245, 158, 11, 0.18); }
 .identity-not-found,
 .identity-detection-error { color: #a12b2b; background: rgba(239, 68, 68, 0.14); }
-.identity-not-checked { color: var(--text-muted, #6b7280); background: rgba(107, 114, 128, 0.12); }
+/* theme-registry Stage 2.8: different story from its four siblings above
+   - var(--text-muted, ...) references a custom property that is never
+   defined anywhere in this codebase (grepped, same broken-var situation
+   as Stage 2.4's --color-* family), so this always renders its fallback,
+   #6b7280. That value genuinely FAILS AA on its own composited badge
+   background (4.16:1 on #edeef0) - unlike its four siblings, this one
+   isn't a deliberately-darkened passing variant, it's a real gap.
+   --mc-text-secondary, the semantically obvious replacement, ALSO fails
+   here (4.38:1, short of the 4.5:1 floor - no rounding up). Fixed by
+   pointing the broken var() at the real token that both resolves the
+   dead reference and passes AA: --mc-text-primary (13.56:1). */
+.identity-not-checked { color: var(--mc-text-primary); background: rgba(107, 114, 128, 0.12); }
 .identity-error {
     margin-top: 10px;
     padding: 9px 10px;
@@ -3883,6 +3909,21 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 /* ============================================================
    SCHEDULES (Time & Timers card + schedule edit modal)
    Stage 6 - Schedule Engine MVP.
+   theme-registry Stage 2.8: this block's own header comment (kept below)
+   already explains why it used plain hardcoded colors instead of
+   inventing new custom properties - a deliberate, documented choice, not
+   an oversight. Re-checked with the Stage 2.1-2.7 rigor now that the
+   --mc-* token system is far more established than when this comment was
+   written: every raw value below is genuinely live (confirmed - no
+   shadowing anywhere in this domain) and has a real, checkable
+   consolidation target. Three literals reuse values already checked
+   elsewhere this session rather than re-derived: .schedule-action-params'
+   background #f8fbff is the same first gradient stop already normalized
+   for .weather-card/.time-card; .schedule-form-error's background/color
+   pair #fde9eb/#a43d45 is the identical pair already checked for Stage
+   2.7's .notification-error icon; .schedule-modal-footer's border-top
+   #e8e8e8 is the same value already checked for Stage 2.7's
+   .modal-header border.
    No --mc-* custom properties exist anywhere in this stylesheet (every
    var(--mc-*, fallback) usage always resolves to its fallback - confirmed
    by grep), so this block uses plain hardcoded colors matching the
@@ -3890,7 +3931,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
    above, instead of inventing new custom properties.
    ============================================================ */
 .time-schedules-empty {
-    color: #93a2b3;
+    color: var(--mc-text-secondary);
     font-size: 11px;
     padding: 4px 0 8px;
 }
@@ -3901,7 +3942,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     justify-content: space-between;
     gap: 8px;
     padding: 6px 4px;
-    border-bottom: 1px solid #e6ecf3;
+    border-bottom: 1px solid var(--mc-border-soft);
 }
 .time-schedule-row:last-child { border-bottom: 0; }
 .time-schedule-row.is-disabled { opacity: .55; }
@@ -3918,13 +3959,13 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 .time-schedule-label {
     font-size: 12px;
     font-weight: 650;
-    color: #2d4057;
+    color: var(--mc-text-primary);
     overflow-wrap: anywhere;
 }
 
 .time-schedule-summary {
     font-size: 10px;
-    color: #79879a;
+    color: var(--mc-text-secondary);
 }
 
 .time-schedule-actions {
@@ -3952,7 +3993,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     display: block;
     font-size: 11px;
     font-weight: 650;
-    color: #79879a;
+    color: var(--mc-text-secondary);
     text-transform: uppercase;
     letter-spacing: .02em;
     margin-bottom: 4px;
@@ -3963,10 +4004,10 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     width: 100%;
     box-sizing: border-box;
     padding: 8px 10px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--mc-border);
     border-radius: 8px;
-    background: #fff;
-    color: #263b52;
+    background: var(--mc-bg-panel);
+    color: var(--mc-text-primary);
     font: inherit;
     font-size: 13px;
 }
@@ -3975,8 +4016,8 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     display: inline-block;
 }
 
-.schedule-inline { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: #445366; }
-.schedule-inline-label { font-size: 11px; color: #93a2b3; margin-right: 6px; }
+.schedule-inline { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--mc-text-secondary); }
+.schedule-inline-label { font-size: 11px; color: var(--mc-text-secondary); margin-right: 6px; }
 
 .timer-duration-picker {
     display: flex;
@@ -3991,30 +4032,30 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 }
 .timer-duration-field label {
     font-size: 11px;
-    color: #93a2b3;
+    color: var(--mc-text-secondary);
 }
 .timer-duration-input {
     box-sizing: border-box;
     width: 64px;
     padding: 6px 4px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--mc-border);
     border-radius: 8px;
-    background: #fff;
-    color: #263b52;
+    background: var(--mc-bg-panel);
+    color: var(--mc-text-primary);
     font: inherit;
     font-size: 18px;
     text-align: center;
 }
 .timer-duration-sep {
     margin-bottom: 16px;
-    color: #93a2b3;
+    color: var(--mc-text-secondary);
     font-size: 20px;
     font-weight: 600;
 }
 
 .schedule-days-label {
     font-size: 10px;
-    color: #93a2b3;
+    color: var(--mc-text-secondary);
     margin: 8px 0 4px;
 }
 
@@ -4030,10 +4071,10 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     align-items: center;
     gap: 4px;
     padding: 4px 8px;
-    border: 1px solid #cbd5e1;
+    border: 1px solid var(--mc-border);
     border-radius: 999px;
     font-size: 11px;
-    color: #445366;
+    color: var(--mc-text-secondary);
     cursor: pointer;
     user-select: none;
 }
@@ -4041,9 +4082,9 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 
 .schedule-action-params {
     padding: 10px;
-    border: 1px solid #e6ecf3;
+    border: 1px solid var(--mc-border-soft);
     border-radius: 9px;
-    background: #f8fbff;
+    background: var(--mc-bg-subtle);
 }
 
 .schedule-target-picker {
@@ -4058,7 +4099,7 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     align-items: center;
     gap: 4px;
     font-size: 12px;
-    color: #445366;
+    color: var(--mc-text-secondary);
     cursor: pointer;
 }
 .schedule-target-picker .schedule-select {
@@ -4070,12 +4111,12 @@ body[data-theme="dark"] .waypoint-action-toast.error {
 .schedule-form-section {
     margin-top: 14px;
     padding-top: 12px;
-    border-top: 1px solid #e6ecf3;
+    border-top: 1px solid var(--mc-border-soft);
 }
 .schedule-section-heading {
     font-size: 11px;
     font-weight: 650;
-    color: #79879a;
+    color: var(--mc-text-secondary);
     text-transform: uppercase;
     letter-spacing: .02em;
     margin-bottom: 8px;
@@ -4086,36 +4127,50 @@ body[data-theme="dark"] .waypoint-action-toast.error {
     align-items: center;
     gap: 8px;
     font-size: 13px;
-    color: #263b52;
+    color: var(--mc-text-primary);
     cursor: pointer;
     margin-bottom: 8px;
 }
 
 .schedule-placeholder-note {
     font-size: 12px;
-    color: #79879a;
+    color: var(--mc-text-secondary);
     margin: 0;
     line-height: 1.4;
 }
 
+/* theme-registry Stage 2.8: background #fde9eb -> --mc-danger-soft
+   (d=4.2, near-exact). color #a43d45 stays raw - identical pair already
+   checked for Stage 2.7's .notification-error icon (--mc-danger fails AA
+   on this background, 3.18:1, while #a43d45 passes, 5.41:1), reused here
+   rather than re-derived. */
 .schedule-form-error {
     margin-top: 10px;
     padding: 8px 10px;
     border-radius: 8px;
-    background: #fde9eb;
+    background: var(--mc-danger-soft);
     color: #a43d45;
     font-size: 12px;
 }
 
+/* theme-registry Stage 2.8: border-top #e8e8e8 -> --mc-border-soft
+   (d=10.0), same value already checked for Stage 2.7's .modal-header
+   border. .schedule-save-btn's #2d6ca3/#255984 -> --mc-primary/
+   --mc-primary-hover (d=57.8/61.9, correct semantic role - this is a
+   primary action button; the numerically-closer --mc-primary-hover
+   (d=38.7) was not used for the base state since that token is
+   consistently the :hover role elsewhere in this codebase, and mixing
+   the pairing would be confusing despite the smaller raw distance) -
+   white text on both tokens passes AA (4.82:1 / 6.11:1). */
 .schedule-modal-footer {
     display: flex;
     gap: 8px;
     padding: 12px 18px 16px;
-    border-top: 1px solid #e8e8e8;
+    border-top: 1px solid var(--mc-border-soft);
 }
 .schedule-modal-footer .modal-action-btn { width: auto; flex: 1; }
-.schedule-modal-footer .schedule-save-btn { background: #2d6ca3; color: #fff; }
-.schedule-modal-footer .schedule-save-btn:hover { background: #255984; }
+.schedule-modal-footer .schedule-save-btn { background: var(--mc-primary); color: #fff; }
+.schedule-modal-footer .schedule-save-btn:hover { background: var(--mc-primary-hover); }
 .schedule-modal-footer #scheduleModalDeleteBtn { flex: 0 0 auto; }
 
 /* TIMERS (Time & Timers card, Stage 7 - session-scoped in-memory timers).

--- a/static/ui-kit.css
+++ b/static/ui-kit.css
@@ -348,6 +348,27 @@ body {
     background: var(--mc-bg-workspace);
 }
 
+/* theme-registry Stage 2.8: this is the confirmed-live winning declaration
+   for .settings-card/.system-card's background (and, together with
+   .settings-panel/.system-panel above, for the whole Settings/System
+   panel shell) - already fully tokenized, no raw hex, nothing to fix.
+   This is a real light/dark asymmetry: Stage 1.8 found the dark
+   equivalents of .settings-panel/.system-panel dead, shadowed by a
+   legacy style-part4.css !important rule, and .settings-card/.system-card
+   dead too (shadowed by a later dark-scoped bundle, with no honest single
+   token to describe the shared dead declaration since the two selectors
+   resolve to different live text colors there). For light, no such
+   legacy !important rule exists (grepped, dark-scoped only) and this
+   rule - not any dark-adjacent bundle - is simply the last equal-
+   specificity declaration in file order, confirmed via CSSOM matching
+   and live computed styles on dev. .settings-select (style-part3.css)
+   is the same story: its own var(--mc-border, #cbd5e1)/var(--mc-input-bg,
+   #fff)/var(--mc-text, #10233c) rule is genuinely live for light (the
+   generic html[data-theme="dark"] :is(input, select, textarea,
+   .message-input) !important rule that shadows dark's .settings-select
+   is dark-scoped only) - confirmed live, computed color #10233f proves
+   the real --mc-text-primary value is being read, not the stale #10233c
+   fallback (fixed in style-part3.css). */
 .system-card,
 .settings-card {
     background: var(--mc-bg-subtle);
@@ -920,6 +941,16 @@ a:focus-visible,
     color: #334155;
 }
 
+/* theme-registry Stage 2.8: border-bottom-color is dead - the "UNIFIED
+   POPOVER SURFACES" shared shell (Stage 2.7's ".workspace-menu-section,
+   .notification-item { border-color: var(--mc-popover-divider); }",
+   ~L3364) is equal specificity (0,1,0) and later in file order, and wins:
+   confirmed live, computed border-bottom-color is #e5eaf0
+   (--mc-popover-divider's real light value), not this rule's own raw
+   #edf0f4. Unlike dark (where Stage 1.8 found the equivalent selector
+   genuinely live and tokenized it), light's border color is shadowed -
+   another light/dark asymmetry from the same shared-shell mechanism
+   Stage 2.7 already documented extensively. */
 .workspace-menu-section {
     padding: 10px 13px;
     border-bottom: 1px solid #edf0f4;
@@ -2812,6 +2843,9 @@ html[data-theme="dark"] .chat-item .chat-time {
     gap: 6px;
 }
 
+/* theme-registry Stage 2.8: confirmed genuinely live (no shadowing found -
+   grepped and confirmed via computed styles on dev). #334155 ->
+   --mc-text-primary (d=51.1), already passes AA (10.35:1 on white). */
 .workspace-nav-btn {
     width: 100%;
     min-height: 46px;
@@ -2823,18 +2857,24 @@ html[data-theme="dark"] .chat-item .chat-time {
     border: 1px solid transparent;
     border-radius: 9px;
     background: transparent;
-    color: #334155;
+    color: var(--mc-text-primary);
     text-align: left;
     cursor: pointer;
 }
 
+/* theme-registry Stage 2.8: #c9d8ea -> --mc-border (d=16.1). #eef5fd ->
+   --mc-bg-muted (d=5.4, close). #173f73 -> --mc-text-primary (d=59.5),
+   already passes AA (9.58:1 on the live hover background). */
 .workspace-nav-btn:hover,
 .workspace-nav-btn.active {
-    border-color: #c9d8ea;
-    background: #eef5fd;
-    color: #173f73;
+    border-color: var(--mc-border);
+    background: var(--mc-bg-muted);
+    color: var(--mc-text-primary);
 }
 
+/* theme-registry Stage 2.8: #e6eef8 -> --mc-bg-muted (d=9.4, semantically
+   the right role for an icon-swatch fill; --mc-border-soft is marginally
+   closer numerically, d=8.3, but is a border token, not a fill token). */
 .workspace-nav-icon {
     width: 26px;
     height: 26px;
@@ -2842,7 +2882,7 @@ html[data-theme="dark"] .chat-item .chat-time {
     align-items: center;
     justify-content: center;
     border-radius: 7px;
-    background: #e6eef8;
+    background: var(--mc-bg-muted);
 }
 
 .workspace-nav-btn strong,
@@ -2855,9 +2895,16 @@ html[data-theme="dark"] .chat-item .chat-time {
     line-height: 1.2;
 }
 
+/* theme-registry Stage 2.8: #8795a8 failed AA (3.05:1) - the nearest
+   token, --mc-text-muted, is a near-exact color match (d=5.8) but ALSO
+   fails (2.95:1, established repeatedly this session). Darkened instead
+   to --mc-text-secondary (d=64.8, the largest distance in this stage, but
+   the closest token that actually passes, 5.09:1 PASS) - same "no closer
+   passing option exists" reasoning as every other large-distance fix this
+   session (Stage 2.5's .sensor-update, Stage 2.2's .node-inline-id). */
 .workspace-nav-btn small {
     margin-top: 2px;
-    color: #8795a8;
+    color: var(--mc-text-secondary);
     font-size: 9px;
     font-weight: 500;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,11 +6,11 @@
     <meta name="app-version" content="{{ app_version }}">
     <title>MeshCenter</title>
     <!-- MeshCenter build: stage2c7-4-unified-popovers-20260725 -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-5">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-7">
-    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-6">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part1.css') }}?v=20260904-theme-stage2-8">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part2.css') }}?v=20260904-theme-stage2-8">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part3.css') }}?v=20260904-theme-stage2-8">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style-part4.css') }}?v=20260904-theme-stage2-8">
+    <link rel="stylesheet" href="{{ url_for('static', filename='ui-kit.css') }}?v=20260904-theme-stage2-8">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>


### PR DESCRIPTION
## Summary

Light counterpart of Stage 1.8 (dark, PR #182) — the **final domain of Stage 2**. Settings cards, Updates card, Instance Identity status colors, System Log/chart well, Time/Schedules/Timer block, Workspace popover's Panels-divider and Application-nav row, across `ui-kit.css`, `style-part1.css`, `style-part2.css`, `style-part3.css`, `style-part4.css`. Applies Stage 2.1-2.7's RGB-distance + contrast methodology rather than 1.8's exact-match-only filter.

### Confirmed light/dark asymmetries (several real ones, as flagged in the brief)

- `.settings-panel`/`.system-panel`/`.settings-card`/`.system-card`/`.settings-select`: all already fully tokenized and genuinely **live** for light — the legacy `style-part4.css` `!important` bundle and the generic `html[data-theme="dark"] :is(input, select, ...)` rule that shadowed their dark counterparts are both dark-scoped only (grepped, confirmed). `.settings-card`/`.system-card`'s real light winner is a *different* rule than dark's shadowing mechanism implied (the "Settings: color adoption only" bundle, ~`ui-kit.css` L351) — confirmed via CSSOM matching, not assumed. Nothing to fix, documented.
- `.workspace-menu-section`: unlike dark (where Stage 1.8 found this genuinely live and tokenized it), **light's border-bottom-color is dead** — shadowed by Stage 2.7's "UNIFIED POPOVER SURFACES" shared shell (`--mc-popover-divider`), confirmed via CSSOM (computed color doesn't match this rule's own raw value).
- `.workspace-nav-btn` and friends: genuinely live for light (no shadowing layer exists) — checked and normalized for the first time.

### Genuinely live and normalized

| Selector | Raw hex | Token | Contrast |
|---|---|---|---|
| `.workspace-nav-btn` | `#334155` | `--mc-text-primary` | 10.35:1 |
| `.workspace-nav-btn:hover`/`.active` | `#c9d8ea`/`#eef5fd`/`#173f73` | `--mc-border`/`--mc-bg-muted`/`--mc-text-primary` | 9.58:1 |
| `.workspace-nav-icon` | `#e6eef8` | `--mc-bg-muted` | surface |
| `.workspace-nav-btn small` | `#8795a8` | `--mc-text-secondary` (fixed: 3.05→5.09:1) | pass |
| `.updates-version-row`/`strong` | `#6b7280`/`#1f2937` | `--mc-text-secondary`/`--mc-text-primary` | pass |
| `.updates-status-text` | `#34445f` | `--mc-text-primary` | 9.82:1 |
| `.export-time-sep` | `#6b7280` | `--mc-text-secondary` | 4.83:1 |
| `.time-card` | `#dce4ed` / `#f8fbff→#eef4fa` | `--mc-border` / `--mc-bg-subtle→--mc-bg-muted` | surface |
| `.identity-not-checked` | broken `var(--text-muted, #6b7280)` | `--mc-text-primary` (fixed: 4.16→13.56:1, and fixes a never-defined custom property) | pass |
| Schedule dialog block (~25 selectors) | various | `--mc-text-primary`/`-secondary`/`-border`/`-border-soft`/`-bg-panel`/`-bg-subtle`/`-primary`/`-primary-hover` | pass |

### Genuinely live, checked, left raw with documented reasoning

- `.identity-match`/`.identity-mismatch`/`.identity-not-found`/`.identity-detection-error`/`.identity-error`: independently re-confirmed the same deliberately-darkened-AA-variant pattern Stage 2.7 found for notification icons, this time with this component's **own** composited badge-background numbers (e.g. `.identity-match` `#176b3a`: 5.82:1 on its real composited background, vs `--mc-success` failing at 2.26:1).
- `.settings-card-note--warning`: same `#946316` literal already checked in Stage 2.7, independently re-verified against **this rule's own** real background (`.settings-card`'s `--mc-bg-subtle`) rather than assumed to transfer — it does (4.91:1 pass vs `--mc-warning`'s 1.92:1 fail).
- `.schedule-form-error` color: identical pair to Stage 2.7's notification-error icon, reused rather than re-derived.

### Investigated, found orphaned / no-hex-to-check (System Log well)

`.chart-container`/`.system-chart`/`.system-log-body`/`.log-container` (the selectors the task brief pointed at) are **orphaned in both themes**, not just unchecked for light — the real live System Log body is `.radio-history-panel.system-log-panel`, confirmed via live DOM inspection, and its background/border are semi-transparent `rgba()` washes with no hex to check or tokenize.

### Stale `var()` fallback fixed (`style-part3.css`, zero visual effect)

`.settings-select`'s `--mc-border` fallback (`#cbd5e1` → `#d7e0ea`) and `--mc-text` fallback (`#10233c` → `#10233f`, off by 0,0,3).

### Out of scope, confirmed untouched

The Appearance/theme-radio segment of the Workspace popover (Stage 3.2), the legacy `--theme-*` family itself (Stage 3.1), the About page.

**This is the final domain of Stage 2 — once this merges, all 8 Light-normalization domains (matching Stage 1's Dark set) are complete.**

No new hex values introduced (`check_new_hex.py`: OK, 1049 known values). No visual redesign — verified via live render comparison in both Light and Dark on dev.

## Test plan

- [x] `check_new_hex.py` on all 5 changed files: OK, no unregistered hex
- [x] `python -m compileall .`: OK
- [x] `scripts/check-i18n.py`: OK, catalogs in sync (no labels touched)
- [x] Deployed to dev (192.168.2.104), live-verified computed styles for the Settings panel/select, Updates card, Workspace popover nav row, Time card, Instance Identity badges (rendered via DOM injection), and the full Schedule creation dialog (opened for real) — all resolve to the intended tokens
- [x] Visual check in Light and Dark workspace themes on dev — dark mode confirmed unaffected (`#timeCard` border and `.identity-not-checked` color both still resolve to their pre-existing dark values)
- [x] Dev restored to `main` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)