### PR TITLE
MCAttach Step 1.6A.2: read-only REST API

### DIFF
--- a/api/api_attachments.py
+++ b/api/api_attachments.py
@@ -1,0 +1,486 @@
+"""api/api_attachments.py
+
+Step 1.6A.2: the read-only MCAttach REST surface (internal-rest-api.md
+§7.1). MIT-licensed Core code - never `meshtastic`, never anything under
+`adapters/meshtastic/`.
+
+Exactly the ten `GET` endpoints §7.1 defines, and nothing else:
+
+    GET /api/attachments
+    GET /api/attachments/{attachment_id}
+    GET /api/attachments/{attachment_id}/deliveries
+    GET /api/mca/delivery-adapters
+    GET /api/mca/providers
+    GET /api/mca/providers/{provider_id}
+    GET /api/mca/providers/{provider_id}/upload-readiness
+    GET /api/mca/connectivity
+    GET /api/mca/identity
+    GET /api/mca/commands/{command_id}
+
+Every mutation, `GET /api/attachments/{id}/content`, contacts/connectors,
+multipart upload, and provider onboarding is deliberately out of scope
+here (1.6A.3+).
+
+Threading boundary (the point of Step 1.6A.1's facade - §3.1/§3.2): these
+handlers only ever read the worker-published in-memory snapshots and
+registries through `AttachmentsFacade`. They never touch SQLite, the
+filesystem, the network, the radio, or the worker's tick lock, and they
+never create/lazily-initialize the MCA runtime - `mca_runtime.
+get_attachments_facade()` returns `None` until the runtime has actually
+been constructed (an explicit "not ready" signal, mapped to 503 here,
+never a fallback that would open `attachments.db` from a request thread).
+
+No-secret discipline (§11): every response is built by an explicit
+allowlist serializer. No `dataclasses.asdict()`, no `__dict__`, no generic
+encoder. Upload tokens, token filenames, private-key filenames, raw public
+key bytes, filesystem paths, `ContentDescriptor.locator`, ciphertext, and
+internal SQLite fields never reach the wire. `handle_errors` (server.py)
+would otherwise turn an uncaught exception into a 500 envelope that leaks
+`str(e)`, so the readiness-gated reads catch `FacadeNotReady` themselves
+and the id/query validation returns the documented 400/404 codes directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+
+from flask import jsonify, request
+
+from meshsrv.attachments import mca_runtime, receiver, sender
+from meshsrv.attachments.delivery.meshtastic import MESHTASTIC_TEXT_MAX_PAYLOAD_BYTES
+from meshsrv.attachments.facade import FacadeNotReady
+from meshsrv.attachments.snapshots import (
+    serialize_attachment_public,
+    serialize_delivery,
+    serialize_timeline_event,
+)
+from meshsrv.connectivity_monitor import RelayState, evaluate_upload_readiness
+
+# ---- id shapes (§7.9: attachment_id and command_id are both uuid4().hex) --
+
+_HEX32_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _is_hex32(value: str) -> bool:
+    return isinstance(value, str) and _HEX32_RE.match(value) is not None
+
+
+# ---- list-filter state sets ----------------------------------------------
+#
+# `error_code` alone is NOT a reliable "errors" signal: the sender state
+# machine stamps `error_code` on non-terminal retrying states too
+# (QUEUED_UPLOAD="relay_unavailable", READY_TO_SEND="radio_send_failed").
+# The `errors` filter is therefore driven by the terminal FAILED_* states,
+# and `pending` by the terminal-state complement.
+
+_ALL_STATES = frozenset(
+    {
+        sender.DRAFT, sender.VALIDATING, sender.ENCRYPTING, sender.QUEUED_UPLOAD,
+        sender.UPLOADING, sender.READY_TO_SEND, sender.SENT, sender.RECEIVED,
+        sender.DOWNLOADED, sender.EXPIRED, sender.REVOKED, sender.CANCELLED,
+        sender.FAILED_VALIDATION, sender.FAILED_UPLOAD, sender.FAILED_RADIO,
+        receiver.OFFER_RECEIVED, receiver.WAITING_KEY, receiver.WAITING_PROVIDER,
+        receiver.WAITING_NETWORK, receiver.WAITING_CONSENT, receiver.DOWNLOADING,
+        receiver.VERIFYING, receiver.AVAILABLE, receiver.EXPIRED, receiver.REJECTED,
+        receiver.FAILED,
+    }
+)
+
+_TERMINAL_STATES = frozenset(sender.TERMINAL_STATES | receiver.TERMINAL_STATES)
+
+_FILTER_ERROR_STATES = frozenset(
+    {sender.FAILED_VALIDATION, sender.FAILED_UPLOAD, sender.FAILED_RADIO, receiver.FAILED}
+)
+
+_VALID_DIRECTIONS = frozenset({"sent", "received", "all"})
+_VALID_FILTERS = frozenset({"pending", "errors", "saved", "all"})
+
+
+# ---- small response helpers ----------------------------------------------
+
+
+def _not_ready():
+    """The one 503 every handler returns before the MCA runtime exists."""
+    return jsonify({
+        "ok": False,
+        "error": "MCAttach service is not ready",
+        "error_code": "mca_not_ready",
+    }), 503
+
+
+def _json_error(error_code: str, message: str):
+    return jsonify({"ok": False, "error": message, "error_code": error_code})
+
+
+def _parse_int(raw, *, default, minimum=None, maximum=None) -> int:
+    """Parse an integer query param, falling back to `default` on anything
+    unparseable and clamping into `[minimum, maximum]`. Pagination bounds
+    are best-effort (§7.1 documents no error code for a malformed
+    limit/offset), so a garbage value degrades to the default rather than
+    inventing a 400."""
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and value < minimum:
+        return minimum
+    if maximum is not None and value > maximum:
+        return maximum
+    return value
+
+
+def _parse_optional_int(raw):
+    """Parse an optional non-negative integer query param. Returns `None`
+    when absent/empty, the int when valid, and raises `ValueError` when
+    present but not a valid non-negative integer (a caller bug worth a
+    400, not a silent skip)."""
+    if raw is None or raw == "":
+        return None
+    value = int(raw)
+    if value < 0:
+        raise ValueError("must be non-negative")
+    return value
+
+
+def _resolve_attachment(facade, attachment_id):
+    """Validate `attachment_id` and look it up in the published snapshot.
+    Returns `(record, None)` on success, or `(None, (body, status))` with a
+    fully-built response on a validation/not-found/not-ready error. Catches
+    `FacadeNotReady` itself so `handle_errors` can never leak exception
+    text into a 500 for the normal "service still starting" case."""
+    if not _is_hex32(attachment_id):
+        return None, (_json_error("invalid_attachment_id", "invalid attachment id"), 400)
+    try:
+        record = facade.get_attachment(attachment_id)
+    except FacadeNotReady:
+        return None, (_not_ready()[0], 503)
+    if record is None:
+        return None, (_json_error("attachment_not_found", "attachment not found"), 404)
+    return record, None
+
+
+# ---- serializers (explicit allowlists, no dataclasses.asdict) ------------
+
+
+def _serialize_provider(profile, relay_status, *, include_latency_error=False):
+    """The §7.13 public provider projection, joined with the connectivity
+    snapshot's per-provider `RelayStatus` (§7.1). Never emits the raw
+    `service_public_key` bytes (replaced by its SHA-256 fingerprint), the
+    upload-token filename, or any upload token.
+
+    `state`/`upload_readiness` come from the relay status when it exists
+    (the monitor publishes one per registered profile during `refresh()`);
+    before the first refresh there is no `RelayStatus`, so `state` falls
+    back to `unknown` and `upload_readiness` to the pure, config-derived
+    `evaluate_upload_readiness(profile)` value - both are still correct,
+    they just reflect "not yet probed" rather than a live reading.
+
+    `include_latency_error` adds the live `latency_ms`/`error_code` the
+    list endpoint §7.1 joins (distinct from the profile's persisted
+    `last_latency_ms`/`last_error_code` cache)."""
+    fingerprint = hashlib.sha256(profile.service_public_key).hexdigest()
+    if relay_status is not None:
+        state = relay_status.state.value
+        upload_readiness = relay_status.upload_readiness.value
+    else:
+        state = RelayState.UNKNOWN.value
+        upload_readiness = evaluate_upload_readiness(profile).value
+    out = {
+        "provider_id": profile.provider_id,
+        "display_name": profile.display_name,
+        "origin": profile.origin,
+        "service_key_fingerprint": fingerprint,
+        "kind": profile.kind,
+        "tls_required": profile.tls_required,
+        "upload_allowed": profile.upload_allowed,
+        "download_allowed": profile.download_allowed,
+        "max_ciphertext_bytes": profile.max_ciphertext_bytes,
+        "is_default": profile.is_default,
+        "enabled": profile.enabled,
+        "min_ttl_seconds": profile.min_ttl_seconds,
+        "max_ttl_seconds": profile.max_ttl_seconds,
+        "protocol_version": profile.protocol_version,
+        "upload_token_configured": profile.upload_token_configured,
+        "last_checked_at": profile.last_checked_at,
+        "last_check_result": profile.last_check_result,
+        "last_latency_ms": profile.last_latency_ms,
+        "last_error_code": profile.last_error_code,
+        "state": state,
+        "upload_readiness": upload_readiness,
+    }
+    if include_latency_error:
+        out["latency_ms"] = relay_status.latency_ms if relay_status is not None else None
+        out["error_code"] = relay_status.error_code if relay_status is not None else None
+    return out
+
+
+def _serialize_identity(principal):
+    """The §7.1 identity projection. `fingerprint` is the full-key SHA-256
+    hex of `public_identity`, deliberately distinct from the 64-bit
+    `key_id`. Never emits `public_identity`/`public_x25519` bytes or the
+    private-key filename."""
+    return {
+        "principal_id": principal.principal_id,
+        "key_id": principal.key_id,
+        "epoch": principal.epoch,
+        "fingerprint": hashlib.sha256(principal.public_identity).hexdigest(),
+        "status": principal.status,
+    }
+
+
+def _jsonable(value):
+    """Recursively convert a worker-frozen `CommandResult.result` (nested
+    `MappingProxyType`/tuple - already JSON-native and validated, just
+    wrapped in read-only containers) back into plain dict/list values
+    `jsonify` can serialize. No `default=str`, no generic fallback."""
+    if isinstance(value, Mapping):
+        return {key: _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _serialize_command(result):
+    """The §7.9 command-result projection. `type` is the command kind; the
+    `result` payload was already validated JSON-native and no-secret by the
+    worker (command_registry), so `_jsonable` only un-freezes its shape."""
+    return {
+        "command_id": result.command_id,
+        "type": result.kind,
+        "status": result.status,
+        "resource_id": result.resource_id,
+        "result": _jsonable(result.result),
+        "error_code": result.error_code,
+        "created_at": result.created_at,
+        "updated_at": result.updated_at,
+    }
+
+
+# ---- route registration (DI pattern, no Blueprints) ----------------------
+
+
+def register_attachments_routes(app, handle_errors):
+    """Wire the ten §7.1 read endpoints onto `app`. Closes over nothing but
+    `mca_runtime.get_attachments_facade()` (the same already-constructed
+    runtime `server.py`'s `start_runtime()` builds) - the facade itself is
+    fetched per request, never captured, so a request thread can never hold
+    a stale facade across a profile switch / runtime reset."""
+
+    def _facade():
+        return mca_runtime.get_attachments_facade()
+
+    @app.route("/api/attachments", methods=["GET"])
+    @handle_errors
+    def list_attachments():
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        direction = request.args.get("direction", "all")
+        if direction not in _VALID_DIRECTIONS:
+            return _json_error("invalid_direction", "invalid direction"), 400
+
+        state = request.args.get("state", "all")
+        if state != "all" and state not in _ALL_STATES:
+            return _json_error("invalid_state", "invalid state"), 400
+
+        filter_ = request.args.get("filter", "all")
+        if filter_ not in _VALID_FILTERS:
+            return _json_error("invalid_filter", "invalid filter"), 400
+
+        limit = _parse_int(request.args.get("limit"), default=100, minimum=1, maximum=500)
+        offset = _parse_int(request.args.get("offset"), default=0, minimum=0)
+
+        try:
+            snapshot = facade.attachments_snapshot()
+        except FacadeNotReady:
+            return _not_ready()
+
+        matching = []
+        for record in snapshot.records:
+            if direction != "all" and record.direction != direction:
+                continue
+            if state != "all" and record.state != state:
+                continue
+            if filter_ == "pending" and record.state in _TERMINAL_STATES:
+                continue
+            if filter_ == "errors" and record.state not in _FILTER_ERROR_STATES:
+                continue
+            if filter_ == "saved" and not record.saved:
+                continue
+            matching.append(record)
+
+        total = len(matching)
+        page = matching[offset:offset + limit]
+        return jsonify({
+            "ok": True,
+            "attachments": [serialize_attachment_public(r) for r in page],
+            "total": total,
+        })
+
+    @app.route("/api/attachments/<attachment_id>", methods=["GET"])
+    @handle_errors
+    def get_attachment_detail(attachment_id):
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        record, err = _resolve_attachment(facade, attachment_id)
+        if err is not None:
+            body, status = err
+            return body, status
+
+        return jsonify({
+            "ok": True,
+            "attachment": serialize_attachment_public(record),
+            "timeline": [serialize_timeline_event(e) for e in record.timeline],
+        })
+
+    @app.route("/api/attachments/<attachment_id>/deliveries", methods=["GET"])
+    @handle_errors
+    def get_attachment_deliveries(attachment_id):
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        record, err = _resolve_attachment(facade, attachment_id)
+        if err is not None:
+            body, status = err
+            return body, status
+
+        return jsonify({
+            "ok": True,
+            "deliveries": [serialize_delivery(d) for d in record.deliveries],
+        })
+
+    @app.route("/api/mca/delivery-adapters", methods=["GET"])
+    @handle_errors
+    def mca_delivery_adapters():
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        # Read-only: the one real adapter (delivery/meshtastic.py) reports
+        # `connector_state`/`ack_semantics` from the *live* radio transport,
+        # which a read endpoint must not touch (§7.1 is a static capability
+        # snapshot, not a radio probe). This is the documented §7.1 shape,
+        # with the payload ceiling taken from the adapter's own constant.
+        return jsonify({
+            "ok": True,
+            "adapters": [{
+                "adapter_id": "meshtastic",
+                "connector_profile_id": "meshtastic",
+                "capabilities": {
+                    "wire_formats": ["MCA1_TEXT"],
+                    "max_payload_bytes": MESHTASTIC_TEXT_MAX_PAYLOAD_BYTES,
+                    "supports_direct": True,
+                    "supports_channel": False,
+                    "supports_incoming": True,
+                    "ack_semantics": "CONFIRMED",
+                    "connector_state": "READY",
+                },
+            }],
+        })
+
+    @app.route("/api/mca/providers", methods=["GET"])
+    @handle_errors
+    def mca_providers():
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        profiles = facade.provider_snapshot()
+        connectivity = facade.connectivity_snapshot()
+        providers = [
+            _serialize_provider(profile, connectivity.relays.get(provider_id), include_latency_error=True)
+            for provider_id, profile in profiles.items()
+        ]
+        return jsonify({"ok": True, "providers": providers})
+
+    @app.route("/api/mca/providers/<provider_id>", methods=["GET"])
+    @handle_errors
+    def mca_provider(provider_id):
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        profile = facade.provider_snapshot().get(provider_id)
+        if profile is None:
+            return _json_error("provider_not_found", "provider not found"), 404
+
+        relay_status = facade.connectivity_snapshot().relays.get(provider_id)
+        return jsonify({"ok": True, "provider": _serialize_provider(profile, relay_status)})
+
+    @app.route("/api/mca/providers/<provider_id>/upload-readiness", methods=["GET"])
+    @handle_errors
+    def mca_provider_upload_readiness(provider_id):
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        try:
+            ciphertext_bytes = _parse_optional_int(request.args.get("ciphertext_bytes"))
+            requested_ttl_seconds = _parse_optional_int(request.args.get("requested_ttl_seconds"))
+        except ValueError:
+            return _json_error("invalid_query", "invalid upload-readiness query parameter"), 400
+
+        decision = facade.evaluate_upload_readiness(
+            provider_id,
+            ciphertext_bytes=ciphertext_bytes,
+            requested_ttl_seconds=requested_ttl_seconds,
+        )
+        return jsonify({
+            "ok": True,
+            "ready": decision.ready,
+            "reason": decision.reason.value if decision.reason is not None else None,
+            "detail": None,
+        })
+
+    @app.route("/api/mca/connectivity", methods=["GET"])
+    @handle_errors
+    def mca_connectivity():
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        snapshot = facade.connectivity_snapshot()
+        relays = {
+            provider_id: {
+                "state": status.state.value,
+                "upload_readiness": status.upload_readiness.value,
+                "checked_at": status.checked_at,
+                "latency_ms": status.latency_ms,
+                "error_code": status.error_code,
+            }
+            for provider_id, status in snapshot.relays.items()
+        }
+        return jsonify({"ok": True, "internet": snapshot.internet.value, "relays": relays})
+
+    @app.route("/api/mca/identity", methods=["GET"])
+    @handle_errors
+    def mca_identity():
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        return jsonify({"ok": True, **_serialize_identity(facade.identity_snapshot())})
+
+    @app.route("/api/mca/commands/<command_id>", methods=["GET"])
+    @handle_errors
+    def mca_command(command_id):
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+
+        if not _is_hex32(command_id):
+            return _json_error("invalid_command_id", "invalid command id"), 400
+
+        result = facade.get_command(command_id)
+        if result is None:
+            return _json_error("command_not_found", "command not found"), 404
+
+        return jsonify({"ok": True, "command": _serialize_command(result)})

--- a/api/api_attachments.py
+++ b/api/api_attachments.py
@@ -34,23 +34,37 @@ No-secret discipline (§11): every response is built by an explicit
 allowlist serializer. No `dataclasses.asdict()`, no `__dict__`, no generic
 encoder. Upload tokens, token filenames, private-key filenames, raw public
 key bytes, filesystem paths, `ContentDescriptor.locator`, ciphertext, and
-internal SQLite fields never reach the wire. `handle_errors` (server.py)
-would otherwise turn an uncaught exception into a 500 envelope that leaks
-`str(e)`, so the readiness-gated reads catch `FacadeNotReady` themselves
-and the id/query validation returns the documented 400/404 codes directly.
+internal SQLite fields never reach the wire.
+
+Error boundary (§11 "no secret logging"): the project-wide `handle_errors`
+(server.py) turns an uncaught exception into a 500 envelope that leaks
+`str(e)` and, in debug mode, a traceback. Every handler here is therefore
+additionally wrapped in a local `_mca_error_boundary` (innermost, beneath
+`handle_errors`) that maps `FacadeNotReady` to the 503 `mca_not_ready`
+envelope and any other unexpected exception to a clean 500 `internal_error`
+envelope - no exception text, class name, traceback, path, or identifier in
+the response, and only the handler name + exception class logged. The
+legacy wrapper never sees an exception, so it cannot re-wrap or leak one.
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 from collections.abc import Mapping
+from functools import wraps
 
 from flask import jsonify, request
 
 from meshsrv.attachments import mca_runtime, receiver, sender
 from meshsrv.attachments.delivery.meshtastic import MESHTASTIC_TEXT_MAX_PAYLOAD_BYTES
 from meshsrv.attachments.facade import FacadeNotReady
+from meshsrv.attachments.provider_registry import (
+    ProviderRegistryError,
+    decode_provider_id,
+    encode_provider_id,
+)
 from meshsrv.attachments.snapshots import (
     serialize_attachment_public,
     serialize_delivery,
@@ -58,9 +72,16 @@ from meshsrv.attachments.snapshots import (
 )
 from meshsrv.connectivity_monitor import RelayState, evaluate_upload_readiness
 
+_log = logging.getLogger("meshsrv.attachments.api")
+
 # ---- id shapes (§7.9: attachment_id and command_id are both uuid4().hex) --
 
 _HEX32_RE = re.compile(r"^[0-9a-f]{32}$")
+
+# Strict ASCII-decimal shape for the numeric query params (§7.1): digits
+# only, no sign, no whitespace, no leading/trailing junk. `fullmatch` (not
+# `match`) so a trailing newline or space can never sneak past.
+_ASCII_DECIMAL_RE = re.compile(r"[0-9]+")
 
 
 def _is_hex32(value: str) -> bool:
@@ -97,12 +118,17 @@ _FILTER_ERROR_STATES = frozenset(
 _VALID_DIRECTIONS = frozenset({"sent", "received", "all"})
 _VALID_FILTERS = frozenset({"pending", "errors", "saved", "all"})
 
+_LIST_LIMIT_DEFAULT = 100
+_LIST_LIMIT_MIN = 1
+_LIST_LIMIT_MAX = 500
+
 
 # ---- small response helpers ----------------------------------------------
 
 
 def _not_ready():
-    """The one 503 every handler returns before the MCA runtime exists."""
+    """The one 503 every handler returns before the MCA runtime exists (or a
+    snapshot-backed read raises `FacadeNotReady`)."""
     return jsonify({
         "ok": False,
         "error": "MCAttach service is not ready",
@@ -114,50 +140,113 @@ def _json_error(error_code: str, message: str):
     return jsonify({"ok": False, "error": message, "error_code": error_code})
 
 
-def _parse_int(raw, *, default, minimum=None, maximum=None) -> int:
-    """Parse an integer query param, falling back to `default` on anything
-    unparseable and clamping into `[minimum, maximum]`. Pagination bounds
-    are best-effort (§7.1 documents no error code for a malformed
-    limit/offset), so a garbage value degrades to the default rather than
-    inventing a 400."""
-    if raw is None:
-        return default
+def _internal_error_response():
+    """The one sanitized 500 an unexpected exception maps to (§11): a stable
+    public message + `internal_error` - never `str(e)`, a class name, a
+    traceback, a path, or an identifier."""
+    return jsonify({
+        "ok": False,
+        "error": "Internal server error",
+        "error_code": "internal_error",
+    }), 500
+
+
+def _mca_error_boundary(fn):
+    """The local sanitized exception boundary for every MCAttach read
+    handler. It sits *beneath* the project-wide `handle_errors` decorator,
+    so it sees (and fully handles) every exception first: `handle_errors`
+    then only ever returns the clean response, never its own leaky 500.
+
+    `FacadeNotReady` -> 503 `mca_not_ready`; anything else -> 500
+    `internal_error`, logging only the handler name and the exception class
+    (never `str(exc)`, args, `exc_info`, the request body, the query string,
+    or any identifier)."""
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except FacadeNotReady:
+            return _not_ready()
+        except Exception as exc:  # noqa: BLE001 - this is the sanitized boundary itself
+            _log.error(
+                "MCAttach read endpoint '%s' raised %s", fn.__name__, type(exc).__name__
+            )
+            return _internal_error_response()
+
+    return wrapper
+
+
+def _parse_ascii_int(raw) -> int:
+    """Parse a strict ASCII decimal string. Raises `ValueError` for anything
+    that is not exactly ASCII digits - no `+`/`-` sign, no whitespace, no
+    `.`, no empty string. Callers decide bounds and the error envelope."""
+    if not isinstance(raw, str) or _ASCII_DECIMAL_RE.fullmatch(raw) is None:
+        raise ValueError("not an ASCII decimal integer")
+    return int(raw)
+
+
+def _parse_limit_offset():
+    """Strict pagination for `GET /api/attachments` (§7.1). An absent
+    `limit`/`offset` keeps the documented defaults (100 / 0); a present value
+    must be a strict ASCII decimal integer within bounds (`limit` 1..500,
+    `offset` >= 0), otherwise a 400 `invalid_pagination` - never silently
+    clamped or coerced to a default, and never a partially-executed query.
+
+    Returns `(limit, offset, None)` or `(None, None, (body, status))`."""
+    limit_raw = request.args.get("limit")
+    offset_raw = request.args.get("offset")
     try:
-        value = int(raw)
-    except (TypeError, ValueError):
-        return default
-    if minimum is not None and value < minimum:
-        return minimum
-    if maximum is not None and value > maximum:
-        return maximum
-    return value
+        limit = _LIST_LIMIT_DEFAULT if limit_raw is None else _parse_ascii_int(limit_raw)
+        offset = 0 if offset_raw is None else _parse_ascii_int(offset_raw)
+    except ValueError:
+        return None, None, (_json_error("invalid_pagination", "invalid pagination"), 400)
+    if not (_LIST_LIMIT_MIN <= limit <= _LIST_LIMIT_MAX):
+        return None, None, (_json_error("invalid_pagination", "invalid pagination"), 400)
+    return limit, offset, None
 
 
-def _parse_optional_int(raw):
-    """Parse an optional non-negative integer query param. Returns `None`
-    when absent/empty, the int when valid, and raises `ValueError` when
-    present but not a valid non-negative integer (a caller bug worth a
-    400, not a silent skip)."""
-    if raw is None or raw == "":
+def _parse_optional_query_int(raw, *, minimum: int):
+    """Parse an optional, non-negative-by-default integer query param. Returns
+    `None` when absent; the int when a valid strict ASCII decimal >= `minimum`;
+    raises `ValueError` when present but blank/malformed/signed/fractional, or
+    below `minimum` (a caller bug worth a 400, not a silent skip)."""
+    if raw is None:
         return None
-    value = int(raw)
-    if value < 0:
-        raise ValueError("must be non-negative")
+    value = _parse_ascii_int(raw)
+    if value < minimum:
+        raise ValueError(f"must be >= {minimum}")
     return value
+
+
+def _validate_provider_id(value):
+    """Canonical-provider-id validation shared by the two provider routes
+    (§7.1). Decodes with the registry's own `decode_provider_id()` (the one
+    existing encoding implementation - no second, hand-written one) and
+    requires canonical round-trip equality (`encode_provider_id(decode(v))
+    == v`), so padded, wrong-length, wrong-alphabet, and non-canonical
+    spellings are all rejected before any snapshot lookup or readiness
+    evaluation.
+
+    Returns `None` on success, or a `(body, status)` 400 `invalid_provider_id`
+    response on a malformed id."""
+    try:
+        decoded = decode_provider_id(value)
+    except ProviderRegistryError:
+        return _json_error("invalid_provider_id", "invalid provider id"), 400
+    if encode_provider_id(decoded) != value:
+        return _json_error("invalid_provider_id", "invalid provider id"), 400
+    return None
 
 
 def _resolve_attachment(facade, attachment_id):
     """Validate `attachment_id` and look it up in the published snapshot.
     Returns `(record, None)` on success, or `(None, (body, status))` with a
-    fully-built response on a validation/not-found/not-ready error. Catches
-    `FacadeNotReady` itself so `handle_errors` can never leak exception
-    text into a 500 for the normal "service still starting" case."""
+    fully-built response on a validation/not-found error. `FacadeNotReady`
+    is left to propagate to `_mca_error_boundary` (the single 503 mapping),
+    rather than being caught here."""
     if not _is_hex32(attachment_id):
         return None, (_json_error("invalid_attachment_id", "invalid attachment id"), 400)
-    try:
-        record = facade.get_attachment(attachment_id)
-    except FacadeNotReady:
-        return None, (_not_ready()[0], 503)
+    record = facade.get_attachment(attachment_id)
     if record is None:
         return None, (_json_error("attachment_not_found", "attachment not found"), 404)
     return record, None
@@ -275,6 +364,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/attachments", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def list_attachments():
         facade = _facade()
         if facade is None:
@@ -292,13 +382,12 @@ def register_attachments_routes(app, handle_errors):
         if filter_ not in _VALID_FILTERS:
             return _json_error("invalid_filter", "invalid filter"), 400
 
-        limit = _parse_int(request.args.get("limit"), default=100, minimum=1, maximum=500)
-        offset = _parse_int(request.args.get("offset"), default=0, minimum=0)
+        limit, offset, err = _parse_limit_offset()
+        if err is not None:
+            body, status = err
+            return body, status
 
-        try:
-            snapshot = facade.attachments_snapshot()
-        except FacadeNotReady:
-            return _not_ready()
+        snapshot = facade.attachments_snapshot()
 
         matching = []
         for record in snapshot.records:
@@ -324,6 +413,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/attachments/<attachment_id>", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def get_attachment_detail(attachment_id):
         facade = _facade()
         if facade is None:
@@ -342,6 +432,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/attachments/<attachment_id>/deliveries", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def get_attachment_deliveries(attachment_id):
         facade = _facade()
         if facade is None:
@@ -359,16 +450,21 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/delivery-adapters", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_delivery_adapters():
         facade = _facade()
         if facade is None:
             return _not_ready()
 
-        # Read-only: the one real adapter (delivery/meshtastic.py) reports
-        # `connector_state`/`ack_semantics` from the *live* radio transport,
-        # which a read endpoint must not touch (§7.1 is a static capability
-        # snapshot, not a radio probe). This is the documented §7.1 shape,
-        # with the payload ceiling taken from the adapter's own constant.
+        # Read-only: the real adapter's `connector_state` (READY/DEGRADED/
+        # UNAVAILABLE) is derived from the *live* radio transport's
+        # `get_connection_info()`, which a request thread must not touch.
+        # There is no request-thread-safe, immutable snapshot of the local
+        # radio's connection state (and internet/Relay state must never be
+        # conflated with it), so the read endpoint reports UNKNOWN rather
+        # than fabricating READY. The remaining fields are static
+        # capabilities (§7.1), with the payload ceiling from the adapter's
+        # own constant.
         return jsonify({
             "ok": True,
             "adapters": [{
@@ -381,13 +477,14 @@ def register_attachments_routes(app, handle_errors):
                     "supports_channel": False,
                     "supports_incoming": True,
                     "ack_semantics": "CONFIRMED",
-                    "connector_state": "READY",
+                    "connector_state": "UNKNOWN",
                 },
             }],
         })
 
     @app.route("/api/mca/providers", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_providers():
         facade = _facade()
         if facade is None:
@@ -403,10 +500,16 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/providers/<provider_id>", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_provider(provider_id):
         facade = _facade()
         if facade is None:
             return _not_ready()
+
+        err = _validate_provider_id(provider_id)
+        if err is not None:
+            body, status = err
+            return body, status
 
         profile = facade.provider_snapshot().get(provider_id)
         if profile is None:
@@ -417,14 +520,24 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/providers/<provider_id>/upload-readiness", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_provider_upload_readiness(provider_id):
         facade = _facade()
         if facade is None:
             return _not_ready()
 
+        err = _validate_provider_id(provider_id)
+        if err is not None:
+            body, status = err
+            return body, status
+
         try:
-            ciphertext_bytes = _parse_optional_int(request.args.get("ciphertext_bytes"))
-            requested_ttl_seconds = _parse_optional_int(request.args.get("requested_ttl_seconds"))
+            ciphertext_bytes = _parse_optional_query_int(
+                request.args.get("ciphertext_bytes"), minimum=0
+            )
+            requested_ttl_seconds = _parse_optional_query_int(
+                request.args.get("requested_ttl_seconds"), minimum=1
+            )
         except ValueError:
             return _json_error("invalid_query", "invalid upload-readiness query parameter"), 400
 
@@ -442,6 +555,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/connectivity", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_connectivity():
         facade = _facade()
         if facade is None:
@@ -462,6 +576,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/identity", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_identity():
         facade = _facade()
         if facade is None:
@@ -471,6 +586,7 @@ def register_attachments_routes(app, handle_errors):
 
     @app.route("/api/mca/commands/<command_id>", methods=["GET"])
     @handle_errors
+    @_mca_error_boundary
     def mca_command(command_id):
         facade = _facade()
         if facade is None:

--- a/docs/attachments/internal-rest-api.md
+++ b/docs/attachments/internal-rest-api.md
@@ -1,6 +1,6 @@
 # MCAttach Internal REST API Contract
 
-**Status:** Design contract (Step 1.6A), revised (second pass). This document defines the HTTP surface — it does **not** implement it. No endpoint below exists yet; no runtime code, migration, test, JS, HTML or CSS was changed in the Step 1.6A change that added/revised this document.
+**Status:** Design contract (Step 1.6A), revised (second pass). The read-only endpoints of sub-stage 1.6A.2 (§5) are implemented in `api/api_attachments.py`; every mutation endpoint (sub-stages 1.6A.3–1.6A.5) remains design-only and does not exist yet.
 **Canonical source:** the Russian system design spec (section 18 primary, sections 17/19/20 and the state machines also consulted). That spec is reference-only and is not committed to the repository.
 **Audience:** a future implementation task, split into sub-stages (§5).
 

--- a/docs/attachments/internal-rest-api.md
+++ b/docs/attachments/internal-rest-api.md
@@ -387,9 +387,9 @@ Every mutation returns `202` + `command_id` (§3.4) unless a synchronous validat
 ### 7.1 Reads (1.6A.2)
 
 **`GET /api/attachments`** — list.
-- Query: `direction` (`sent`|`received`|`all`, default `all`); `state` (one state or `all`); `filter` (`pending`|`errors`|`saved`|`all`); `limit` (default 100, max 500); `offset` (default 0).
+- Query: `direction` (`sent`|`received`|`all`, default `all`); `state` (one state or `all`); `filter` (`pending`|`errors`|`saved`|`all`); `limit` (default 100, range 1–500); `offset` (default 0, ≥ 0). A present `limit`/`offset` must be a strict ASCII decimal integer within bounds — malformed or out-of-range values are a hard `400 invalid_pagination`, never silently clamped or coerced to a default.
 - Response: `{"ok": true, "attachments": [<public projection §7.5>], "total": <int>}`.
-- Errors: `400 invalid_direction` / `invalid_state` / `invalid_filter`.
+- Errors: `400 invalid_direction` / `invalid_state` / `invalid_filter` / `invalid_pagination`.
 
 **`GET /api/attachments/{id}`** — detail + timeline.
 - Response: `{"ok": true, "attachment": {…§7.5…}, "timeline": [{"event_type", "detail", "created_at"}]}` (timeline from `attachment_events`, redacted per §11).
@@ -403,17 +403,19 @@ Every mutation returns `202` + `command_id` (§3.4) unless a synchronous validat
 - Response: `{"ok": true, "contacts": [{"source_address", "key_id", "status": "trusted|confirmation_required|key_unknown|key_changed"}]}`.
 
 **`GET /api/mca/delivery-adapters`** — capabilities/state of the one adapter.
-- Response: `{"ok": true, "adapters": [{"adapter_id": "meshtastic", "connector_profile_id": "meshtastic", "capabilities": {"wire_formats": ["MCA1_TEXT"], "max_payload_bytes": 180, "supports_direct": true, "supports_channel": false, "supports_incoming": true, "ack_semantics": "CONFIRMED", "connector_state": "READY"}}]}`.
+- Response: `{"ok": true, "adapters": [{"adapter_id": "meshtastic", "connector_profile_id": "meshtastic", "capabilities": {"wire_formats": ["MCA1_TEXT"], "max_payload_bytes": 180, "supports_direct": true, "supports_channel": false, "supports_incoming": true, "ack_semantics": "CONFIRMED", "connector_state": "UNKNOWN"}}]}`.
+- `connector_state` is always `"UNKNOWN"` on this read endpoint: the real adapter's `ConnectorState` (`READY`/`DEGRADED`/`UNAVAILABLE`) is derived from the live radio transport's `get_connection_info()` (§4.6), which a request thread must not touch (§3.1), and there is no request-thread-safe immutable snapshot of it. It must never be conflated with internet/Relay status (those live in `connectivity` above), and it is never fabricated as `READY`.
 
 **`GET /api/mca/connectors`** — Multi-transport placeholder; MVP returns the single Meshtastic connector plus its BLE receive-blindness flag.
 
 **`GET /api/mca/providers`** — registry.
 - Response: `{"ok": true, "providers": [<public provider projection §7.12>]}` — includes `state`/`upload_readiness`/`latency_ms`/`error_code` joined from the connectivity snapshot by `provider_id`.
 
-**`GET /api/mca/providers/{id}`** — one profile (public projection §7.12). `404 provider_not_found`.
+**`GET /api/mca/providers/{id}`** — one profile (public projection §7.12). The `{id}` is canonical-validated via the registry's own `decode_provider_id`/`encode_provider_id` (round-trip equality), so a padded/wrong-length/wrong-alphabet/non-canonical id is `400 invalid_provider_id`. A canonical-but-unregistered id is `404 provider_not_found`.
 
 **`GET /api/mca/providers/{id}/upload-readiness`** — delegates to `AttachmentsService.evaluate_upload_readiness()`.
-- Query (optional): `ciphertext_bytes`, `requested_ttl_seconds`.
+- `{id}` is canonical-validated as in the provider detail endpoint (`400 invalid_provider_id`); a canonical-but-unregistered id returns `200` `{"ready": false, "reason": "profile_not_found"}`.
+- Query (optional): `ciphertext_bytes` (ASCII decimal, ≥ 0); `requested_ttl_seconds` (ASCII decimal, > 0). A present value that is blank/malformed/signed/fractional/out-of-range — including a zero or negative `requested_ttl_seconds` — is a `400 invalid_query`. `ciphertext_bytes: 0` is valid.
 - Response: `{"ok": true, "ready": bool, "reason": "<UploadRejectionReason|null>", "detail": null}`.
 
 **`GET /api/mca/connectivity`** — `{"ok": true, "internet": "...", "relays": {provider_id: {"state","upload_readiness","checked_at","latency_ms","error_code"}}}`.
@@ -641,7 +643,7 @@ Stable, snake_case, additive.
 
 | Status | `error_code` | Meaning |
 |---|---|---|
-| 400 | `invalid_metadata` / `invalid_attachment_id` / `invalid_direction` / `invalid_state` / `invalid_filter` / `invalid_command_id` / `invalid_origin` | malformed input |
+| 400 | `invalid_metadata` / `invalid_attachment_id` / `invalid_direction` / `invalid_state` / `invalid_filter` / `invalid_command_id` / `invalid_origin` / `invalid_pagination` / `invalid_provider_id` / `invalid_query` | malformed input |
 | 400 | `mime_not_allowed` / `file_too_large` | file validation |
 | 400 | `recipient_not_found` / `recipient_not_trusted` | binding missing or not `trusted` |
 | 400 | `provider_not_found` / `ttl_out_of_range` / `provider_id_mismatch` | provider/registration |
@@ -661,6 +663,7 @@ Stable, snake_case, additive.
 | 429 | `command_queue_full` | worker command queue at capacity |
 | 503 | `radio_unavailable` / `relay_unreachable` | runtime unavailability at an action's execution |
 | 503 | `mca_not_ready` | the attachments facade exists but readiness is unset (service not yet started, or the first snapshot publish failed); snapshot-backed reads and `submit()` reject until readiness (§3.2) |
+| 500 | `internal_error` | an unexpected exception was sanitized by the MCAttach read endpoint's local error boundary — a stable envelope with no exception text, class, traceback, or path (§11) |
 
 Command-result `error_code`s reuse this table plus the probe failure codes (`origin_not_routable`, `relay_identity_mismatch`, `relay_incompatible`) and the two worker-side execution codes `unsupported_command_kind` (an enumerated kind with no wired handler — a terminal `failed`, never a crash) and `command_execution_failed` (a wired handler raised; the drain loop records it as a terminal `failed`). `UploadRejectionReason` maps 1:1 to `error_code`s on upload-readiness: `profile_not_found`, `profile_disabled`, `upload_not_allowed`, `upload_token_missing`, `relay_not_yet_checked`, `relay_unreachable`, `relay_identity_mismatch`, `relay_incompatible`, `ciphertext_too_large`, `ttl_below_minimum`, `ttl_above_maximum`.
 

--- a/meshsrv/attachments/service.py
+++ b/meshsrv/attachments/service.py
@@ -502,14 +502,25 @@ class AttachmentsService:
         the tick continues."""
         try:
             self._command_registry.mark_running(command.command_id)
-        except Exception:  # noqa: BLE001 - an impossible transition must not kill the tick
-            logger.exception("AttachmentsService: could not mark command %s running", command.command_id)
+        except Exception as exc:  # noqa: BLE001 - an impossible transition must not kill the tick
+            # Sanitized: no exception text/traceback (the exception may be
+            # influenced by command input) - log only safe identifiers + class.
+            logger.error(
+                "AttachmentsService: could not mark command %s (%s) running: %s",
+                command.command_id, command.kind, type(exc).__name__,
+            )
             self._recover_internal_failure(command)
             return
         try:
             outcome = self._dispatcher.dispatch(command)
-        except Exception:  # noqa: BLE001 - a raising handler (or an invalid outcome) must not stop the drain
-            logger.exception("AttachmentsService: command handler raised for %s", command.command_id)
+        except Exception as exc:  # noqa: BLE001 - a raising handler (or an invalid outcome) must not stop the drain
+            # Sanitized: a handler exception's text may embed file names,
+            # Relay tokens, keys, comments or other untrusted command input -
+            # log only the safe identifier, kind and exception class.
+            logger.error(
+                "AttachmentsService: command %s (%s) handler raised %s",
+                command.command_id, command.kind, type(exc).__name__,
+            )
             self._record_failed(command, COMMAND_EXECUTION_FAILED)
             return
         if not isinstance(outcome, CommandOutcome):
@@ -539,8 +550,11 @@ class AttachmentsService:
             self._command_registry.mark_succeeded(
                 command.command_id, resource_id=outcome.resource_id, result=outcome.result
             )
-        except Exception:  # noqa: BLE001 - a transition error must not kill the tick
-            logger.exception("AttachmentsService: could not mark command %s succeeded", command.command_id)
+        except Exception as exc:  # noqa: BLE001 - a transition error must not kill the tick
+            logger.error(
+                "AttachmentsService: could not mark command %s (%s) succeeded: %s",
+                command.command_id, command.kind, type(exc).__name__,
+            )
             self._recover_internal_failure(command)
 
     def _record_failed(self, command: Command, error_code: str) -> None:
@@ -553,16 +567,20 @@ class AttachmentsService:
         already-terminal entry."""
         try:
             self._command_registry.mark_failed(command.command_id, error_code=error_code)
-        except Exception:  # noqa: BLE001 - a transition error must not kill the tick
-            logger.exception("AttachmentsService: could not mark command %s failed", command.command_id)
+        except Exception as exc:  # noqa: BLE001 - a transition error must not kill the tick
+            logger.error(
+                "AttachmentsService: could not mark command %s (%s) failed: %s",
+                command.command_id, command.kind, type(exc).__name__,
+            )
             self._recover_internal_failure(command)
 
     def _recover_internal_failure(self, command: Command) -> None:
         """Invoke the registry's internal-recovery fail-safe (final correction
         pass). It terminalizes a `queued`/`running` entry (or materializes a
         missing one) to `command_execution_failed` under the registry's own
-        lock, and never overwrites an already-terminal result. It logs only the
-        safe identifier (command_id) and exception class, never the payload.
+        lock, and never overwrites an already-terminal result. It logs only
+        safe identifiers (command_id and the enumerated kind) and the
+        exception class, never the exception text, traceback, or payload.
 
         A failure *here* means the registry itself is corrupt - there is
         nothing left to record against - so the worker logs it and survives
@@ -571,10 +589,11 @@ class AttachmentsService:
         and that is documented rather than papered over."""
         try:
             self._command_registry.record_internal_failure(command)
-        except Exception:  # noqa: BLE001 - registry corruption; survive, do not raise
-            logger.exception(
-                "AttachmentsService: could not record internal failure for command %s "
-                "(registry corruption)", command.command_id,
+        except Exception as exc:  # noqa: BLE001 - registry corruption; survive, do not raise
+            logger.error(
+                "AttachmentsService: could not record internal failure for command %s (%s) "
+                "(registry corruption): %s",
+                command.command_id, command.kind, type(exc).__name__,
             )
 
     def _refresh_snapshot(self) -> None:

--- a/server.py
+++ b/server.py
@@ -60,6 +60,7 @@ from api.api_settings import register_settings_routes, normalize_settings, SUPPO
 from api.api_meshtastic import register_meshtastic_routes
 from api.api_system import register_system_routes
 from api.api_updates import register_updates_routes
+from api.api_attachments import register_attachments_routes
 from system.cpu_history import (
     get_current_usage as get_cpu_current_usage,
     read_cpu_temperature,
@@ -537,6 +538,7 @@ register_camera_manager_routes(app, device_manager, handle_errors, camera_manage
 register_system_routes(app, get_cpu_temperature=lambda: read_cpu_temperature(), get_app_version=lambda: APP_VERSION)
 register_cpu_history_routes(app, CPU_HISTORY_FILE)
 register_updates_routes(app, resolve_version=lambda: APP_VERSION, project_dir=PROJECT_DIR, handle_errors=handle_errors)
+register_attachments_routes(app, handle_errors)
 
 # Constructing DisplayManager (and the driver it wraps) never touches
 # SPI/GPIO by itself - only display_manager.start(), called later from the

--- a/tests/test_mca_api_attachments.py
+++ b/tests/test_mca_api_attachments.py
@@ -17,12 +17,21 @@ network/tick (the endpoints only read facade snapshots); the service is
 first snapshot publish; every error uses the documented 400/404 codes; and
 no secret (upload token, private-key filename, raw public key bytes,
 locator/ciphertext/internal fields) reaches the wire.
+
+It also pins the five review corrections to Step 1.6A.2: delivery-adapters
+never fabricates `connector_state: READY` (§ UNKNOWN); pagination is strict
+(`invalid_pagination`, never clamped); provider ids are canonical-validated
+(`invalid_provider_id`); every route has a sanitized exception boundary
+(`internal_error`, no `str(e)`/traceback/marker); and `requested_ttl_seconds`
+must be a positive ASCII decimal (`invalid_query`).
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import threading
+import traceback
 from functools import wraps
 from types import SimpleNamespace
 
@@ -34,6 +43,11 @@ from meshsrv.attachments import mca_runtime
 from meshsrv.attachments.command_registry import CommandResult, STATUS_SUCCEEDED
 from meshsrv.attachments.delivery.fakes import FakeRadioTransport, InMemoryEther
 from meshsrv.attachments.facade import FacadeNotReady
+from meshsrv.attachments.provider_registry import (
+    ProviderRegistryError,
+    decode_provider_id,
+    encode_provider_id,
+)
 from meshsrv.attachments.snapshots import (
     AttachmentRecord,
     AttachmentsSnapshot,
@@ -54,31 +68,61 @@ from meshsrv.connectivity_monitor import (
 ATTACHMENT_ID = "0" * 32
 COMMAND_ID = "f" * 32
 
+# Canonical provider ids, derived from the registry's own encoder (the one
+# source of truth for what "canonical Base64URL" means). PROVIDER_ID is
+# registered in the fakes; UNREGISTERED_PROVIDER_ID is canonical but never
+# registered, so it exercises the 404 / profile_not_found paths.
+PROVIDER_ID = encode_provider_id(b"\x00" * 8)
+UNREGISTERED_PROVIDER_ID = encode_provider_id(b"\x01" * 8)
+
+# Malformed / non-canonical provider ids that must all 400
+# `invalid_provider_id` on both provider routes (padded, wrong-length,
+# invalid-alphabet, and non-canonical-trailing-bits spellings).
+MALFORMED_PROVIDER_IDS = [
+    PROVIDER_ID + "=",   # padded (non-canonical spelling)
+    "AAAA",              # wrong length (decodes to 3 bytes, not 8)
+    "AAAAAAAAAAAA",      # wrong length (decodes to 9 bytes, not 8)
+    "AAAAAAAAAAB",       # non-canonical trailing bits
+    "AAAAAAAAAA!",       # invalid alphabet character
+]
+
 
 # ---- minimal handle_errors (mirrors server.py's behaviour) ----------------
 
-def _handle_errors(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        try:
-            return f(*args, **kwargs)
-        except Exception as e:  # pragma: no cover - safety net only
-            return jsonify({"ok": False, "error": str(e), "traceback": None}), 500
+def _make_handle_errors(app):
+    """Mirror server.py's `handle_errors`, including the debug-mode traceback
+    it would emit for an uncaught exception. The local `_mca_error_boundary`
+    must catch everything first, so this leaky safety net is never reached."""
+    def _handle_errors(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            try:
+                return f(*args, **kwargs)
+            except Exception as e:  # pragma: no cover - safety net only
+                return jsonify({
+                    "ok": False,
+                    "error": str(e),
+                    "traceback": traceback.format_exc() if app.debug else None,
+                }), 500
 
-    return decorated
+        return decorated
+
+    return _handle_errors
 
 
-def _build_client():
+def _build_client(debug=False):
     app = Flask(__name__)
     app.config["TESTING"] = True
-    register_attachments_routes(app, _handle_errors)
+    if debug:
+        app.debug = True
+    register_attachments_routes(app, _make_handle_errors(app))
     return app.test_client()
 
 
-def _client(monkeypatch, facade):
+def _client(monkeypatch, facade, debug=False):
     """A Flask test client whose per-request facade lookup returns `facade`."""
     monkeypatch.setattr(mca_runtime, "get_attachments_facade", lambda: facade)
-    return _build_client()
+    return _build_client(debug=debug)
 
 
 # ---- fake facade + record builders ---------------------------------------
@@ -96,7 +140,7 @@ def _attachment(id=ATTACHMENT_ID, direction="sent", state="SENT", **overrides):
         created_at=100.0,
         hard_expires_at=200.0,
         download_grace_seconds=3600,
-        provider_id="AbCdEfGhIjK",
+        provider_id=PROVIDER_ID,
         saved=False,
         primary_delivery_id=None,
         error_code=None,
@@ -167,9 +211,25 @@ class _FakeFacade:
         return self._identity
 
 
+class _RaisingFacade(_FakeFacade):
+    """A fake whose `provider_snapshot()`/`identity_snapshot()` raise with a
+    caller-supplied secret marker, to prove the sanitized boundary never lets
+    the exception text reach the wire or the log."""
+
+    def __init__(self, marker="SECRET_MARKER_x7k3", **kwargs):
+        super().__init__(**kwargs)
+        self._marker = marker
+
+    def provider_snapshot(self):
+        raise RuntimeError(f"boom {self._marker}")
+
+    def identity_snapshot(self):
+        raise ValueError(f"leak {self._marker}")
+
+
 def _provider(**overrides):
     base = dict(
-        provider_id="AbCdEfGhIjK",
+        provider_id=PROVIDER_ID,
         display_name="Example Relay",
         origin="https://relay.example.net",
         service_public_key=b"K" * 32,
@@ -195,7 +255,7 @@ def _provider(**overrides):
 
 def _relay_status(**overrides):
     base = dict(
-        provider_id="AbCdEfGhIjK",
+        provider_id=PROVIDER_ID,
         state=RelayState.ONLINE,
         upload_readiness=UploadReadiness.READY,
         checked_at=300.0,
@@ -252,8 +312,8 @@ _ALL_PATHS = [
     f"/api/attachments/{ATTACHMENT_ID}/deliveries",
     "/api/mca/delivery-adapters",
     "/api/mca/providers",
-    "/api/mca/providers/AbCdEfGhIjK",
-    "/api/mca/providers/AbCdEfGhIjK/upload-readiness",
+    f"/api/mca/providers/{PROVIDER_ID}",
+    f"/api/mca/providers/{PROVIDER_ID}/upload-readiness",
     "/api/mca/connectivity",
     "/api/mca/identity",
     f"/api/mca/commands/{COMMAND_ID}",
@@ -301,7 +361,7 @@ def test_registry_and_connectivity_endpoints_are_not_readiness_gated(monkeypatch
     assert c.get("/api/mca/connectivity").status_code == 200
     assert c.get("/api/mca/delivery-adapters").status_code == 200
     assert c.get(f"/api/mca/commands/{COMMAND_ID}").status_code == 404
-    assert c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").status_code == 200
+    assert c.get(f"/api/mca/providers/{PROVIDER_ID}/upload-readiness").status_code == 200
 
 
 def test_real_runtime_serves_empty_reads_after_startup(tmp_path):
@@ -356,7 +416,7 @@ def test_routes_reject_non_get_methods(monkeypatch):
     c = _client(monkeypatch, _FakeFacade())
     assert c.post("/api/attachments").status_code == 405
     assert c.put("/api/mca/identity").status_code == 405
-    assert c.delete("/api/mca/providers/AbCdEfGhIjK").status_code == 405
+    assert c.delete(f"/api/mca/providers/{PROVIDER_ID}").status_code == 405
 
 
 # ---- GET /api/attachments -------------------------------------------------
@@ -459,15 +519,49 @@ def test_list_total_is_before_pagination(monkeypatch):
     assert body["total"] == 5  # total is the full filtered count, not the page
 
 
-def test_list_limit_and_offset_clamping(monkeypatch):
+@pytest.mark.parametrize(
+    "query",
+    [
+        "limit=0",      # below minimum
+        "limit=501",    # above maximum
+        "limit=abc",    # non-numeric
+        "limit=-1",     # signed
+        "limit=5.5",    # fractional
+        "limit=+5",     # signed
+        "limit=",       # blank (present but empty)
+        "offset=-1",    # signed
+        "offset=abc",   # non-numeric
+        "offset=5.5",   # fractional
+        "offset=+1",    # signed
+        "offset=",      # blank
+    ],
+)
+def test_list_invalid_pagination(monkeypatch, query):
+    # A present-but-malformed or out-of-range limit/offset is a hard 400
+    # `invalid_pagination`, never a clamp or a silent default.
     facade = _FakeFacade(snapshot=_snapshot([_attachment(id=f"{i:032x}") for i in range(3)]))
     c = _client(monkeypatch, facade)
-    # limit above 500 clamps to 500; negative offset clamps to 0; garbage
-    # falls back to defaults (100) rather than a 400.
-    body = c.get("/api/attachments?limit=9999&offset=-5").get_json()
+    resp = c.get(f"/api/attachments?{query}")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_pagination"
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("", 3),                 # defaults (limit=100, offset=0)
+        ("limit=1", 1),          # lower bound
+        ("limit=500", 3),        # upper bound accepted (only 3 records exist)
+        ("offset=0", 3),         # offset lower bound
+        ("limit=2&offset=1", 2),  # page 2 of 3
+    ],
+)
+def test_list_pagination_valid_boundaries(monkeypatch, query, expected):
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(id=f"{i:032x}") for i in range(3)]))
+    c = _client(monkeypatch, facade)
+    body = c.get(f"/api/attachments?{query}" if query else "/api/attachments").get_json()
     assert body["total"] == 3
-    assert len(body["attachments"]) == 3
-    assert c.get("/api/attachments?limit=abc").status_code == 200
+    assert len(body["attachments"]) == expected
 
 
 @pytest.mark.parametrize(
@@ -562,23 +656,37 @@ def test_deliveries_invalid_and_missing(monkeypatch):
 # ---- GET /api/mca/delivery-adapters --------------------------------------
 
 
-def test_delivery_adapters_static_shape(monkeypatch):
+def test_delivery_adapters_reports_unknown_connector_state(monkeypatch):
+    # The read endpoint must NOT fabricate readiness: the real adapter's
+    # connector_state derives from the live radio transport's
+    # `get_connection_info()` (not request-thread-safe), and there is no
+    # immutable snapshot of it. So it reports UNKNOWN, never READY.
     c = _client(monkeypatch, _FakeFacade())
     body = c.get("/api/mca/delivery-adapters").get_json()
     assert body["ok"] is True
-    assert body["adapters"] == [{
-        "adapter_id": "meshtastic",
-        "connector_profile_id": "meshtastic",
-        "capabilities": {
-            "wire_formats": ["MCA1_TEXT"],
-            "max_payload_bytes": 180,
-            "supports_direct": True,
-            "supports_channel": False,
-            "supports_incoming": True,
-            "ack_semantics": "CONFIRMED",
-            "connector_state": "READY",
-        },
-    }]
+    adapter = body["adapters"][0]
+    assert adapter["adapter_id"] == "meshtastic"
+    assert adapter["connector_profile_id"] == "meshtastic"
+    assert adapter["capabilities"]["connector_state"] == "UNKNOWN"
+    # The static capability fields are still present and unchanged.
+    assert adapter["capabilities"]["wire_formats"] == ["MCA1_TEXT"]
+    assert adapter["capabilities"]["max_payload_bytes"] == 180
+    assert adapter["capabilities"]["ack_semantics"] == "CONFIRMED"
+
+
+def test_delivery_adapters_does_not_derive_state_from_connectivity(monkeypatch):
+    # Internet/Relay status must never be conflated with the adapter's
+    # connector_state: even with the relay ONLINE and internet up, the read
+    # endpoint still reports UNKNOWN (no request-thread-safe radio state).
+    relay = _relay_status()
+    facade = _FakeFacade(
+        connectivity=ConnectivitySnapshot(
+            internet=InternetStatus.ONLINE, relays={PROVIDER_ID: relay}
+        )
+    )
+    c = _client(monkeypatch, facade)
+    adapter = c.get("/api/mca/delivery-adapters").get_json()["adapters"][0]
+    assert adapter["capabilities"]["connector_state"] == "UNKNOWN"
 
 
 # ---- GET /api/mca/providers ----------------------------------------------
@@ -593,9 +701,9 @@ def test_providers_list_joins_connectivity_without_raw_key(monkeypatch):
     provider = _provider()
     relay = _relay_status()
     facade = _FakeFacade(
-        providers={"AbCdEfGhIjK": provider},
+        providers={PROVIDER_ID: provider},
         connectivity=ConnectivitySnapshot(
-            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+            internet=InternetStatus.ONLINE, relays={PROVIDER_ID: relay}
         ),
     )
     c = _client(monkeypatch, facade)
@@ -604,7 +712,7 @@ def test_providers_list_joins_connectivity_without_raw_key(monkeypatch):
     assert body["ok"] is True
     assert len(body["providers"]) == 1
     item = body["providers"][0]
-    assert item["provider_id"] == "AbCdEfGhIjK"
+    assert item["provider_id"] == PROVIDER_ID
     assert item["display_name"] == "Example Relay"
     assert item["service_key_fingerprint"] == hashlib.sha256(b"K" * 32).hexdigest()
     assert item["state"] == "online"
@@ -620,7 +728,7 @@ def test_providers_list_falls_back_when_no_relay_status(monkeypatch):
     # No RelayStatus yet (monitor never refreshed) -> state "unknown" and
     # upload_readiness derived from config only; latency/error are null.
     provider = _provider(upload_token_configured=False)
-    facade = _FakeFacade(providers={"AbCdEfGhIjK": provider})
+    facade = _FakeFacade(providers={PROVIDER_ID: provider})
     c = _client(monkeypatch, facade)
     item = c.get("/api/mca/providers").get_json()["providers"][0]
     assert item["state"] == "unknown"
@@ -636,17 +744,17 @@ def test_provider_detail_projection_omits_live_latency_fields(monkeypatch):
     provider = _provider()
     relay = _relay_status()
     facade = _FakeFacade(
-        providers={"AbCdEfGhIjK": provider},
+        providers={PROVIDER_ID: provider},
         connectivity=ConnectivitySnapshot(
-            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+            internet=InternetStatus.ONLINE, relays={PROVIDER_ID: relay}
         ),
     )
     c = _client(monkeypatch, facade)
-    body = c.get("/api/mca/providers/AbCdEfGhIjK").get_json()
+    body = c.get(f"/api/mca/providers/{PROVIDER_ID}").get_json()
 
     assert body["ok"] is True
     item = body["provider"]
-    assert item["provider_id"] == "AbCdEfGhIjK"
+    assert item["provider_id"] == PROVIDER_ID
     assert item["state"] == "online"
     assert item["upload_readiness"] == "ready"
     # The detail projection is §7.13 only - no live latency/error join.
@@ -655,11 +763,53 @@ def test_provider_detail_projection_omits_live_latency_fields(monkeypatch):
     assert "service_public_key" not in item
 
 
-def test_provider_detail_not_found(monkeypatch):
+# ---- provider id canonical validation (both provider routes) -------------
+
+
+@pytest.mark.parametrize("path", [
+    f"/api/mca/providers/{PROVIDER_ID}",
+    f"/api/mca/providers/{PROVIDER_ID}/upload-readiness",
+])
+def test_provider_id_canonical_known(monkeypatch, path):
+    facade = _FakeFacade(
+        providers={PROVIDER_ID: _provider()},
+        connectivity=ConnectivitySnapshot(internet=InternetStatus.UNKNOWN, relays={}),
+        decisions={PROVIDER_ID: UploadDecision(ready=True, reason=None, detail=None)},
+    )
+    c = _client(monkeypatch, facade)
+    assert c.get(path).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path,status,error_code",
+    [
+        (f"/api/mca/providers/{UNREGISTERED_PROVIDER_ID}", 404, "provider_not_found"),
+        (f"/api/mca/providers/{UNREGISTERED_PROVIDER_ID}/upload-readiness", 200, "profile_not_found"),
+    ],
+)
+def test_provider_id_canonical_unknown(monkeypatch, path, status, error_code):
+    # A canonical-but-unregistered id is a well-formed id that resolves to
+    # nothing: 404 on detail, and a 200 ready:false profile_not_found on
+    # upload-readiness (the readiness eval reports the miss as a rejection).
     c = _client(monkeypatch, _FakeFacade())
-    resp = c.get("/api/mca/providers/never-registered")
-    assert resp.status_code == 404
-    assert resp.get_json()["error_code"] == "provider_not_found"
+    resp = c.get(path)
+    assert resp.status_code == status
+    if status == 404:
+        assert resp.get_json()["error_code"] == error_code
+    else:
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["ready"] is False
+        assert body["reason"] == error_code
+
+
+@pytest.mark.parametrize("provider_id", MALFORMED_PROVIDER_IDS)
+@pytest.mark.parametrize("suffix", ["", "/upload-readiness"])
+def test_provider_id_malformed(monkeypatch, provider_id, suffix):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get(f"/api/mca/providers/{provider_id}{suffix}")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_provider_id"
 
 
 # ---- GET /api/mca/providers/{id}/upload-readiness ------------------------
@@ -667,35 +817,74 @@ def test_provider_detail_not_found(monkeypatch):
 
 def test_upload_readiness_ready(monkeypatch):
     facade = _FakeFacade(
-        decisions={"AbCdEfGhIjK": UploadDecision(ready=True, reason=None, detail=None)}
+        decisions={PROVIDER_ID: UploadDecision(ready=True, reason=None, detail=None)}
     )
     c = _client(monkeypatch, facade)
-    body = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").get_json()
+    body = c.get(f"/api/mca/providers/{PROVIDER_ID}/upload-readiness").get_json()
     assert body == {"ok": True, "ready": True, "reason": None, "detail": None}
 
 
 def test_upload_readiness_rejected_with_reason(monkeypatch):
     facade = _FakeFacade(
         decisions={
-            "AbCdEfGhIjK": UploadDecision(
+            PROVIDER_ID: UploadDecision(
                 ready=False, reason=UploadRejectionReason.CIPHERTEXT_TOO_LARGE, detail=None
             )
         }
     )
     c = _client(monkeypatch, facade)
-    body = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").get_json()
+    body = c.get(f"/api/mca/providers/{PROVIDER_ID}/upload-readiness").get_json()
     assert body["ok"] is True
     assert body["ready"] is False
     assert body["reason"] == "ciphertext_too_large"
 
 
-def test_upload_readiness_malformed_query(monkeypatch):
+@pytest.mark.parametrize(
+    "query",
+    [
+        "requested_ttl_seconds=0",    # zero
+        "requested_ttl_seconds=-3",   # negative (signed)
+        "requested_ttl_seconds=",     # blank
+        "requested_ttl_seconds=abc",  # malformed
+        "requested_ttl_seconds=+5",   # signed
+        "requested_ttl_seconds=5.5",  # fractional
+    ],
+)
+def test_upload_readiness_rejects_invalid_ttl(monkeypatch, query):
     c = _client(monkeypatch, _FakeFacade())
-    resp = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness?ciphertext_bytes=abc")
+    resp = c.get(f"/api/mca/providers/{PROVIDER_ID}/upload-readiness?{query}")
     assert resp.status_code == 400
     assert resp.get_json()["error_code"] == "invalid_query"
-    resp2 = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness?requested_ttl_seconds=-3")
-    assert resp2.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "ciphertext_bytes=abc",  # malformed
+        "ciphertext_bytes=-1",   # negative (signed)
+        "ciphertext_bytes=5.5",  # fractional
+        "ciphertext_bytes=+5",   # signed
+        "ciphertext_bytes=",     # blank
+    ],
+)
+def test_upload_readiness_rejects_invalid_ciphertext(monkeypatch, query):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get(f"/api/mca/providers/{PROVIDER_ID}/upload-readiness?{query}")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_query"
+
+
+def test_upload_readiness_accepts_zero_ciphertext_and_positive_ttl(monkeypatch):
+    # ciphertext_bytes may be zero-or-greater; requested_ttl_seconds must be
+    # a positive integer. Both here are valid and pass through.
+    facade = _FakeFacade(
+        decisions={PROVIDER_ID: UploadDecision(ready=True, reason=None, detail=None)}
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get(
+        f"/api/mca/providers/{PROVIDER_ID}/upload-readiness?ciphertext_bytes=0&requested_ttl_seconds=1"
+    ).get_json()
+    assert body == {"ok": True, "ready": True, "reason": None, "detail": None}
 
 
 # ---- GET /api/mca/connectivity -------------------------------------------
@@ -705,7 +894,7 @@ def test_connectivity_separates_internet_and_relays(monkeypatch):
     relay = _relay_status()
     facade = _FakeFacade(
         connectivity=ConnectivitySnapshot(
-            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+            internet=InternetStatus.ONLINE, relays={PROVIDER_ID: relay}
         )
     )
     c = _client(monkeypatch, facade)
@@ -713,7 +902,7 @@ def test_connectivity_separates_internet_and_relays(monkeypatch):
     assert body["ok"] is True
     assert body["internet"] == "online"
     assert body["relays"] == {
-        "AbCdEfGhIjK": {
+        PROVIDER_ID: {
             "state": "online",
             "upload_readiness": "ready",
             "checked_at": 300.0,
@@ -753,8 +942,8 @@ def test_command_shape_and_frozen_result_unfrozen(monkeypatch):
         status=STATUS_SUCCEEDED,
         created_at=0.0,
         updated_at=1.0,
-        resource_id="AbCdEfGhIjK",
-        result={"provider_id": "AbCdEfGhIjK", "nested": {"items": [1, 2, 3]}},
+        resource_id=PROVIDER_ID,
+        result={"provider_id": PROVIDER_ID, "nested": {"items": [1, 2, 3]}},
         error_code=None,
     )
     facade = _FakeFacade(commands={COMMAND_ID: result})
@@ -766,8 +955,8 @@ def test_command_shape_and_frozen_result_unfrozen(monkeypatch):
         "command_id": COMMAND_ID,
         "type": "provider_register",
         "status": "succeeded",
-        "resource_id": "AbCdEfGhIjK",
-        "result": {"provider_id": "AbCdEfGhIjK", "nested": {"items": [1, 2, 3]}},
+        "resource_id": PROVIDER_ID,
+        "result": {"provider_id": PROVIDER_ID, "nested": {"items": [1, 2, 3]}},
         "error_code": None,
         "created_at": 0.0,
         "updated_at": 1.0,
@@ -786,3 +975,71 @@ def test_command_not_found(monkeypatch):
     resp = c.get(f"/api/mca/commands/{COMMAND_ID}")
     assert resp.status_code == 404
     assert resp.get_json()["error_code"] == "command_not_found"
+
+
+# ---- sanitized exception boundary (§11 "no secret logging") --------------
+
+
+def test_unexpected_exception_is_sanitized(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+    marker = "SECRET_MARKER_x7k3"
+    c = _client(monkeypatch, _RaisingFacade(marker=marker))
+
+    # Two representative facade reads (provider_snapshot + identity_snapshot)
+    # each raise an exception carrying the marker.
+    resp = c.get("/api/mca/providers")
+    resp2 = c.get("/api/mca/identity")
+
+    for r in (resp, resp2):
+        assert r.status_code == 500
+        assert r.get_json() == {
+            "ok": False,
+            "error": "Internal server error",
+            "error_code": "internal_error",
+        }
+        assert marker not in r.get_data(as_text=True)
+        assert "Traceback" not in r.get_data(as_text=True)
+
+    # The log carries only the safe handler name + exception class.
+    assert "MCAttach read endpoint" in caplog.text
+    assert marker not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+def test_unexpected_exception_is_sanitized_even_in_debug_mode(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR)
+    marker = "SECRET_MARKER_debug"
+    c = _client(monkeypatch, _RaisingFacade(marker=marker), debug=True)
+
+    resp = c.get("/api/mca/providers")
+    assert resp.status_code == 500
+    assert resp.get_json() == {
+        "ok": False,
+        "error": "Internal server error",
+        "error_code": "internal_error",
+    }
+    # Even with app.debug=True, no traceback and no marker leak (the legacy
+    # handle_errors traceback path is never reached).
+    assert marker not in resp.get_data(as_text=True)
+    assert "Traceback" not in resp.get_data(as_text=True)
+    assert marker not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+def test_next_request_succeeds_after_injected_failure(monkeypatch):
+    class _FlakyFacade(_FakeFacade):
+        def __init__(self):
+            super().__init__(identity=_identity())
+            self._fail = True
+
+        def identity_snapshot(self):
+            if self._fail:
+                self._fail = False
+                raise RuntimeError("boom SECRET_MARKER_transient")
+            return self._identity
+
+    c = _client(monkeypatch, _FlakyFacade())
+    assert c.get("/api/mca/identity").status_code == 500
+    second = c.get("/api/mca/identity")
+    assert second.status_code == 200
+    assert second.get_json()["ok"] is True

--- a/tests/test_mca_api_attachments.py
+++ b/tests/test_mca_api_attachments.py
@@ -1,0 +1,788 @@
+"""Tests for api/api_attachments.py (Step 1.6A.2; internal-rest-api.md §7.1).
+
+Covers the ten read-only `GET` endpoints end-to-end through a real Flask
+test client, against two backends:
+
+- a **fake facade** (monkeypatched `mca_runtime.get_attachments_facade`) for
+  the routing/serialization/validation/no-secret assertions - the bulk of
+  the suite, so each endpoint's exact §7.x projection can be pinned without
+  standing up the whole worker;
+- the **real runtime** (the same `FakeRadioTransport`/`InMemoryEther` shape
+  as tests/test_mca_runtime_wiring.py) for the wiring/not-ready/threading
+  guarantees.
+
+Together they pin that: a request thread never touches SQLite/filesystem/
+network/tick (the endpoints only read facade snapshots); the service is
+503-mapped (`mca_not_ready`) before the runtime exists *and* before the
+first snapshot publish; every error uses the documented 400/404 codes; and
+no secret (upload token, private-key filename, raw public key bytes,
+locator/ciphertext/internal fields) reaches the wire.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from functools import wraps
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, jsonify
+
+from api.api_attachments import register_attachments_routes
+from meshsrv.attachments import mca_runtime
+from meshsrv.attachments.command_registry import CommandResult, STATUS_SUCCEEDED
+from meshsrv.attachments.delivery.fakes import FakeRadioTransport, InMemoryEther
+from meshsrv.attachments.facade import FacadeNotReady
+from meshsrv.attachments.snapshots import (
+    AttachmentRecord,
+    AttachmentsSnapshot,
+    DeliveryRecord,
+    TimelineEvent,
+)
+from meshsrv.connectivity_monitor import (
+    ConnectivitySnapshot,
+    InternetStatus,
+    RelayState,
+    RelayStatus,
+    UploadDecision,
+    UploadReadiness,
+    UploadRejectionReason,
+)
+
+# The endpoints share one 32-hex id shape (uuid4().hex).
+ATTACHMENT_ID = "0" * 32
+COMMAND_ID = "f" * 32
+
+
+# ---- minimal handle_errors (mirrors server.py's behaviour) ----------------
+
+def _handle_errors(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except Exception as e:  # pragma: no cover - safety net only
+            return jsonify({"ok": False, "error": str(e), "traceback": None}), 500
+
+    return decorated
+
+
+def _build_client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_attachments_routes(app, _handle_errors)
+    return app.test_client()
+
+
+def _client(monkeypatch, facade):
+    """A Flask test client whose per-request facade lookup returns `facade`."""
+    monkeypatch.setattr(mca_runtime, "get_attachments_facade", lambda: facade)
+    return _build_client()
+
+
+# ---- fake facade + record builders ---------------------------------------
+
+
+def _attachment(id=ATTACHMENT_ID, direction="sent", state="SENT", **overrides):
+    base = dict(
+        id=id,
+        direction=direction,
+        state=state,
+        file_name="photo.jpg",
+        mime_type="image/jpeg",
+        plain_size=1234,
+        cipher_size=1300,
+        created_at=100.0,
+        hard_expires_at=200.0,
+        download_grace_seconds=3600,
+        provider_id="AbCdEfGhIjK",
+        saved=False,
+        primary_delivery_id=None,
+        error_code=None,
+        recipients=(),
+        deliveries=(),
+        descriptor=None,
+        timeline=(),
+    )
+    base.update(overrides)
+    return AttachmentRecord(**base)
+
+
+def _snapshot(records):
+    return AttachmentsSnapshot(
+        records=tuple(records),
+        by_id={r.id: r for r in records},
+        idempotency={},
+        built_at=0.0,
+    )
+
+
+class _FakeFacade:
+    def __init__(
+        self,
+        *,
+        snapshot=None,
+        providers=None,
+        connectivity=None,
+        identity=None,
+        commands=None,
+        decisions=None,
+    ):
+        self._snapshot = snapshot or _snapshot([])
+        self._providers = providers or {}
+        self._connectivity = connectivity or ConnectivitySnapshot(
+            internet=InternetStatus.UNKNOWN, relays={}
+        )
+        self._identity = identity
+        self._commands = commands or {}
+        self._decisions = decisions or {}
+        self.not_ready = False
+
+    def attachments_snapshot(self):
+        if self.not_ready:
+            raise FacadeNotReady()
+        return self._snapshot
+
+    def get_attachment(self, attachment_id):
+        if self.not_ready:
+            raise FacadeNotReady()
+        return self._snapshot.by_id.get(attachment_id)
+
+    def get_command(self, command_id):
+        return self._commands.get(command_id)
+
+    def provider_snapshot(self):
+        return self._providers
+
+    def connectivity_snapshot(self):
+        return self._connectivity
+
+    def evaluate_upload_readiness(self, provider_id, *, ciphertext_bytes=None, requested_ttl_seconds=None):
+        if provider_id in self._decisions:
+            return self._decisions[provider_id]
+        return UploadDecision(ready=False, reason=UploadRejectionReason.PROFILE_NOT_FOUND, detail=None)
+
+    def identity_snapshot(self):
+        return self._identity
+
+
+def _provider(**overrides):
+    base = dict(
+        provider_id="AbCdEfGhIjK",
+        display_name="Example Relay",
+        origin="https://relay.example.net",
+        service_public_key=b"K" * 32,
+        kind="provider",
+        tls_required=True,
+        upload_allowed=True,
+        download_allowed=True,
+        max_ciphertext_bytes=5 * 1024 * 1024,
+        is_default=True,
+        enabled=True,
+        min_ttl_seconds=60,
+        max_ttl_seconds=86400,
+        protocol_version="1",
+        upload_token_configured=True,
+        last_checked_at=300.0,
+        last_check_result="ok",
+        last_latency_ms=42,
+        last_error_code=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _relay_status(**overrides):
+    base = dict(
+        provider_id="AbCdEfGhIjK",
+        state=RelayState.ONLINE,
+        upload_readiness=UploadReadiness.READY,
+        checked_at=300.0,
+        latency_ms=42,
+        error_code=None,
+    )
+    base.update(overrides)
+    return RelayStatus(**base)
+
+
+def _identity(**overrides):
+    base = dict(
+        principal_id="princ-1",
+        key_id="0123456789abcdef",
+        epoch=7,
+        public_identity=b"P" * 32,
+        status="ACTIVE",
+        public_x25519=b"X" * 32,
+        private_key_file="id_mca.key",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---- real runtime helpers -------------------------------------------------
+
+
+class _AlwaysDownSession:
+    def request(self, *args, **kwargs):
+        import requests
+
+        raise requests.ConnectionError("down for this test")
+
+
+def _started(tmp_path, tag):
+    """Start the real runtime and stop its worker thread for deterministic
+    single-threaded driving, re-setting readiness (mirrors the wiring
+    test's `_started_state`)."""
+    mca_runtime.reset_state_for_tests()
+    mca_runtime.set_connectivity_session_for_tests(_AlwaysDownSession())
+    ether = InMemoryEther()
+    transport = FakeRadioTransport(ether, "!aaaaaaaa")
+    data_dir = str(tmp_path / tag)
+    mca_runtime.start_attachments_service(data_dir, transport)
+    state = mca_runtime._get_state(data_dir)  # noqa: SLF001
+    assert state.service.stop(), "worker did not stop"
+    state.ready_event.set()
+    return state
+
+
+_ALL_PATHS = [
+    "/api/attachments",
+    f"/api/attachments/{ATTACHMENT_ID}",
+    f"/api/attachments/{ATTACHMENT_ID}/deliveries",
+    "/api/mca/delivery-adapters",
+    "/api/mca/providers",
+    "/api/mca/providers/AbCdEfGhIjK",
+    "/api/mca/providers/AbCdEfGhIjK/upload-readiness",
+    "/api/mca/connectivity",
+    "/api/mca/identity",
+    f"/api/mca/commands/{COMMAND_ID}",
+]
+
+
+# ---- not-ready / wiring ---------------------------------------------------
+
+
+def test_every_endpoint_is_503_when_the_facade_does_not_exist(monkeypatch):
+    c = _client(monkeypatch, None)
+    for path in _ALL_PATHS:
+        resp = c.get(path)
+        assert resp.status_code == 503, path
+        body = resp.get_json()
+        assert body["ok"] is False
+        assert body["error_code"] == "mca_not_ready"
+
+
+def test_snapshot_backed_endpoints_are_503_when_not_ready(monkeypatch):
+    facade = _FakeFacade()
+    facade.not_ready = True
+    c = _client(monkeypatch, facade)
+
+    for path in (
+        "/api/attachments",
+        f"/api/attachments/{ATTACHMENT_ID}",
+        f"/api/attachments/{ATTACHMENT_ID}/deliveries",
+    ):
+        resp = c.get(path)
+        assert resp.status_code == 503, path
+        assert resp.get_json()["error_code"] == "mca_not_ready"
+
+
+def test_registry_and_connectivity_endpoints_are_not_readiness_gated(monkeypatch):
+    # get_command / provider / connectivity / identity / upload-readiness are
+    # independent of snapshot publication - they must NOT 503 even before the
+    # first snapshot, matching the facade's own docstring (§3.2).
+    facade = _FakeFacade(identity=_identity())
+    facade.not_ready = True
+    c = _client(monkeypatch, facade)
+
+    assert c.get("/api/mca/identity").status_code == 200
+    assert c.get("/api/mca/providers").status_code == 200
+    assert c.get("/api/mca/connectivity").status_code == 200
+    assert c.get("/api/mca/delivery-adapters").status_code == 200
+    assert c.get(f"/api/mca/commands/{COMMAND_ID}").status_code == 404
+    assert c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").status_code == 200
+
+
+def test_real_runtime_serves_empty_reads_after_startup(tmp_path):
+    state = _started(tmp_path, "wire")
+    try:
+        c = _build_client()
+
+        resp = c.get("/api/attachments")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["attachments"] == []
+        assert body["total"] == 0
+
+        identity = c.get("/api/mca/identity").get_json()
+        assert identity["ok"] is True
+        assert identity["fingerprint"]
+        assert "private_key_file" not in identity
+        assert "public_identity" not in identity
+
+        cmd = c.get(f"/api/mca/commands/{COMMAND_ID}")
+        assert cmd.status_code == 404
+        assert cmd.get_json()["error_code"] == "command_not_found"
+    finally:
+        mca_runtime.reset_state_for_tests()
+
+
+def test_endpoint_reads_do_not_block_on_the_tick_lock(tmp_path):
+    state = _started(tmp_path, "thread")
+    try:
+        c = _build_client()
+        state.tick_lock.acquire()
+        try:
+            result = {}
+
+            def hit():
+                result["resp"] = c.get("/api/attachments")
+
+            reader = threading.Thread(target=hit, name="request-thread")
+            reader.start()
+            reader.join(timeout=2.0)
+            assert not reader.is_alive(), "endpoint blocked on the worker tick lock"
+        finally:
+            state.tick_lock.release()
+
+        assert result["resp"].status_code == 200
+    finally:
+        mca_runtime.reset_state_for_tests()
+
+
+def test_routes_reject_non_get_methods(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    assert c.post("/api/attachments").status_code == 405
+    assert c.put("/api/mca/identity").status_code == 405
+    assert c.delete("/api/mca/providers/AbCdEfGhIjK").status_code == 405
+
+
+# ---- GET /api/attachments -------------------------------------------------
+
+
+def test_list_empty_snapshot(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    body = c.get("/api/attachments").get_json()
+    assert body["ok"] is True
+    assert body["attachments"] == []
+    assert body["total"] == 0
+
+
+def test_list_serializes_public_projection_without_timeline(monkeypatch):
+    facade = _FakeFacade(snapshot=_snapshot([_attachment()]))
+    c = _client(monkeypatch, facade)
+    item = c.get("/api/attachments").get_json()["attachments"][0]
+    assert item["id"] == ATTACHMENT_ID
+    assert item["direction"] == "sent"
+    assert item["state"] == "SENT"
+    assert item["file_name"] == "photo.jpg"
+    assert item["content_available"] is False
+    assert "timeline" not in item  # timeline is detail-only (§7.5)
+    assert "descriptor" not in item  # locator never leaks
+    assert item["recipients"] == []
+    assert item["deliveries"] == []
+
+
+def test_list_direction_filter(monkeypatch):
+    facade = _FakeFacade(
+        snapshot=_snapshot([
+            _attachment(id="a" * 32, direction="sent"),
+            _attachment(id="b" * 32, direction="received", state="AVAILABLE"),
+        ])
+    )
+    c = _client(monkeypatch, facade)
+    sent = c.get("/api/attachments?direction=sent").get_json()
+    assert [a["id"] for a in sent["attachments"]] == ["a" * 32]
+    received = c.get("/api/attachments?direction=received").get_json()
+    assert [a["id"] for a in received["attachments"]] == ["b" * 32]
+    assert c.get("/api/attachments").get_json()["total"] == 2
+
+
+def test_list_state_filter(monkeypatch):
+    facade = _FakeFacade(
+        snapshot=_snapshot([
+            _attachment(id="a" * 32, state="DRAFT"),
+            _attachment(id="b" * 32, state="SENT"),
+        ])
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/attachments?state=DRAFT").get_json()
+    assert [a["id"] for a in body["attachments"]] == ["a" * 32]
+
+
+def test_list_filter_errors_uses_failed_states(monkeypatch):
+    facade = _FakeFacade(
+        snapshot=_snapshot([
+            _attachment(id="a" * 32, state="SENT"),
+            _attachment(id="b" * 32, state="FAILED_UPLOAD", error_code="relay_unreachable"),
+            _attachment(id="c" * 32, state="DRAFT"),
+        ])
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/attachments?filter=errors").get_json()
+    assert [a["id"] for a in body["attachments"]] == ["b" * 32]
+
+
+def test_list_filter_pending_uses_non_terminal_states(monkeypatch):
+    # "SENT"/"RECEIVED" are not terminal (the sender waits for the download
+    # ACK after them); "EXPIRED" is. `pending` = anything not terminal.
+    facade = _FakeFacade(
+        snapshot=_snapshot([
+            _attachment(id="a" * 32, state="EXPIRED"),
+            _attachment(id="b" * 32, state="DRAFT"),
+        ])
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/attachments?filter=pending").get_json()
+    assert [a["id"] for a in body["attachments"]] == ["b" * 32]
+
+
+def test_list_filter_saved(monkeypatch):
+    facade = _FakeFacade(
+        snapshot=_snapshot([
+            _attachment(id="a" * 32, saved=False),
+            _attachment(id="b" * 32, saved=True),
+        ])
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/attachments?filter=saved").get_json()
+    assert [a["id"] for a in body["attachments"]] == ["b" * 32]
+
+
+def test_list_total_is_before_pagination(monkeypatch):
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(id=f"{i:032x}") for i in range(5)]))
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/attachments?limit=2&offset=0").get_json()
+    assert len(body["attachments"]) == 2
+    assert body["total"] == 5  # total is the full filtered count, not the page
+
+
+def test_list_limit_and_offset_clamping(monkeypatch):
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(id=f"{i:032x}") for i in range(3)]))
+    c = _client(monkeypatch, facade)
+    # limit above 500 clamps to 500; negative offset clamps to 0; garbage
+    # falls back to defaults (100) rather than a 400.
+    body = c.get("/api/attachments?limit=9999&offset=-5").get_json()
+    assert body["total"] == 3
+    assert len(body["attachments"]) == 3
+    assert c.get("/api/attachments?limit=abc").status_code == 200
+
+
+@pytest.mark.parametrize(
+    "query,code",
+    [
+        ("direction=up", "invalid_direction"),
+        ("state=NOT_A_STATE", "invalid_state"),
+        ("filter=weird", "invalid_filter"),
+    ],
+)
+def test_list_invalid_query_params(monkeypatch, query, code):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get(f"/api/attachments?{query}")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == code
+
+
+# ---- GET /api/attachments/{id} -------------------------------------------
+
+
+def test_detail_returns_attachment_with_separate_timeline(monkeypatch):
+    events = (
+        TimelineEvent(event_type="uploaded", detail={"error_code": "relay_unreachable"}, created_at=120.0),
+        TimelineEvent(event_type="sent", detail={"secret": "SHOULD-NOT-LEAK"}, created_at=130.0),
+    )
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(timeline=events)]))
+    c = _client(monkeypatch, facade)
+    body = c.get(f"/api/attachments/{ATTACHMENT_ID}").get_json()
+
+    assert body["ok"] is True
+    assert body["attachment"]["id"] == ATTACHMENT_ID
+    assert "timeline" not in body["attachment"]  # timeline is sibling, not nested
+    assert [e["event_type"] for e in body["timeline"]] == ["uploaded", "sent"]
+    # §11 safe-key allowlist redacts a non-allowlisted detail key.
+    assert body["timeline"][0]["detail"] == {"error_code": "relay_unreachable"}
+    assert body["timeline"][1]["detail"] == {}
+
+
+def test_detail_invalid_id(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get("/api/attachments/not-hex")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_attachment_id"
+
+
+def test_detail_not_found(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get(f"/api/attachments/{ATTACHMENT_ID}")
+    assert resp.status_code == 404
+    assert resp.get_json()["error_code"] == "attachment_not_found"
+
+
+# ---- GET /api/attachments/{id}/deliveries --------------------------------
+
+
+def test_deliveries_returns_the_delivery_projection(monkeypatch):
+    deliveries = (
+        DeliveryRecord(
+            id="deliv-1",
+            adapter_id="meshtastic",
+            connector_profile_id="meshtastic",
+            route_type="direct",
+            route_id="!aaaaaaaa",
+            state="CONFIRMED",
+            external_message_id=None,
+            sent_at=150.0,
+        ),
+    )
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(deliveries=deliveries)]))
+    c = _client(monkeypatch, facade)
+    body = c.get(f"/api/attachments/{ATTACHMENT_ID}/deliveries").get_json()
+
+    assert body["ok"] is True
+    assert body["deliveries"] == [{
+        "id": "deliv-1",
+        "adapter_id": "meshtastic",
+        "connector_profile_id": "meshtastic",
+        "route_type": "direct",
+        "route_id": "!aaaaaaaa",
+        "state": "CONFIRMED",
+        "external_message_id": None,
+        "sent_at": 150.0,
+    }]
+
+
+def test_deliveries_invalid_and_missing(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    assert c.get("/api/attachments/not-hex/deliveries").status_code == 400
+    assert c.get(f"/api/attachments/{ATTACHMENT_ID}/deliveries").status_code == 404
+
+
+# ---- GET /api/mca/delivery-adapters --------------------------------------
+
+
+def test_delivery_adapters_static_shape(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    body = c.get("/api/mca/delivery-adapters").get_json()
+    assert body["ok"] is True
+    assert body["adapters"] == [{
+        "adapter_id": "meshtastic",
+        "connector_profile_id": "meshtastic",
+        "capabilities": {
+            "wire_formats": ["MCA1_TEXT"],
+            "max_payload_bytes": 180,
+            "supports_direct": True,
+            "supports_channel": False,
+            "supports_incoming": True,
+            "ack_semantics": "CONFIRMED",
+            "connector_state": "READY",
+        },
+    }]
+
+
+# ---- GET /api/mca/providers ----------------------------------------------
+
+
+def test_providers_empty(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    assert c.get("/api/mca/providers").get_json() == {"ok": True, "providers": []}
+
+
+def test_providers_list_joins_connectivity_without_raw_key(monkeypatch):
+    provider = _provider()
+    relay = _relay_status()
+    facade = _FakeFacade(
+        providers={"AbCdEfGhIjK": provider},
+        connectivity=ConnectivitySnapshot(
+            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+        ),
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/providers").get_json()
+
+    assert body["ok"] is True
+    assert len(body["providers"]) == 1
+    item = body["providers"][0]
+    assert item["provider_id"] == "AbCdEfGhIjK"
+    assert item["display_name"] == "Example Relay"
+    assert item["service_key_fingerprint"] == hashlib.sha256(b"K" * 32).hexdigest()
+    assert item["state"] == "online"
+    assert item["upload_readiness"] == "ready"
+    assert item["latency_ms"] == 42
+    assert item["error_code"] is None
+    # No raw key material, no token filename.
+    assert "service_public_key" not in item
+    assert "upload_token_file" not in item
+
+
+def test_providers_list_falls_back_when_no_relay_status(monkeypatch):
+    # No RelayStatus yet (monitor never refreshed) -> state "unknown" and
+    # upload_readiness derived from config only; latency/error are null.
+    provider = _provider(upload_token_configured=False)
+    facade = _FakeFacade(providers={"AbCdEfGhIjK": provider})
+    c = _client(monkeypatch, facade)
+    item = c.get("/api/mca/providers").get_json()["providers"][0]
+    assert item["state"] == "unknown"
+    assert item["upload_readiness"] == "upload_token_missing"
+    assert item["latency_ms"] is None
+    assert item["error_code"] is None
+
+
+# ---- GET /api/mca/providers/{id} -----------------------------------------
+
+
+def test_provider_detail_projection_omits_live_latency_fields(monkeypatch):
+    provider = _provider()
+    relay = _relay_status()
+    facade = _FakeFacade(
+        providers={"AbCdEfGhIjK": provider},
+        connectivity=ConnectivitySnapshot(
+            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+        ),
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/providers/AbCdEfGhIjK").get_json()
+
+    assert body["ok"] is True
+    item = body["provider"]
+    assert item["provider_id"] == "AbCdEfGhIjK"
+    assert item["state"] == "online"
+    assert item["upload_readiness"] == "ready"
+    # The detail projection is §7.13 only - no live latency/error join.
+    assert "latency_ms" not in item
+    assert "error_code" not in item
+    assert "service_public_key" not in item
+
+
+def test_provider_detail_not_found(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get("/api/mca/providers/never-registered")
+    assert resp.status_code == 404
+    assert resp.get_json()["error_code"] == "provider_not_found"
+
+
+# ---- GET /api/mca/providers/{id}/upload-readiness ------------------------
+
+
+def test_upload_readiness_ready(monkeypatch):
+    facade = _FakeFacade(
+        decisions={"AbCdEfGhIjK": UploadDecision(ready=True, reason=None, detail=None)}
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").get_json()
+    assert body == {"ok": True, "ready": True, "reason": None, "detail": None}
+
+
+def test_upload_readiness_rejected_with_reason(monkeypatch):
+    facade = _FakeFacade(
+        decisions={
+            "AbCdEfGhIjK": UploadDecision(
+                ready=False, reason=UploadRejectionReason.CIPHERTEXT_TOO_LARGE, detail=None
+            )
+        }
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness").get_json()
+    assert body["ok"] is True
+    assert body["ready"] is False
+    assert body["reason"] == "ciphertext_too_large"
+
+
+def test_upload_readiness_malformed_query(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness?ciphertext_bytes=abc")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_query"
+    resp2 = c.get("/api/mca/providers/AbCdEfGhIjK/upload-readiness?requested_ttl_seconds=-3")
+    assert resp2.status_code == 400
+
+
+# ---- GET /api/mca/connectivity -------------------------------------------
+
+
+def test_connectivity_separates_internet_and_relays(monkeypatch):
+    relay = _relay_status()
+    facade = _FakeFacade(
+        connectivity=ConnectivitySnapshot(
+            internet=InternetStatus.ONLINE, relays={"AbCdEfGhIjK": relay}
+        )
+    )
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/connectivity").get_json()
+    assert body["ok"] is True
+    assert body["internet"] == "online"
+    assert body["relays"] == {
+        "AbCdEfGhIjK": {
+            "state": "online",
+            "upload_readiness": "ready",
+            "checked_at": 300.0,
+            "latency_ms": 42,
+            "error_code": None,
+        }
+    }
+
+
+# ---- GET /api/mca/identity -----------------------------------------------
+
+
+def test_identity_shape_and_no_secret(monkeypatch):
+    facade = _FakeFacade(identity=_identity())
+    c = _client(monkeypatch, facade)
+    body = c.get("/api/mca/identity").get_json()
+
+    assert body["ok"] is True
+    assert body["principal_id"] == "princ-1"
+    assert body["key_id"] == "0123456789abcdef"
+    assert body["epoch"] == 7
+    assert body["status"] == "ACTIVE"
+    assert body["fingerprint"] == hashlib.sha256(b"P" * 32).hexdigest()
+    # No raw key material / filename.
+    assert "public_identity" not in body
+    assert "public_x25519" not in body
+    assert "private_key_file" not in body
+
+
+# ---- GET /api/mca/commands/{id} ------------------------------------------
+
+
+def test_command_shape_and_frozen_result_unfrozen(monkeypatch):
+    result = CommandResult(
+        command_id=COMMAND_ID,
+        kind="provider_register",
+        status=STATUS_SUCCEEDED,
+        created_at=0.0,
+        updated_at=1.0,
+        resource_id="AbCdEfGhIjK",
+        result={"provider_id": "AbCdEfGhIjK", "nested": {"items": [1, 2, 3]}},
+        error_code=None,
+    )
+    facade = _FakeFacade(commands={COMMAND_ID: result})
+    c = _client(monkeypatch, facade)
+    body = c.get(f"/api/mca/commands/{COMMAND_ID}").get_json()
+
+    assert body["ok"] is True
+    assert body["command"] == {
+        "command_id": COMMAND_ID,
+        "type": "provider_register",
+        "status": "succeeded",
+        "resource_id": "AbCdEfGhIjK",
+        "result": {"provider_id": "AbCdEfGhIjK", "nested": {"items": [1, 2, 3]}},
+        "error_code": None,
+        "created_at": 0.0,
+        "updated_at": 1.0,
+    }
+
+
+def test_command_invalid_id(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get("/api/mca/commands/not-hex")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_command_id"
+
+
+def test_command_not_found(monkeypatch):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.get(f"/api/mca/commands/{COMMAND_ID}")
+    assert resp.status_code == 404
+    assert resp.get_json()["error_code"] == "command_not_found"

--- a/tests/test_mca_runtime_wiring.py
+++ b/tests/test_mca_runtime_wiring.py
@@ -24,6 +24,7 @@ rather than racing the daemon thread.
 
 from __future__ import annotations
 
+import logging
 import threading
 
 import pytest
@@ -594,5 +595,37 @@ def test_one_broken_command_does_not_stop_the_drain(tmp_path, monkeypatch):
         second = facade.get_command("cmd-b")
         assert second.status == STATUS_SUCCEEDED
         assert second.resource_id == "cmd-b"
+    finally:
+        mca_runtime.reset_state_for_tests()
+
+
+def test_handler_exception_text_is_not_logged(tmp_path, caplog):
+    # Step 1.6A.2 safe-logging correction: a handler exception's *text* may
+    # embed file names, Relay tokens, keys, comments or other untrusted
+    # command input, so the worker logs only the safe identifier, kind and
+    # exception class - never the message, and never a traceback.
+    marker = "SENSITIVE-MARKER-DO-NOT-LOG-9f2c"
+
+    def handler(command):
+        raise RuntimeError(f"upload failed for {marker}")
+
+    state = _state_with_handlers(tmp_path, "log", {"attachment_cancel": handler})
+    try:
+        state.facade.submit(
+            Command(command_id="cmd-log", kind="attachment_cancel", payload={}, created_at=0.0)
+        )
+
+        with caplog.at_level(logging.ERROR, logger="meshsrv.attachments.service"):
+            state.service.tick()
+
+        # The command still reaches the correct terminal state.
+        result = state.facade.get_command("cmd-log")
+        assert result.status == STATUS_FAILED
+        assert result.error_code == COMMAND_EXECUTION_FAILED
+
+        logged = caplog.text
+        assert "RuntimeError" in logged   # exception *class* is logged
+        assert "cmd-log" in logged        # command id is logged
+        assert marker not in logged       # sensitive message is not
     finally:
         mca_runtime.reset_state_for_tests()


### PR DESCRIPTION
## MCAttach Step 1.6A.2 — read-only REST API

Implements the ten read-only `GET` endpoints from `docs/attachments/internal-rest-api.md` §7.1, on top of the Step 1.6A.1 facade plumbing (#235):

- `GET /api/attachments`
- `GET /api/attachments/{attachment_id}`
- `GET /api/attachments/{attachment_id}/deliveries`
- `GET /api/mca/delivery-adapters`
- `GET /api/mca/providers`
- `GET /api/mca/providers/{provider_id}`
- `GET /api/mca/providers/{provider_id}/upload-readiness`
- `GET /api/mca/connectivity`
- `GET /api/mca/identity`
- `GET /api/mca/commands/{command_id}`

### Scope
Read-only only. All mutations, `GET /api/attachments/{id}/content`, contacts, connectors, multipart upload, and provider onboarding are deliberately deferred to 1.6A.3+.

### Design
- Handlers read only worker-published in-memory snapshots/registries via `AttachmentsFacade`; no SQLite, filesystem, network, radio, or tick-lock access from a request thread.
- `mca_not_ready` → HTTP 503 when the runtime has not been constructed.
- Explicit allowlist serializers — no `dataclasses.asdict()`/`__dict__`; no upload tokens, private-key filenames, raw key bytes, filesystem paths, `ContentDescriptor.locator`, ciphertext, or internal SQLite fields on the wire.
- Provider/relay join for live `state`/`upload_readiness`; identity fingerprint without raw material; §7.9 command shape.

### Review corrections
Independent review identified five blocking findings, each corrected in a dedicated commit without expanding scope:

- **`088b436`** — `MCAttach read API: sanitize error boundary + strict input validation`
- **`1eb7303`** — `MCAttach read API: regression tests for the five review findings`
- **`e00b8e0`** — `MCAttach: reconcile read-API contract with the review corrections`

Resolved findings:

1. **Truthful delivery-adapter state** — `GET /api/mca/delivery-adapters` reports `connector_state: "UNKNOWN"` rather than fabricating `READY`; internet/relay state is kept separate.
2. **Strict pagination** — missing `limit`/`offset` keep defaults; present values must be ASCII decimal, `limit ∈ [1, 500]`, `offset ≥ 0`; malformed → 400 `invalid_pagination`.
3. **Canonical provider-ID validation** — round-trip `encode_provider_id(decode_provider_id(value)) == value`; malformed → 400 `invalid_provider_id`, canonical-but-unregistered → 404 `provider_not_found` / 200 `ready:false reason:profile_not_found`.
4. **Sanitized MCAttach error boundary** — a local boundary wraps all ten routes: `FacadeNotReady` → 503 `mca_not_ready`, everything else → 500 `internal_error` with no exception text or traceback; logs only the handler name and exception class.
5. **Positive TTL validation** — `requested_ttl_seconds` must be ASCII decimal > 0 → else 400 `invalid_query`; `ciphertext_bytes` may be zero or greater.

### Verification
- Full local suite: **1511 passed, 38 skipped** (skips pre-existing Windows/hardware/privilege).
- Final-head CI (`e00b8e0`): `checks` ✅, `release-build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
