### PR TITLE
MCAttach: fix create_draft()'s comment parameter being silently dropped

### DIFF
--- a/meshsrv/attachments/db/migrations.py
+++ b/meshsrv/attachments/db/migrations.py
@@ -404,6 +404,29 @@ DROP TABLE IF EXISTS mca_receiver_state;
 """
 
 
+_MIGRATION_0007_UP = """
+-- Fixes a real gap: create_draft()'s `comment` parameter (design spec
+-- 17.4 point 5, "Комментарий") was accepted but silently dropped -
+-- _step_encrypting() hard-coded ManifestHeader(comment=None) regardless
+-- of what the caller passed. A comment must survive an arbitrary restart
+-- between create_draft() and the ENCRYPTING step actually running (same
+-- crash-recovery guarantee as every other draft field), so it cannot
+-- live only in a local Python variable - it needs a persisted column,
+-- exactly like `file_name`/`mime_type` already do. Nullable and plaintext
+-- at rest (this workspace already stores the plaintext source file at
+-- `saved_path` for the same DRAFT/VALIDATING/ENCRYPTING window, so this
+-- is not a new trust boundary) - cleared back to NULL by
+-- _step_encrypting() once the encrypted manifest has been built, since
+-- nothing needs the plaintext copy again after that point and the Relay
+-- itself only ever receives the already-encrypted manifest blob.
+ALTER TABLE attachments ADD COLUMN draft_comment TEXT;
+"""
+
+_MIGRATION_0007_DOWN = """
+ALTER TABLE attachments DROP COLUMN draft_comment;
+"""
+
+
 @dataclass(frozen=True)
 class Migration:
     version: int
@@ -419,6 +442,7 @@ MIGRATIONS: Sequence[Migration] = (
     Migration(4, "mca_principal_and_key_exchange_state", _MIGRATION_0004_UP, _MIGRATION_0004_DOWN),
     Migration(5, "mca_sender_state", _MIGRATION_0005_UP, _MIGRATION_0005_DOWN),
     Migration(6, "mca_receiver_state", _MIGRATION_0006_UP, _MIGRATION_0006_DOWN),
+    Migration(7, "attachments_draft_comment", _MIGRATION_0007_UP, _MIGRATION_0007_DOWN),
 )
 
 LATEST_VERSION: int = MIGRATIONS[-1].version if MIGRATIONS else 0

--- a/meshsrv/attachments/sender.py
+++ b/meshsrv/attachments/sender.py
@@ -96,6 +96,33 @@ DEFAULT_HARD_TTL_SECONDS = 72 * 3600  # design spec 14: hard_expiry = 72h
 DEFAULT_DOWNLOAD_GRACE_SECONDS = 3600  # design spec 14: download_grace = 1h
 
 KIND_GENERIC = 0
+
+# design spec 17.4 point 5: an optional caption, stored only in the
+# encrypted manifest, never sent to the Relay in the clear. Bounded so a
+# UI text field can't be used to smuggle an arbitrarily large plaintext
+# blob into local storage under the guise of a "comment".
+MAX_COMMENT_BYTES = 1000
+
+
+def _normalize_comment(comment: Optional[str]) -> Optional[str]:
+    """None and the empty/whitespace-only string are treated identically
+    (both mean "no comment") - a UI text field that the user left empty
+    must not round-trip as a comment=="" manifest header down the line.
+    Rejects an embedded NUL (would truncate as a C string in some
+    consumers) and anything over MAX_COMMENT_BYTES once UTF-8 encoded."""
+
+    if comment is None:
+        return None
+    stripped = comment.strip()
+    if not stripped:
+        return None
+    if "\x00" in stripped:
+        raise SenderError("comment must not contain a NUL byte")
+    encoded = stripped.encode("utf-8", errors="strict")
+    if len(encoded) > MAX_COMMENT_BYTES:
+        raise SenderError(f"comment exceeds {MAX_COMMENT_BYTES} bytes once UTF-8 encoded (got {len(encoded)})")
+    return stripped
+
 KIND_IMAGE = 1
 KIND_VIDEO = 2
 KIND_AUDIO = 3
@@ -195,6 +222,7 @@ def create_draft(
         raise SenderError("a draft must have at least one recipient")
     if len(provider_id) != 8:
         raise SenderError(f"provider_id must be 8 raw bytes, got {len(provider_id)}")
+    comment = _normalize_comment(comment)
 
     now = _now() if now is None else now
     attachment_id = uuid.uuid4().hex
@@ -204,8 +232,9 @@ def create_draft(
         """
         INSERT INTO attachments
             (id, workspace_id, transfer_id, direction, principal_id, provider_id, state,
-             file_name, mime_type, created_at, hard_expires_at, download_grace_seconds, saved_path)
-        VALUES (?, ?, ?, 'sent', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             file_name, mime_type, created_at, hard_expires_at, download_grace_seconds, saved_path,
+             draft_comment)
+        VALUES (?, ?, ?, 'sent', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             attachment_id,
@@ -220,6 +249,7 @@ def create_draft(
             0,  # hard_expires_at: unknown until commit(); 0 is never a valid real value
             download_grace_seconds,
             source_path,
+            comment,
         ),
     )
     for recipient in recipients:
@@ -397,7 +427,7 @@ def _step_encrypting(
         plain_size=plain_size,
         plain_sha256=plain_sha256,
         chunk_count=plan.chunk_count,
-        comment=None,
+        comment=row["draft_comment"],
     )
 
     envelopes = []
@@ -449,7 +479,12 @@ def _step_encrypting(
         attachment_id,
         QUEUED_UPLOAD,
         now,
-        extra_sql=", cipher_size = ?",
+        # draft_comment was only ever needed to build `header` above (it's
+        # now sealed inside manifest_blob, already persisted to
+        # mca_sender_state a few lines up) - clear the local plaintext
+        # copy now that it has done its one job, same spirit as clearing
+        # `pending_offer_cbor` once receiver.py is done with it.
+        extra_sql=", cipher_size = ?, draft_comment = NULL",
         extra_params=(total_ciphertext_size,),
     )
     return QUEUED_UPLOAD

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -16,7 +16,7 @@ import sqlite3
 import pytest
 from nacl.signing import SigningKey
 
-from meshsrv.attachments import identity, sender
+from meshsrv.attachments import identity, manifest, sender
 from meshsrv.attachments.db import migrations
 from meshsrv.attachments.delivery.fakes import FakeTextAdapter, InMemoryEther
 from meshsrv.attachments.relay.mock_server import MockRelayStore, create_mock_relay_app
@@ -88,7 +88,7 @@ def recipient():
     return sk, pub, key_id
 
 
-def _draft(conn, wsm, principal, recipient, tmp_path, *, file_name="a.txt", mime_type="text/plain", content=b"hello" * 1000, adapter_id="fake-text", route_id="receiver"):
+def _draft(conn, wsm, principal, recipient, tmp_path, *, file_name="a.txt", mime_type="text/plain", content=b"hello" * 1000, adapter_id="fake-text", route_id="receiver", comment=None):
     _, pub, key_id = recipient
     source_path = tmp_path / file_name
     source_path.write_bytes(content)
@@ -104,8 +104,29 @@ def _draft(conn, wsm, principal, recipient, tmp_path, *, file_name="a.txt", mime
         route_type="DIRECT",
         route_id=route_id,
         provider_id=b"\x01" * 8,
+        comment=comment,
     )
     return attachment_id, str(source_path)
+
+
+def _decrypt_sender_manifest_header(conn, attachment_id, recipient):
+    """Decrypts the header of the manifest sender.py has already built and
+    persisted to mca_sender_state for `attachment_id`, using the
+    recipient's own private key - exactly what a real receiver would do,
+    but reading the manifest_blob straight out of local sender-side state
+    instead of round-tripping it through a mock Relay + receiver.py."""
+
+    _, _, key_id = recipient
+    sk = recipient[0]
+    row = conn.execute("SELECT plain_size FROM attachments WHERE id = ?", (attachment_id,)).fetchone()
+    state_row = sender._get_sender_state(conn, attachment_id)
+    parsed = manifest.parse_manifest_blob(state_row["manifest_blob"])
+    envelope = manifest.find_recipient_envelope(parsed, bytes.fromhex(key_id))
+    secret = manifest.open_recipient_secret(envelope.sealed_envelope, sk)
+    return manifest.decrypt_manifest_header(
+        parsed, data_key=secret.data_key, nonce_prefix=secret.nonce_prefix,
+        chunk_count=secret.chunk_count, plain_size=row["plain_size"],
+    )
 
 
 def _drive_to(conn, wsm, principal, recipient, relay_client, delivery_adapter, attachment_id, target_states, max_steps=20):
@@ -313,3 +334,112 @@ def test_create_upload_409_with_no_local_upload_id_tombstones_and_restarts(
     adapter = FakeTextAdapter(ether, "sender-addr")
     final = _drive_to(conn, wsm, principal, recipient, relay_client, adapter, attachment_id, {sender.SENT})
     assert final == sender.SENT
+
+
+# ---- draft_comment (fixes the comment-loss bug: create_draft() accepted ---
+# ---- `comment` but _step_encrypting() hard-coded comment=None) -----------
+
+
+def test_comment_survives_from_create_draft_to_decrypted_manifest(conn, wsm, principal, recipient, tmp_path, relay_client):
+    attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, comment="hello from the sender")
+    recipient_identities = {recipient[2]: recipient[1]}
+    for _ in range(5):
+        if sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD:
+            break
+        sender.run_step(
+            conn, workspace_manager=wsm, principal=principal, recipient_identities=recipient_identities,
+            relay_client=relay_client, delivery_adapter=None, attachment_id=attachment_id,
+        )
+    assert sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD
+
+    header = _decrypt_sender_manifest_header(conn, attachment_id, recipient)
+    assert header.comment == "hello from the sender"
+
+
+def test_none_comment_stays_none(conn, wsm, principal, recipient, tmp_path, relay_client):
+    attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, comment=None)
+    recipient_identities = {recipient[2]: recipient[1]}
+    for _ in range(5):
+        if sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD:
+            break
+        sender.run_step(
+            conn, workspace_manager=wsm, principal=principal, recipient_identities=recipient_identities,
+            relay_client=relay_client, delivery_adapter=None, attachment_id=attachment_id,
+        )
+    header = _decrypt_sender_manifest_header(conn, attachment_id, recipient)
+    assert header.comment is None
+
+
+def test_empty_and_whitespace_comment_normalizes_to_none(conn, wsm, principal, recipient, tmp_path, relay_client):
+    for raw in ("", "   ", "\t\n"):
+        attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, file_name=f"a-{len(raw)}.txt", route_id=f"r-{len(raw)}", comment=raw)
+        row = conn.execute("SELECT draft_comment FROM attachments WHERE id = ?", (attachment_id,)).fetchone()
+        assert row[0] is None
+
+
+def test_comment_survives_a_restart_between_draft_and_encrypting(conn, wsm, principal, recipient, tmp_path, relay_client):
+    """A crash between create_draft() and _step_encrypting() actually
+    running must not lose the comment - it has to come from persisted
+    state, not a variable held only in the caller's process."""
+
+    attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, comment="survives a restart")
+    # simulate "restart": nothing but the DB row exists at this point: no
+    # in-memory reference to the original comment string is used below.
+    recipient_identities = {recipient[2]: recipient[1]}
+    for _ in range(5):
+        if sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD:
+            break
+        sender.run_step(
+            conn, workspace_manager=wsm, principal=principal, recipient_identities=recipient_identities,
+            relay_client=relay_client, delivery_adapter=None, attachment_id=attachment_id,
+        )
+    header = _decrypt_sender_manifest_header(conn, attachment_id, recipient)
+    assert header.comment == "survives a restart"
+
+
+def test_comment_over_length_limit_rejected_before_draft_created(conn, wsm, principal, recipient, tmp_path):
+    too_long = "x" * (sender.MAX_COMMENT_BYTES + 1)
+    source_path = tmp_path / "a.txt"
+    source_path.write_bytes(b"hello")
+    _, pub, key_id = recipient
+    with pytest.raises(sender.SenderError):
+        sender.create_draft(
+            conn, wsm, principal, workspace_id="local", source_path=str(source_path), file_name="a.txt",
+            mime_type="text/plain", recipients=[sender.RecipientTarget(public_identity=pub, key_id=key_id)],
+            adapter_id="fake-text", connector_profile_id="default", route_type="DIRECT", route_id="r",
+            provider_id=b"\x01" * 8, comment=too_long,
+        )
+    # rejected before any row was created at all
+    count = conn.execute("SELECT COUNT(*) FROM attachments").fetchone()[0]
+    assert count == 0
+
+
+def test_comment_never_reaches_relay_in_plaintext(conn, wsm, principal, recipient, tmp_path, relay_client, store):
+    secret_comment = "this must never appear in cleartext on the wire"
+    attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, comment=secret_comment)
+    ether = InMemoryEther()
+    adapter = FakeTextAdapter(ether, "sender-addr")
+    final = _drive_to(conn, wsm, principal, recipient, relay_client, adapter, attachment_id, {sender.SENT})
+    assert final == sender.SENT
+
+    transfer_id = bytes.fromhex(conn.execute("SELECT transfer_id FROM attachments WHERE id = ?", (attachment_id,)).fetchone()[0])
+    transfer = store._fetch_object(transfer_id)
+    haystacks = [transfer.manifest_data] + [c.data for c in transfer.chunks.values()]
+    needle = secret_comment.encode("utf-8")
+    for blob in haystacks:
+        assert needle not in blob
+
+
+def test_draft_comment_column_cleared_after_encrypting(conn, wsm, principal, recipient, tmp_path, relay_client):
+    attachment_id, _ = _draft(conn, wsm, principal, recipient, tmp_path, comment="temporary plaintext")
+    recipient_identities = {recipient[2]: recipient[1]}
+    for _ in range(5):
+        if sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD:
+            break
+        sender.run_step(
+            conn, workspace_manager=wsm, principal=principal, recipient_identities=recipient_identities,
+            relay_client=relay_client, delivery_adapter=None, attachment_id=attachment_id,
+        )
+    assert sender.get_state(conn, attachment_id) == sender.QUEUED_UPLOAD
+    row = conn.execute("SELECT draft_comment FROM attachments WHERE id = ?", (attachment_id,)).fetchone()
+    assert row[0] is None


### PR DESCRIPTION
## Summary
Split out from PR #227 per review feedback — this fix is independently correct and ready to merge on its own, ahead of the larger ADR-0008/0009 work (which needs the blocking defects from that review addressed first).

`sender.create_draft()` accepted a `comment` parameter (design spec 17.4 point 5, "Комментарий") but never persisted it — `_step_encrypting()` hard-coded `ManifestHeader(comment=None)` regardless of what was passed, making the send form's future comment field a silent no-op end to end.

Fixed by adding a nullable `attachments.draft_comment` column (migration 7) so the comment survives a restart between `create_draft()` and `ENCRYPTING` actually running — the same crash-recovery guarantee as every other draft field. `create_draft()` normalizes it (`None` and blank/whitespace-only both mean "no comment"), rejects an embedded NUL byte and anything over `MAX_COMMENT_BYTES` (1000 UTF-8 bytes), and `_step_encrypting()` reads it into the manifest header and clears the column back to `NULL` once the encrypted manifest is built — the plaintext copy has done its one job and the Relay never receives anything but the encrypted blob.

## Verification
`python -m pytest -q --ignore=tests/hardware` → **951 passed, 3 failed, 32 skipped** (986 total, matching the original handoff's claim). The 3 failures are the same pre-existing Windows-only platform artifacts already documented across prior PRs (unrelated to this change) — also being fixed independently in #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)