### PR TITLE
🛡️ Sentinel: Reject ASCII control characters in redirect target validation

### DIFF
--- a/api/api_auth.py
+++ b/api/api_auth.py
@@ -260,6 +260,8 @@ def _is_safe_redirect_target(target):
     """
     if not target or not isinstance(target, str):
         return False
+    if any(ord(c) < 32 or ord(c) == 127 for c in target):
+        return False
     if not target.startswith("/") or target.startswith("//") or "\\" in target:
         return False
     parsed = urlsplit(target)

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -225,6 +225,14 @@ def test_is_safe_redirect_target_rejects_open_redirects():
     # rejected.
     assert _is_safe_redirect_target("/\t/evil.example") is False
 
+    # Control characters (ASCII 0-31 and 127) must be rejected to prevent
+    # URL manipulation, open redirects, or HTTP header injection.
+    assert _is_safe_redirect_target("/\x0b/evil.example") is False
+    assert _is_safe_redirect_target("/\x0c/evil.example") is False
+    assert _is_safe_redirect_target("/\r\n/evil.example") is False
+    assert _is_safe_redirect_target("/\x7f/evil.example") is False
+    assert _is_safe_redirect_target("/\x00/evil.example") is False
+
 
 def test_login_redirect_rejects_the_live_reproduced_open_redirect(tmp_path):
     # End-to-end regression test through the real route (not just the


### PR DESCRIPTION
🛡️ **Sentinel Security Improvement**

- **🚨 Severity:** MEDIUM / Security Enhancement
- **💡 Vulnerability:** Unsanitized ASCII control characters (such as vertical tab, form feed, newlines, or null bytes) in redirect targets could potentially cause URL parsing inconsistencies, open redirects, or response splitting across different WSGI/HTTP server implementations.
- **🎯 Impact:** Attackers could bypass target path validation or inject HTTP headers on redirect responses if control characters are stripped by downstream frameworks or proxies.
- **🔧 Fix:** Updated `_is_safe_redirect_target` in `api/api_auth.py` to reject any target string containing ASCII control characters (`ord(c) < 32` or `ord(c) == 127`).
- **✅ Verification:** Added test cases in `tests/test_api_auth.py` ensuring `_is_safe_redirect_target` fails closed when encountering control characters. Ran full pytest suite and verified all tests pass.

---
*PR created automatically by Jules for task [12150103122707413159](https://jules.google.com/task/12150103122707413159) started by @FlintUA*