### PR TITLE
🛡️ Sentinel: Fix input validation and sanitization on /api/nodes_import

### DIFF
--- a/server.py
+++ b/server.py
@@ -5731,16 +5731,51 @@ def api_nodes_export():
 @app.route("/api/nodes_import", methods=["POST"])
 @handle_errors
 def api_nodes_import():
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     imported_nodes = data.get("nodes", [])
+    if not isinstance(imported_nodes, list):
+        return jsonify({"ok": False, "error": "Invalid payload format", "error_code": "invalid_payload"}), 400
+
     imported_count = 0
     with state_lock:
         for node_data in imported_nodes:
-            node_id = node_data.get("node_id")
-            if not node_id:
+            if not isinstance(node_data, dict):
                 continue
+            node_id = str(node_data.get("node_id") or "").strip()
+            # Security: validate node_id format (e.g. !00000000) to reject malformed,
+            # path-traversal, or injection payloads before persisting into nodes/chats.
+            if not node_id or not is_valid_node_id(node_id):
+                continue
+
             old = nodes.get(node_id, {})
-            name = node_data.get("name") or old.get("name") or friendly_unknown_node_name(node_id)
+            raw_name = node_data.get("name")
+            name = (
+                sanitize_text(str(raw_name).strip())
+                if raw_name is not None and str(raw_name).strip()
+                else (old.get("name") or friendly_unknown_node_name(node_id))
+            )
+
+            raw_short = node_data.get("short_name")
+            short_name = (
+                sanitize_text(str(raw_short).strip())
+                if raw_short is not None and str(raw_short).strip()
+                else (old.get("short_name", "") or node_id[-4:])
+            )
+
+            raw_hw = node_data.get("hw_model")
+            hw_model = (
+                sanitize_text(str(raw_hw).strip())
+                if raw_hw is not None and str(raw_hw).strip()
+                else old.get("hw_model", "")
+            )
+
+            raw_role = node_data.get("role")
+            role = (
+                sanitize_text(str(raw_role).strip())
+                if raw_role is not None and str(raw_role).strip()
+                else old.get("role", "CLIENT")
+            )
+
             nodes[node_id] = {
                 "name": name, "node_id": node_id,
                 "last_seen": old.get("last_seen", time.time()),
@@ -5750,9 +5785,9 @@ def api_nodes_import():
                 "hop_start": old.get("hop_start", ""),
                 "relay_node": old.get("relay_node", ""),
                 "last_text": old.get("last_text", ""),
-                "short_name": node_data.get("short_name", old.get("short_name", "") or node_id[-4:]),
-                "hw_model": node_data.get("hw_model", old.get("hw_model", "")),
-                "role": node_data.get("role", old.get("role", "CLIENT")),
+                "short_name": short_name,
+                "hw_model": hw_model,
+                "role": role,
                 "ignored": old.get("ignored", False),
                 "favorite": old.get("favorite", False),
                 # Importing metadata must not discard a stored position.

--- a/tests/test_nodes_import_security.py
+++ b/tests/test_nodes_import_security.py
@@ -1,0 +1,94 @@
+"""Security tests for POST /api/nodes_import input validation and sanitization.
+"""
+
+
+def test_nodes_import_valid_node(server_module):
+    client = server_module.app.test_client()
+
+    payload = {
+        "nodes": [
+            {
+                "node_id": "!12345678",
+                "name": "Valid Node",
+                "short_name": "VALD",
+                "hw_model": "TLORA_V2",
+                "role": "CLIENT",
+            }
+        ]
+    }
+
+    response = client.post("/api/nodes_import", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["imported_count"] == 1
+
+    assert "!12345678" in server_module.nodes
+    node = server_module.nodes["!12345678"]
+    assert node["name"] == "Valid Node"
+    assert node["short_name"] == "VALD"
+    assert node["hw_model"] == "TLORA_V2"
+    assert node["role"] == "CLIENT"
+
+
+def test_nodes_import_rejects_malformed_and_injection_node_ids(server_module):
+    client = server_module.app.test_client()
+
+    payload = {
+        "nodes": [
+            {"node_id": "12345678", "name": "Missing Exclamation"},
+            {"node_id": "!1234567", "name": "Too Short"},
+            {"node_id": "!123456789", "name": "Too Long"},
+            {"node_id": "!1234567g", "name": "Non Hex"},
+            {"node_id": "!12345678/../../etc/passwd", "name": "Path Traversal"},
+            {"node_id": "!12345678; rm -rf /", "name": "Command Injection"},
+            {"node_id": "!12345678\x00", "name": "Null Byte"},
+            {"node_id": None, "name": "None ID"},
+            {"node_id": "", "name": "Empty ID"},
+        ]
+    }
+
+    response = client.post("/api/nodes_import", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["imported_count"] == 0
+
+    assert len(server_module.nodes) == 0
+
+
+def test_nodes_import_invalid_payload_format(server_module):
+    client = server_module.app.test_client()
+
+    response = client.post("/api/nodes_import", json={"nodes": "not-a-list"})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["ok"] is False
+    assert data["error_code"] == "invalid_payload"
+
+
+def test_nodes_import_sanitizes_input_strings(server_module):
+    client = server_module.app.test_client()
+
+    payload = {
+        "nodes": [
+            {
+                "node_id": "!87654321",
+                "name": "Bad\x00Name\x07With\x00Controls",
+                "short_name": "S\x00T",
+                "hw_model": "HW\x01Model",
+                "role": "CLIENT\x00",
+            }
+        ]
+    }
+
+    response = client.post("/api/nodes_import", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["imported_count"] == 1
+
+    node = server_module.nodes["!87654321"]
+    assert node["name"] == "BadNameWithControls"
+    assert node["short_name"] == "ST"
+    assert node["hw_model"] == "HWModel"
+    assert node["role"] == "CLIENT"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing input validation and string sanitization on `POST /api/nodes_import`.
🎯 Impact: An unvalidated import payload could inject malformed node IDs, path traversal strings, or control characters into internal `nodes` and `chats` data stores.
🔧 Fix: Added strict type checks, `is_valid_node_id()` validation, and `sanitize_text()` string sanitization for all imported node fields in `server.py`. Added unit tests in `tests/test_nodes_import_security.py`.
✅ Verification: Ran `python3 -m pytest tests/test_nodes_import_security.py` and the full pytest test suite (983 tests passed).

---
*PR created automatically by Jules for task [11848576519505656417](https://jules.google.com/task/11848576519505656417) started by @FlintUA*