### PR TITLE
🛡️ Sentinel: Fix input validation on system API endpoints

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -53,7 +53,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
     @app.route("/api/system/action", methods=["POST"])
     def api_system_action():
-        data = request.get_json(silent=True) or {}
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         action = str(data.get("action") or "").strip()
 
         allowed = {
@@ -320,7 +322,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
     @app.route("/api/system/wifi/connect", methods=["POST"])
     def api_system_wifi_connect():
-        data = request.get_json(force=True)
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         ssid = (data.get("ssid") or "").strip()
         password = data.get("password") or ""
         if not ssid:
@@ -339,7 +343,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
     @app.route("/api/system/wifi/forget", methods=["POST"])
     def api_system_wifi_forget():
-        data = request.get_json(force=True)
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         ssid = (data.get("ssid") or "").strip()
         if not ssid:
             return jsonify({"ok": False, "error": "SSID is required"}), 400
@@ -454,14 +460,18 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
     def api_create_schedule():
         from meshsrv.schedule_engine import create_rule
 
-        data = request.get_json(force=True)
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         return jsonify(create_rule(data)), 201
 
     @app.route("/api/schedules/<sid>", methods=["PUT"])
     def api_update_schedule(sid):
         from meshsrv.schedule_engine import update_rule
 
-        data = request.get_json(force=True)
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         result = update_rule(sid, data)
         if result is None:
             return jsonify({"error": "not found"}), 404
@@ -493,7 +503,9 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
     def api_create_timer():
         from meshsrv.timer_service import create_timer
 
-        data = request.get_json(force=True)
+        data = request.get_json(silent=True, force=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "Invalid JSON payload"}), 400
         label = data.get("label", "")
         duration_s = data.get("duration_s")
         notify_cfg = data.get("notify")

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -181,3 +181,20 @@ def test_system_info_model_field_is_none_when_unavailable(client, monkeypatch):
     response = client.get("/api/system/info")
 
     assert response.get_json()["model"] is None
+
+
+@pytest.mark.parametrize("endpoint,method", [
+    ("/api/system/wifi/connect", "post"),
+    ("/api/system/wifi/forget", "post"),
+    ("/api/system/action", "post"),
+    ("/api/schedules", "post"),
+    ("/api/schedules/1", "put"),
+    ("/api/timers", "post"),
+])
+def test_invalid_json_payload_returns_400(client, endpoint, method):
+    tester = getattr(client, method)
+    response = tester(endpoint, data="[1, 2, 3]", content_type="application/json")
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["ok"] is False or "error" in data
+    assert "error" in data


### PR DESCRIPTION
This PR adds explicit input validation for JSON request bodies in POST and PUT routes in `api/api_system.py`.

### Security Impact
- **Vulnerability:** Unhandled exceptions (500 Internal Server Error) when clients submit non-dictionary JSON payloads (e.g., arrays, primitives, or nulls).
- **Fix:** Validates that incoming request JSON is a `dict` before performing key lookups (`.get()`), returning a clean `400 Bad Request` response if the payload is invalid.
- **Verification:** Added parameterized unit tests in `tests/test_api_system.py` verifying that sending non-dict JSON payloads to `/api/system/wifi/connect`, `/api/system/wifi/forget`, `/api/system/action`, `/api/schedules`, `/api/schedules/<sid>`, and `/api/timers` returns a 400 Bad Request response.

---
*PR created automatically by Jules for task [11405451059794102009](https://jules.google.com/task/11405451059794102009) started by @FlintUA*