### PR TITLE
🛡️ Sentinel: Fix info disclosure in weather config error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2026-03-30 - Sanitize OS Errors in API Responses
+**Vulnerability:** Raw `OSError` exceptions during weather API key secret saving were converted to string and returned in JSON HTTP responses, exposing internal server filesystem paths and OS permissions details to clients.
+**Learning:** Returning stringified exceptions directly in error responses inadvertently exposes system internals such as absolute directory structure and file permissions.
+**Prevention:** Log system/OS exceptions on the server side with `print`/logger and return sanitized generic error messages in API responses.

--- a/api/api_weather.py
+++ b/api/api_weather.py
@@ -162,9 +162,10 @@ def register_weather_routes(
             _save_weather_secret(secrets_path, weather_manager.active_id, api_key)
             provider.set_api_key(api_key)
         except OSError as exc:
+            print(f"[WEATHER] Could not save API key: {exc}", flush=True)
             return jsonify({
                 "ok": False,
-                "error": f"Could not save the API key: {exc}",
+                "error": "Could not save the API key.",
             }), 500
 
         return jsonify({

--- a/tests/test_api_weather.py
+++ b/tests/test_api_weather.py
@@ -1,0 +1,47 @@
+"""Tests for api/api_weather.py error handling and security."""
+
+from unittest.mock import MagicMock
+from flask import Flask
+import pytest
+
+from api.api_weather import register_weather_routes
+import api.api_weather as api_weather_module
+
+
+@pytest.fixture
+def weather_app():
+    app = Flask(__name__)
+    mock_provider = MagicMock()
+    mock_provider.test_api_key.return_value = {"ok": True}
+
+    mock_manager = MagicMock()
+    mock_manager.active.return_value = mock_provider
+    mock_manager.active_id = "openweather"
+
+    register_weather_routes(
+        app,
+        weather_manager=mock_manager,
+        resolve_location=lambda: {"latitude": 50.0, "longitude": 10.0},
+        secrets_path="/dummy/path/weather_secrets.py",
+    )
+    return app.test_client()
+
+
+def test_api_weather_save_key_oserror_sanitizes_error_response(weather_app, monkeypatch):
+    def mock_save_secret(path, provider_id, api_key):
+        raise OSError("[Errno 13] Permission denied: '/app/weather_secrets.py'")
+
+    monkeypatch.setattr(api_weather_module, "_save_weather_secret", mock_save_secret)
+
+    response = weather_app.post(
+        "/api/weather/config",
+        json={"api_key": "a_valid_dummy_api_key_1234567890"},
+    )
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["ok"] is False
+    assert data["error"] == "Could not save the API key."
+    # Ensure raw OSError details and internal paths are NOT exposed to the client
+    assert "/app/weather_secrets.py" not in data["error"]
+    assert "Permission denied" not in data["error"]


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**
- **Severity**: MEDIUM
- **Vulnerability**: Information disclosure via stringified `OSError` in weather API key configuration endpoint
- **Impact**: Exposed internal filesystem paths and OS permission error details in API responses
- **Fix**: Log exception on server side and return sanitized generic error message to client
- **Verification**: Added `tests/test_api_weather.py` unit test verifying no raw paths or OSError details are returned in HTTP response

---
*PR created automatically by Jules for task [11937671104536502945](https://jules.google.com/task/11937671104536502945) started by @FlintUA*