### PR TITLE
MCAttach Step 1.6A.3C: cancel + contact key request

### DIFF
--- a/api/api_attachments.py
+++ b/api/api_attachments.py
@@ -18,10 +18,11 @@ The ten read-only `GET` endpoints §7.1 defines:
 
 plus the mutation endpoints implemented so far: the three Step 1.6A.3A
 lifecycle actions — `POST /api/attachments/{id}/retry`, `/download`,
-`/reject` (§7.3) — and the Step 1.6A.3B idempotent multipart create
-`POST /api/attachments` (§7.2). Everything else (`GET
-/api/attachments/{id}/content`, cancel, save, revoke, local-content,
-contacts/connectors, provider onboarding) remains out of scope (1.6A.3+).
+`/reject` (§7.3) — the Step 1.6A.3B idempotent multipart create
+`POST /api/attachments` (§7.2), and the Step 1.6A.3C cancel mutation
+`POST /api/attachments/{id}/cancel` (§7.4). Everything else
+(`GET /api/attachments/{id}/content`, save, revoke, local-content,
+connector enumeration, provider onboarding) remains out of scope (1.6A.3+).
 
 Threading boundary (the point of Step 1.6A.1's facade - §3.1/§3.2): these
 handlers read the worker-published in-memory snapshots and registries
@@ -894,6 +895,12 @@ def register_attachments_routes(app, handle_errors):
         # §7.3 download/reject: a received attachment awaiting consent only.
         return record.direction == "received" and record.state == receiver.WAITING_CONSENT
 
+    def _cancel_precondition(record):
+        # §7.4 cancel: an outgoing attachment still in an automatic (pre-SENT)
+        # state only - received rows and SENT/RECEIVED/DOWNLOADED/terminal/
+        # failed/rejected/expired/revoked/cancelled rows are never cancellable.
+        return record.direction == "sent" and record.state in sender.AUTOMATIC_STATES
+
     @app.route("/api/attachments/<attachment_id>/retry", methods=["POST"])
     @handle_errors
     @_mca_error_boundary
@@ -911,6 +918,12 @@ def register_attachments_routes(app, handle_errors):
     @_mca_error_boundary
     def reject_attachment(attachment_id):
         return _submit_lifecycle_command(attachment_id, "attachment_reject", _consent_precondition)
+
+    @app.route("/api/attachments/<attachment_id>/cancel", methods=["POST"])
+    @handle_errors
+    @_mca_error_boundary
+    def cancel_attachment(attachment_id):
+        return _submit_lifecycle_command(attachment_id, "attachment_cancel", _cancel_precondition)
 
     # ---- Step 1.6A.3B: idempotent multipart create (§7.2) -------------------
 

--- a/api/api_attachments.py
+++ b/api/api_attachments.py
@@ -19,8 +19,9 @@ The ten read-only `GET` endpoints §7.1 defines:
 plus the mutation endpoints implemented so far: the three Step 1.6A.3A
 lifecycle actions — `POST /api/attachments/{id}/retry`, `/download`,
 `/reject` (§7.3) — the Step 1.6A.3B idempotent multipart create
-`POST /api/attachments` (§7.2), and the Step 1.6A.3C cancel mutation
-`POST /api/attachments/{id}/cancel` (§7.4). Everything else
+`POST /api/attachments` (§7.2), and the two Step 1.6A.3C mutations —
+`POST /api/attachments/{id}/cancel` (§7.4) and
+`POST /api/mca/contacts/{contact_id}/request-key` (§7.10). Everything else
 (`GET /api/attachments/{id}/content`, save, revoke, local-content,
 connector enumeration, provider onboarding) remains out of scope (1.6A.3+).
 
@@ -84,6 +85,7 @@ from meshsrv.attachments.idempotency import (
     compute_canonical_hash,
     validate_client_request_id,
 )
+from meshsrv.attachments.key_exchange import AddressStatus
 from meshsrv.attachments.provider_registry import (
     ProviderRegistryError,
     decode_provider_id,
@@ -111,6 +113,16 @@ _ASCII_DECIMAL_RE = re.compile(r"[0-9]+")
 
 def _is_hex32(value: str) -> bool:
     return isinstance(value, str) and _HEX32_RE.match(value) is not None
+
+
+# Stage 1 contact id (§7.10): a canonical Meshtastic transport address - `!`
+# plus exactly 8 lowercase hex chars (e.g. `!756f9960`). `fullmatch` so a
+# trailing newline/space can never sneak past.
+_CONTACT_ID_RE = re.compile(r"^![0-9a-f]{8}$")
+
+
+def _is_contact_id(value) -> bool:
+    return isinstance(value, str) and _CONTACT_ID_RE.match(value) is not None
 
 
 # ---- list-filter state sets ----------------------------------------------
@@ -924,6 +936,58 @@ def register_attachments_routes(app, handle_errors):
     @_mca_error_boundary
     def cancel_attachment(attachment_id):
         return _submit_lifecycle_command(attachment_id, "attachment_cancel", _cancel_precondition)
+
+    # ---- Step 1.6A.3C: contact key request (§7.10) --------------------------
+
+    @app.route("/api/mca/contacts/<contact_id>/request-key", methods=["POST"])
+    @handle_errors
+    @_mca_error_boundary
+    def request_contact_key(contact_id):
+        """§7.10: ask a contact to announce its MCA key. Synchronous checks are
+        limited to pure validation (contact id shape, an optional DIRECT
+        route that must match) plus a snapshot read of the recipient's status
+        (already `MCA_READY` -> 409 `key_already_known`); the real
+        re-validation, rate limit, and send all happen on the worker via the
+        `contact_request_key` command. An empty body is accepted (DIRECT route
+        is the only supported route); a supplied route must name `meshtastic`
+        and the contact itself."""
+        facade = _facade()
+        if facade is None:
+            return _not_ready()
+        if not _is_contact_id(contact_id):
+            return _json_error("invalid_contact_id", "invalid contact id"), 400
+        body = request.get_json(silent=True)
+        if body is not None:
+            if not isinstance(body, dict):
+                return _json_error("invalid_contact_id", "invalid contact id"), 400
+            route = body.get("route")
+            if route is not None:
+                if not isinstance(route, dict):
+                    return _json_error("invalid_contact_id", "invalid contact id"), 400
+                if (
+                    route.get("adapter_id") != mca_runtime.ADAPTER_ID
+                    or route.get("route_id") != contact_id
+                ):
+                    return _json_error("invalid_contact_id", "invalid contact id"), 400
+        snapshot = facade.recipient_snapshot()
+        binding = snapshot.by_address.get(contact_id)
+        if binding is not None and binding.status is AddressStatus.MCA_READY:
+            return _json_error("key_already_known", "key already known"), 409
+        command = Command(
+            command_id=mint_command_id(),
+            kind="contact_request_key",
+            payload={
+                "contact_id": contact_id,
+                "adapter_id": mca_runtime.ADAPTER_ID,
+                "route_id": contact_id,
+            },
+            created_at=time.time(),
+        )
+        try:
+            command_id = facade.submit(command)
+        except CommandQueueFull:
+            return _json_error("command_queue_full", "command queue is full"), 429
+        return jsonify({"ok": True, "command_id": command_id}), 202
 
     # ---- Step 1.6A.3B: idempotent multipart create (§7.2) -------------------
 

--- a/docs/attachments/internal-rest-api.md
+++ b/docs/attachments/internal-rest-api.md
@@ -1,6 +1,6 @@
 # MCAttach Internal REST API Contract
 
-**Status:** Design contract (Step 1.6A), revised (second pass). The read-only endpoints of sub-stage 1.6A.2 (§5) are implemented in `api/api_attachments.py`. Of the mutation endpoints, the three Step 1.6A.3A lifecycle actions — `POST /api/attachments/{id}/retry`, `/download`, and `/reject` (§7.3) — and the Step 1.6A.3B idempotent multipart create — `POST /api/attachments` (§7.2) — are implemented (worker handlers in `meshsrv/attachments/service.py`); every other mutation endpoint (cancel, request-key, save, revoke, local-content, and the remaining sub-stages 1.6A.3–1.6A.5) remains design-only and does not exist yet.
+**Status:** Design contract (Step 1.6A), revised (second pass). The read-only endpoints of sub-stage 1.6A.2 (§5) are implemented in `api/api_attachments.py`. Of the mutation endpoints, the following are implemented (worker handlers in `meshsrv/attachments/service.py`, enqueued from `api/api_attachments.py`): the three Step 1.6A.3A lifecycle actions — `POST /api/attachments/{id}/retry`, `/download`, and `/reject` (§7.3); the Step 1.6A.3B idempotent multipart create — `POST /api/attachments` (§7.2); and the two Step 1.6A.3C mutations — `POST /api/attachments/{id}/cancel` (§7.4) and `POST /api/mca/contacts/{contact_id}/request-key` (§7.10). Every other mutation endpoint (save, revoke, local-content, and the remaining sub-stages 1.6A.4–1.6A.5) remains design-only and does not exist yet.
 **Canonical source:** the Russian system design spec (section 18 primary, sections 17/19/20 and the state machines also consulted). That spec is reference-only and is not committed to the repository.
 **Audience:** a future implementation task, split into sub-stages (§5).
 
@@ -456,18 +456,18 @@ Every mutation returns `202` + `command_id` (§3.4) unless a synchronous validat
 - Common errors: `404 attachment_not_found`; `409 invalid_state_transition` for any violated precondition — the synchronous 409 body carries the single safe `state` field with the current state: `{"ok": false, "error": "invalid state transition", "error_code": "invalid_state_transition", "state": "<current state>"}` (only `state` is added — never direction, ids, paths, comments, filenames, keys, tokens, or exception text); `503 relay_unreachable` (revoke at runtime, observed via the command result); `409 not_saved` (local-content when `saved=false`).
 - **`/save` is genuinely idempotent, not merely deduplicated.** `unique_file_name()` only resolves a name collision at **first** save — it is **not** an idempotency mechanism (a second save would otherwise create a second copy under a new name). The command instead: if `saved=true` and the file exists → return the prior result (`saved=true`, same `file_name`) **without copying**; if `saved=true` but the file is missing → `content_missing` (or a separately-specified re-save recovery), never a silent duplicate; `unique_file_name()` is applied **only** on the first save to resolve a name conflict.
 
-### 7.4 `POST /api/attachments/{id}/cancel` — cancel an outgoing send (1.6A.3)
+### 7.4 `POST /api/attachments/{id}/cancel` — cancel an outgoing send (1.6A.3C, implemented)
 
-Cancel the send before it is `SENT`. Cleanup is decided by **persisted remote state** (a Relay upload session and/or revoke token), not by the attachment state *name* alone — `UPLOADING` does not imply "committed", and `READY_TO_SEND` implies commit but the revoke token is the authoritative signal:
+Cancel the send before it is `SENT`. **Implementation status:** implemented as the worker command `attachment_cancel` (§4.2, `meshsrv/attachments/service.py`), enqueued from `api/api_attachments.py` with the same synchronous-validation-then-202 model as §7.3.
 
-- **No persisted remote session / revoke token** (nothing was ever uploaded): cancel the local operation and **clear the spool** (`spool/outgoing/<uuid>`), then → `CANCELLED`.
-- **Upload session created but not yet committed** (no revoke token yet): **abort or revoke the session**, then cancel locally → `CANCELLED`.
-- **Committed Relay object, OFFER not yet sent** (a revoke token exists, still in `READY_TO_SEND`): **revoke the object**, then → `CANCELLED`.
-- **Remote cleanup not confirmed:** if the revoke/abort fails, the command **fails** (`error_code: relay_unreachable`) and the attachment is **not** marked `CANCELLED` — the state stays `READY_TO_SEND` so the user can retry or revoke.
-- **After `SENT`** (`SENT`/`RECEIVED`/`DOWNLOADED`): `cancel` is **not** valid — use `/revoke`. → `409 invalid_state_transition`.
-- **Terminal states:** `409 invalid_state_transition`.
+**Synchronous (request thread):** `503 mca_not_ready` when the facade is missing/not ready; `400 invalid_attachment_id` for a non-canonical id (32 lowercase hex); `404 attachment_not_found` when absent from the published snapshot; `409 invalid_state_transition` (with the safe `state` field) unless the row is **outgoing** (`direction == "sent"`) and in `sender.AUTOMATIC_STATES` (`DRAFT`/`VALIDATING`/`ENCRYPTING`/`QUEUED_UPLOAD`/`UPLOADING`/`READY_TO_SEND`) — received rows and terminal / `SENT` / `RECEIVED` / `DOWNLOADED` / `REJECTED` / `EXPIRED` / `REVOKED` / `CANCELLED` rows are never cancellable. Otherwise `202 {"ok": true, "command_id"}`.
 
-Responses: `202 {"ok": true, "command_id"}`; `404 attachment_not_found`; `409 invalid_state_transition`. Success/failure is observed via the command result (§7.9). The "revoke/abort then CANCELLED" orchestration is a **new** worker command composing the Relay session cleanup + `sender.cancel` (§13); it keys off persisted upload-session/revoke-token state.
+**Worker (`_command_cancel`)** re-reads the persisted row (never trusts the snapshot) and runs two halves strictly in order:
+
+1. **Remote first** — decided by persisted `mca_sender_state` (`upload_id`/`revoke_token`), not by the state name: if neither was ever persisted → local-only cancel; if a session exists but `revoke_token` is missing → `relay_unreachable` (cannot safely revoke; the row, sender state, and spool are all preserved); otherwise resolve the Relay client from the row's persisted `provider_id` (never a default) and call `RelayClient.revoke(bytes.fromhex(transfer_id), revoke_token)`. A Relay **404 is confirmed absence** (the object is already gone → the remote half is satisfied); any other `RelayHTTPError`/`RelayError`, or a missing/disabled provider → `relay_unreachable` with the row, sender state, and spool all **preserved** for a manual retry (a committed-but-unreachable object is never silently abandoned).
+2. **Local second**, only after the remote half resolves: unlink **only** `spool/outgoing/<attachment_id>` (derived from the validated id, never `saved_path`; a missing spool is clean; an unlink `OSError` → `spool_cleanup_failed` with the row unchanged), clear `saved_path` to `NULL`, then `sender.cancel()` in the same transaction (a `SenderError` from a state that raced out of `AUTOMATIC_STATES` rolls back → `invalid_state_transition`).
+
+Success result (only when both halves completed): state `CANCELLED`, `saved_path` NULL, no `mca_sender_state` row, no spool file, history preserved — `result: {"attachment_id": ..., "state": "CANCELLED"}`.
 
 ### 7.5 Public attachment projection (all read endpoints)
 
@@ -525,11 +525,16 @@ Responses: `202 {"ok": true, "command_id"}`; `404 attachment_not_found`; `409 in
 - **Errors:** `400 invalid_command_id`; `404 command_not_found` (unknown id, expired, or lost to restart). After a restart the client falls back to polling the domain snapshots (§3.4).
 - **Bounded/immutable/restart behavior:** §3.4.
 
-### 7.10 `POST /api/mca/contacts/{contact_id}/request-key` (1.6A.3)
+### 7.10 `POST /api/mca/contacts/{contact_id}/request-key` (1.6A.3C, implemented)
 
-- **CSRF:** required. **Body:** `{"route": {"adapter_id", "route_id"}}` (optional; defaults to the binding's route).
-- **Flow:** `RequestKeyCommand` → `key_exchange.build_key_request()` → send via the adapter. Rate-limited by `key_exchange`'s per-address gate.
-- **Responses:** `202`; `429 rate_limited`; `409 key_already_known`; `503 radio_unavailable` (observed via the command result).
+Ask a contact to announce its MCA key over the fixed DIRECT route. **Implementation status:** implemented as the worker command `contact_request_key` (§4.2, `meshsrv/attachments/service.py`), enqueued from `api/api_attachments.py`.
+
+- **Contact id (Stage 1):** the canonical Meshtastic transport address — `!` followed by exactly 8 lowercase hex digits (e.g. `!756f9960`). Any other shape → `400 {"ok": false, "error": "invalid contact id", "error_code": "invalid_contact_id"}`.
+- **CSRF:** required. **Body:** empty, or `{"route": {"adapter_id": "meshtastic", "route_id": "<contact_id>"}}`. A missing `route` defaults to DIRECT (the only supported route); a supplied `route` must name `adapter_id == "meshtastic"` and `route_id == contact_id` — anything else → `400 invalid_contact_id`.
+- **Synchronous (request thread):** `503 mca_not_ready`; `400 invalid_contact_id`; `409 key_already_known` when the snapshot binding is already `MCA_READY`; otherwise `202 {"ok": true, "command_id"}`. `KEY_UNKNOWN`/`KEY_UNVERIFIED`/`KEY_CHANGED` may request.
+- **Worker (`_command_request_key`)** re-validates id/adapter/route (never trusts the queue), re-reads the live binding (a contact that became `MCA_READY` since the snapshot read → `key_already_known`), checks the persisted outgoing rate limit, then `build_key_request()` + `encode()` + `send()` over a fixed DIRECT `Route(route_type=DIRECT, route_id=contact_id, destination_address=contact_id)` with `command.command_id` as the idempotency key. A missing delivery adapter, a `DeliveryError`, or a receipt with `sent != True` → `radio_unavailable` (no quota consumed). On `sent == True`, the quota timestamp is persisted and the result is `{"contact_id": ..., "status": "requested"}`.
+- **Rate limit:** one accepted outgoing key request per `(workspace_id, adapter_id, source_address)` per 600 s, persisted in `mca_key_exchange_contact_state.last_request_sent_at` (migration 13) so it survives a restart; the timestamp is recorded **only after** `DeliveryReceipt.sent == True`, so a failed send never consumes the quota. A second request inside the window → `rate_limited` (command result).
+- **Responses:** `202`; `400 invalid_contact_id`; `409 key_already_known`; `429 command_queue_full`; command-result failures `rate_limited` / `radio_unavailable`.
 
 ### 7.11 Provider onboarding — two-phase via `probe_id` (1.6A.4)
 
@@ -617,7 +622,7 @@ Allowed actions per state. `retry` is valid **only** for `AUTOMATIC_STATES` — 
 | State | retry | download | save | reject | revoke | cancel | copy-code | local-content |
 |---|---|---|---|---|---|---|---|---|
 | DRAFT / VALIDATING / ENCRYPTING / QUEUED_UPLOAD | ✓ | — | — | — | — | ✓ (no remote session: local + spool) | — | — |
-| UPLOADING | ✓ | — | — | — | — | ✓ (session uncommitted: abort/revoke session) | — | — |
+| UPLOADING | ✓ | — | — | — | — | ✓ (persisted session: revoke object) | — | — |
 | READY_TO_SEND | ✓ | — | — | — | — | ✓ (committed: revoke object) | — | — |
 | SENT / RECEIVED / DOWNLOADED | — | — | — | — | ✓ | — (use revoke) | ✓ | ✓(if saved) |
 | FAILED_VALIDATION / FAILED_UPLOAD / FAILED_RADIO | — | — | — | — | — | — | — | — |
@@ -629,7 +634,7 @@ Allowed actions per state. `retry` is valid **only** for `AUTOMATIC_STATES` — 
 | AVAILABLE | — | — | ✓ | — | — | — | ✓ | ✓ |
 | REJECTED / FAILED / EXPIRED (receiver) | — | — | — | — | — | — | — | — |
 
-`cancel` semantics (keyed off persisted remote state, §7.4): no remote session/revoke token → local cancel + clear spool → `CANCELLED`; upload session uncommitted → abort/revoke session → `CANCELLED`; committed object not yet sent → revoke object → `CANCELLED` (any remote-cleanup failure ⇒ not `CANCELLED`, `error_code: relay_unreachable`); `SENT/RECEIVED/DOWNLOADED` → use `/revoke`, not `/cancel`.
+`cancel` semantics (keyed off persisted remote state, §7.4): no persisted `upload_id`/`revoke_token` → local cancel + clear spool → `CANCELLED`; a persisted session without a `revoke_token` → `relay_unreachable` (cannot safely revoke — row preserved for manual retry); a persisted `revoke_token` → revoke the object (a Relay 404 is confirmed absence) then local cancel → `CANCELLED` (any other remote-cleanup failure ⇒ not `CANCELLED`, `error_code: relay_unreachable`; an unlink `OSError` ⇒ `spool_cleanup_failed`); `SENT/RECEIVED/DOWNLOADED` → use `/revoke`, not `/cancel`.
 
 `retry` never mutates state directly — it re-dispatches `run_step`/`reconcile_pending` for a state the tick already drives, forcing immediacy (e.g. `READY_TO_SEND` after the radio returns, `QUEUED_UPLOAD` after the network returns). It never mints a new `transfer_id`, and it does **not** recover a terminal `FAILED_*` (that is a future state-machine change).
 
@@ -651,7 +656,7 @@ Stable, snake_case, additive.
 
 | Status | `error_code` | Meaning |
 |---|---|---|
-| 400 | `invalid_metadata` / `invalid_attachment_id` / `invalid_direction` / `invalid_state` / `invalid_filter` / `invalid_command_id` / `invalid_origin` / `invalid_pagination` / `invalid_provider_id` / `invalid_query` | malformed input |
+| 400 | `invalid_metadata` / `invalid_attachment_id` / `invalid_direction` / `invalid_state` / `invalid_filter` / `invalid_command_id` / `invalid_origin` / `invalid_pagination` / `invalid_provider_id` / `invalid_query` / `invalid_contact_id` | malformed input |
 | 400 | `mime_not_allowed` / `file_too_large` / `metadata_too_large` / `ciphertext_too_large` | file/size validation |
 | 400 | `recipient_not_found` / `recipient_not_trusted` | binding missing or not `trusted` |
 | 400 | `provider_not_found` / `provider_disabled` / `upload_not_allowed` / `upload_token_missing` / `ttl_out_of_range` / `provider_id_mismatch` | provider/registration |
@@ -674,7 +679,7 @@ Stable, snake_case, additive.
 | 503 | `mca_not_ready` | the attachments facade exists but readiness is unset (service not yet started, or the first snapshot publish failed); snapshot-backed reads and `submit()` reject until readiness (§3.2) |
 | 500 | `internal_error` | an unexpected exception was sanitized by the MCAttach read endpoint's local error boundary — a stable envelope with no exception text, class, traceback, or path (§11) |
 
-Command-result `error_code`s reuse this table plus the probe failure codes (`origin_not_routable`, `relay_identity_mismatch`, `relay_incompatible`) and the two worker-side execution codes `unsupported_command_kind` (an enumerated kind with no wired handler — a terminal `failed`, never a crash) and `command_execution_failed` (a wired handler raised; the drain loop records it as a terminal `failed`). `UploadRejectionReason` maps 1:1 to `error_code`s on upload-readiness: `profile_not_found`, `profile_disabled`, `upload_not_allowed`, `upload_token_missing`, `relay_not_yet_checked`, `relay_unreachable`, `relay_identity_mismatch`, `relay_incompatible`, `ciphertext_too_large`, `ttl_below_minimum`, `ttl_above_maximum`.
+Command-result `error_code`s reuse this table plus the probe failure codes (`origin_not_routable`, `relay_identity_mismatch`, `relay_incompatible`), the two worker-side execution codes `unsupported_command_kind` (an enumerated kind with no wired handler — a terminal `failed`, never a crash) and `command_execution_failed` (a wired handler raised; the drain loop records it as a terminal `failed`), and the cancel-specific worker code `spool_cleanup_failed` (an unlink `OSError` on `spool/outgoing/<attachment_id>` — §7.4). `UploadRejectionReason` maps 1:1 to `error_code`s on upload-readiness: `profile_not_found`, `profile_disabled`, `upload_not_allowed`, `upload_token_missing`, `relay_not_yet_checked`, `relay_unreachable`, `relay_identity_mismatch`, `relay_incompatible`, `ciphertext_too_large`, `ttl_below_minimum`, `ttl_above_maximum`.
 
 ---
 
@@ -738,10 +743,10 @@ The trust is thus **operator-confirmed fingerprint + server-side probe-verified 
 
 ## 13. Implementation gaps (resolve before/with the named sub-stage)
 
-1. **Facade / queue / snapshots — built in Step 1.6A.1.** The §3 plumbing now exists: `CommandQueue`, `CommandRegistry`, `PendingReservations`, `ProbeRegistry`, `AttachmentsSnapshotPublisher` (+ `ContentDescriptor`), the `AttachmentsFacade` request surface, and the `CommandDispatcher` handler table — wired into `_MCARuntimeState` and drained by the worker (§3.2/§3.3/§3.4). The Step 1.6A.3A lifecycle handlers (`attachment_retry` / `attachment_download` / `attachment_reject`) and the Step 1.6A.3B create handler (`attachment_create` → `sender.create_draft`) are now implemented. What remains is the rest of the per-command handler *implementations* (the actual `save`/`revoke`/provider work), which land in sub-stages 1.6A.3–1.6A.5.
+1. **Facade / queue / snapshots — built in Step 1.6A.1.** The §3 plumbing now exists: `CommandQueue`, `CommandRegistry`, `PendingReservations`, `ProbeRegistry`, `AttachmentsSnapshotPublisher` (+ `ContentDescriptor`), the `AttachmentsFacade` request surface, and the `CommandDispatcher` handler table — wired into `_MCARuntimeState` and drained by the worker (§3.2/§3.3/§3.4). Six command handlers are now implemented: the Step 1.6A.3A lifecycle handlers (`attachment_retry` / `attachment_download` / `attachment_reject`), the Step 1.6A.3B create handler (`attachment_create` → `sender.create_draft`), and the two Step 1.6A.3C handlers (`attachment_cancel` → remote-revoke-then-`sender.cancel`, §7.4; `contact_request_key` → rate-limited KEY_REQUEST send, §7.10). What remains is the rest of the per-command handler *implementations* (the actual `save`/`revoke`/provider work), which land in sub-stages 1.6A.4–1.6A.5.
 2. **`client_request_id` / `canonical_hash` columns — done (migration 11).** The two columns plus the partial unique index on `(workspace_id, client_request_id) WHERE client_request_id IS NOT NULL` now exist (§3.5/§3.6).
 3. **Multipart staging — done (Step 1.6A.3B).** `POST /api/attachments` now accepts `multipart/form-data`, stages the plaintext to `spool/outgoing/<uuid>` in bounded 64 KiB chunks (never whole-file buffered), sniffs MIME from magic bytes plus full-stream text/JSON validation and filename normalization, computes `file_sha256` + `canonical_hash`, and enforces the 5 MiB cap with a per-request total-body cap (`413 request_too_large`) (§7.2).
-4. **No cancel orchestration** — `sender.cancel()` does not clear the spool or abort/revoke an in-flight Relay upload session/object; the `CancelAttachmentCommand`'s persisted-remote-state behavior (§7.4) is a new worker command composing the Relay session cleanup + `sender.cancel`.
+4. **Cancel orchestration — done (Step 1.6A.3C).** `sender.cancel()` still does not itself clear the spool or revoke an in-flight Relay object; the `attachment_cancel` worker command now composes both halves — the persisted-remote-state Relay revoke (with 404-as-confirmed-absence) followed by the spool unlink + `saved_path` clear + `sender.cancel()` (§7.4).
 5. **`ProbeRegistry` built (Step 1.6A.1); `probe_id`→`register()` wiring still open.** The single-use in-memory `ProbeRecord` store with its TTL/check-and-consume semantics (§7.11) is now built and TTL-enforced. What remains is wiring the `probe_id` flow into `register()` so it consumes the probe record instead of re-trusting browser-supplied fields — that lands in 1.6A.4.
 6. **No contact enumeration** — `GET /api/mca/contacts` needs a "list all bindings" method.
 7. **`clear_upload_token()` done (Step 1.6A.1); add-route / save-to-files / revoke still open.** The remaining domain methods — `deliveries` POST (add-route), `save` (save-to-files), and `revoke`-via-facade — still need new worker-executed methods (sub-stages 1.6A.3/1.6A.5).

--- a/meshsrv/attachments/db/migrations.py
+++ b/meshsrv/attachments/db/migrations.py
@@ -767,6 +767,24 @@ _MIGRATION_0012_DOWN = "\n".join(
 ) + "\nDROP TABLE IF EXISTS mca_dirty_attachments;"
 
 
+# Step 1.6A.3C (contact key request): a per-contact outgoing key-request
+# throttle, distinct from the KEY_ANNOUNCE throttle already tracked in
+# `last_announce_sent_at`. The two limits are deliberately independent -
+# announcing your own key and requesting a contact's key are different
+# actions with different abuse surfaces, and recording one must never
+# consume the other's quota window. `last_request_sent_at` is NULL until the
+# first accepted request send, so a contact that has never been asked simply
+# has no row-timestamp to compare against (the rate-limit check treats NULL
+# as "never sent", i.e. allowed).
+_MIGRATION_0013_UP = """
+ALTER TABLE mca_key_exchange_contact_state ADD COLUMN last_request_sent_at INTEGER;
+"""
+
+_MIGRATION_0013_DOWN = """
+ALTER TABLE mca_key_exchange_contact_state DROP COLUMN last_request_sent_at;
+"""
+
+
 @dataclass(frozen=True)
 class Migration:
     version: int
@@ -801,6 +819,7 @@ MIGRATIONS: Sequence[Migration] = (
         12, "snapshot_dirty_tracking", _MIGRATION_0012_UP, _MIGRATION_0012_DOWN,
         data_fixup=_migration_0012_create_dirty_triggers,
     ),
+    Migration(13, "contact_key_request_rate_limit", _MIGRATION_0013_UP, _MIGRATION_0013_DOWN),
 )
 
 LATEST_VERSION: int = MIGRATIONS[-1].version if MIGRATIONS else 0

--- a/meshsrv/attachments/key_exchange.py
+++ b/meshsrv/attachments/key_exchange.py
@@ -53,6 +53,7 @@ from meshsrv.attachments.workspace import MCAWorkspaceManager
 
 DEFAULT_MAX_ANNOUNCES_PER_HOUR = 12
 MIN_SECONDS_BETWEEN_ANNOUNCES_TO_SAME_ADDRESS = 10 * 60
+MIN_SECONDS_BETWEEN_KEY_REQUESTS_TO_SAME_ADDRESS = 10 * 60
 _QUOTA_WINDOW_SECONDS = 3600
 
 
@@ -148,6 +149,7 @@ class KeyExchangeCoordinator:
         *,
         max_announces_per_hour: int = DEFAULT_MAX_ANNOUNCES_PER_HOUR,
         min_seconds_between_announces: int = MIN_SECONDS_BETWEEN_ANNOUNCES_TO_SAME_ADDRESS,
+        min_seconds_between_key_requests: int = MIN_SECONDS_BETWEEN_KEY_REQUESTS_TO_SAME_ADDRESS,
         now_fn=time.time,
     ):
         conn.row_factory = sqlite3.Row
@@ -157,6 +159,7 @@ class KeyExchangeCoordinator:
         self._adapter_id = adapter_id
         self._max_per_hour = max_announces_per_hour
         self._min_interval = min_seconds_between_announces
+        self._min_key_request_interval = min_seconds_between_key_requests
         self._now = now_fn
 
     # ---- incoming message dispatch --------------------------------------
@@ -266,6 +269,49 @@ class KeyExchangeCoordinator:
                 "UPDATE mca_key_exchange_quota SET announces_sent = announces_sent + 1 WHERE workspace_id = ?",
                 (self._principal.workspace_id,),
             )
+        self._conn.commit()
+
+    # ---- outgoing KEY_REQUEST throttle (Step 1.6A.3C) -------------------
+
+    def check_key_request_rate_limit(self, source_address: str, now: float) -> None:
+        """Gate an outgoing KEY_REQUEST to `source_address` behind the
+        per-contact interval (spec: one accepted key request per contact
+        address every `MIN_SECONDS_BETWEEN_KEY_REQUESTS_TO_SAME_ADDRESS`).
+        Raises `RateLimited` when a request was already sent within the
+        window; a NULL `last_request_sent_at` (never asked) is allowed.
+        Deliberately independent of `_check_rate_limits()` - announcing
+        one's own key and requesting a contact's key are different actions
+        and never share a quota window."""
+        state = self._conn.execute(
+            "SELECT last_request_sent_at FROM mca_key_exchange_contact_state "
+            "WHERE workspace_id = ? AND adapter_id = ? AND source_address = ?",
+            (self._principal.workspace_id, self._adapter_id, source_address),
+        ).fetchone()
+        if state is not None and state["last_request_sent_at"] is not None:
+            elapsed = now - state["last_request_sent_at"]
+            if elapsed < self._min_key_request_interval:
+                raise RateLimited(
+                    f"already requested {source_address!r}'s key {elapsed:.0f}s ago "
+                    f"(minimum interval is {self._min_key_request_interval}s)"
+                )
+
+    def record_key_request_sent(self, source_address: str, now: float) -> None:
+        """Persist the quota timestamp only after a request has actually
+        been accepted for send (worker checks the delivery receipt's
+        `sent` flag before calling this - a failed send never consumes the
+        quota). Mirrors `_record_announce_sent()`'s UPSERT shape but writes
+        `last_request_sent_at`, not `last_announce_sent_at`, so the two
+        throttles stay independent."""
+        self._conn.execute(
+            """
+            INSERT INTO mca_key_exchange_contact_state
+                (workspace_id, adapter_id, source_address, last_request_sent_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(workspace_id, adapter_id, source_address)
+            DO UPDATE SET last_request_sent_at = excluded.last_request_sent_at
+            """,
+            (self._principal.workspace_id, self._adapter_id, source_address, now),
+        )
         self._conn.commit()
 
     # ---- KEY_ANNOUNCE handling (someone else's identity arriving) -------

--- a/meshsrv/attachments/service.py
+++ b/meshsrv/attachments/service.py
@@ -145,6 +145,19 @@ _TEMP_SPOOL_SUFFIX = ".tmp"
 # Anchored with \Z (not $) so a trailing newline cannot sneak through.
 _HEX32_RE = re.compile(r"[0-9a-f]{32}\Z")
 
+# Stage 1 contact id (Step 1.6A.3C §7.10): the canonical Meshtastic
+# transport address - a `!` prefix followed by exactly 8 lowercase hex chars
+# (e.g. `!756f9960`). Anchored with \Z so a trailing newline cannot sneak
+# through; used by both the request thread's route validation and the
+# worker's defensive re-validation.
+_CONTACT_ID_RE = re.compile(r"![0-9a-f]{8}\Z")
+
+
+def _is_contact_id(value) -> bool:
+    """True iff `value` is a Stage 1 contact transport address (`!` + 8
+    lowercase hex). Pure - no conn, no filesystem, no lock."""
+    return isinstance(value, str) and _CONTACT_ID_RE.match(value) is not None
+
 RelayClientFactory = Callable[[str], Optional[RelayClient]]
 
 
@@ -775,12 +788,12 @@ class AttachmentsService:
 
     def _build_dispatcher(self) -> CommandDispatcher:
         """The real kind->handler table the worker runs (replaces the empty
-        placeholder this service would otherwise default to). The five command
+        placeholder this service would otherwise default to). The six command
         handlers wired so far - the idempotent create (`attachment_create`,
         Step 1.6A.3B), the three Step 1.6A.3A lifecycle commands
-        (retry/download/reject), and the Step 1.6A.3C cancel mutation - every
-        other enumerated kind stays `unsupported_command_kind` until its own
-        future sub-stage wires it.
+        (retry/download/reject), and the two Step 1.6A.3C mutations (cancel
+        and contact key request) - every other enumerated kind stays
+        `unsupported_command_kind` until its own future sub-stage wires it.
         Built once at construction (the dispatcher snapshots its mapping),
         never mutated afterwards."""
         return CommandDispatcher({
@@ -789,6 +802,7 @@ class AttachmentsService:
             "attachment_download": self._command_download,
             "attachment_reject": self._command_reject,
             "attachment_cancel": self._command_cancel,
+            "contact_request_key": self._command_request_key,
         })
 
     def _command_create(self, command: Command) -> CommandOutcome:
@@ -1501,6 +1515,52 @@ class AttachmentsService:
         return CommandOutcome.succeeded(
             resource_id=attachment_id,
             result={"attachment_id": attachment_id, "state": sender.CANCELLED},
+        )
+
+    def _command_request_key(self, command: Command) -> CommandOutcome:
+        """`contact_request_key` (§7.10): send a signed KEY_REQUEST to a
+        contact whose key is unknown/unverified/changed, over the fixed
+        DIRECT route (route_id == destination_address == the contact
+        transport address). Re-validates contact id/adapter/route (never
+        trusts the queue), re-reads the live binding (a contact that became
+        `MCA_READY` since the request thread's snapshot read fails with
+        `key_already_known`), checks the persisted outgoing key-request rate
+        limit, then encodes and sends. The rate-limit timestamp is persisted
+        *only* after the delivery receipt reports `sent == True` - a failed
+        send never consumes the quota. Any delivery failure (DeliveryError,
+        a false receipt, or a missing delivery adapter) is `radio_unavailable`
+        and consumes no quota."""
+        contact_id = command.payload.get("contact_id")
+        adapter_id = command.payload.get("adapter_id")
+        route_id = command.payload.get("route_id")
+        if not _is_contact_id(contact_id):
+            return CommandOutcome.failed("invalid_contact_id")
+        if adapter_id != "meshtastic" or route_id != contact_id:
+            return CommandOutcome.failed("invalid_contact_id")
+
+        if self._key_exchange.get_status(contact_id) is AddressStatus.MCA_READY:
+            return CommandOutcome.failed("key_already_known")
+        try:
+            self._key_exchange.check_key_request_rate_limit(contact_id, self._now())
+        except RateLimited:
+            return CommandOutcome.failed("rate_limited")
+
+        if self._delivery_adapter is None:
+            return CommandOutcome.failed("radio_unavailable")
+        key_request = self._key_exchange.build_key_request()
+        route = Route(route_type=RouteType.DIRECT, route_id=contact_id, destination_address=contact_id)
+        try:
+            wire_payload = self._delivery_adapter.encode(key_request, route)
+            receipt = self._delivery_adapter.send(wire_payload, route, idempotency_key=command.command_id)
+        except DeliveryError:
+            return CommandOutcome.failed("radio_unavailable")
+        if not receipt.sent:
+            return CommandOutcome.failed("radio_unavailable")
+
+        self._key_exchange.record_key_request_sent(contact_id, self._now())
+        return CommandOutcome.succeeded(
+            resource_id=contact_id,
+            result={"contact_id": contact_id, "status": "requested"},
         )
 
     def _refresh_snapshot(self) -> None:

--- a/meshsrv/attachments/service.py
+++ b/meshsrv/attachments/service.py
@@ -65,7 +65,7 @@ from meshsrv.attachments.idempotency import PendingReservation, PendingReservati
 from meshsrv.attachments.key_exchange import AddressStatus, KeyExchangeCoordinator, RateLimited
 from meshsrv.attachments.provider_registry import ProviderRegistry, ProviderRegistryError, decode_provider_id, encode_provider_id
 from meshsrv.attachments.recipient_snapshot import RecipientSnapshotPublisher
-from meshsrv.attachments.relay_client import RelayClient
+from meshsrv.attachments.relay_client import RelayClient, RelayError, RelayHTTPError
 from meshsrv.attachments.snapshots import AttachmentsSnapshotPublisher
 from meshsrv.attachments.workspace import MCAWorkspaceManager
 from meshsrv.connectivity_monitor import ConnectivityMonitor
@@ -775,11 +775,12 @@ class AttachmentsService:
 
     def _build_dispatcher(self) -> CommandDispatcher:
         """The real kind->handler table the worker runs (replaces the empty
-        placeholder this service would otherwise default to). Exactly the four
-        command handlers this sub-stage wires - the idempotent create
-        (`attachment_create`, Step 1.6A.3B) plus the three Step 1.6A.3A
-        lifecycle commands - every other enumerated kind stays
-        `unsupported_command_kind` until its own future sub-stage wires it.
+        placeholder this service would otherwise default to). The five command
+        handlers wired so far - the idempotent create (`attachment_create`,
+        Step 1.6A.3B), the three Step 1.6A.3A lifecycle commands
+        (retry/download/reject), and the Step 1.6A.3C cancel mutation - every
+        other enumerated kind stays `unsupported_command_kind` until its own
+        future sub-stage wires it.
         Built once at construction (the dispatcher snapshots its mapping),
         never mutated afterwards."""
         return CommandDispatcher({
@@ -787,6 +788,7 @@ class AttachmentsService:
             "attachment_retry": self._command_retry,
             "attachment_download": self._command_download,
             "attachment_reject": self._command_reject,
+            "attachment_cancel": self._command_cancel,
         })
 
     def _command_create(self, command: Command) -> CommandOutcome:
@@ -1398,6 +1400,107 @@ class AttachmentsService:
         return CommandOutcome.succeeded(
             resource_id=attachment_id,
             result={"attachment_id": attachment_id, "state": receiver.REJECTED},
+        )
+
+    def _cancel_row(self, attachment_id: str) -> Optional[sqlite3.Row]:
+        """The wider persisted row a cancel needs beyond `_attachment_row`:
+        `transfer_id` (the Relay object to revoke) and `saved_path` (cleared,
+        never used as a filesystem component). Re-read from the worker-owned
+        `conn` (§3.1). Returns `None` for an unknown id or a row in another
+        workspace."""
+        self._conn.row_factory = sqlite3.Row
+        return self._conn.execute(
+            "SELECT id, direction, provider_id, state, transfer_id, saved_path FROM attachments "
+            "WHERE id = ? AND workspace_id = ?",
+            (attachment_id, self._principal.workspace_id),
+        ).fetchone()
+
+    def _sender_state_row(self, attachment_id: str) -> Optional[sqlite3.Row]:
+        """The sender-state columns a cancel consults to decide whether a
+        Relay object exists to revoke (`upload_id`/`revoke_token`). Only the
+        two remote-cleanup signals are projected - the data key / nonce /
+        upload token stay out of a handler that must never touch key material
+        it has no use for."""
+        self._conn.row_factory = sqlite3.Row
+        return self._conn.execute(
+            "SELECT upload_id, revoke_token FROM mca_sender_state WHERE attachment_id = ?",
+            (attachment_id,),
+        ).fetchone()
+
+    def _command_cancel(self, command: Command) -> CommandOutcome:
+        """`attachment_cancel` (§7.4): the explicit user action that cancels
+        an outgoing attachment still in an automatic (pre-SENT) state. The
+        cancel has a remote half and a local half, and they run strictly in
+        that order:
+
+        - **remote first**: if a Relay upload session was ever created
+          (`upload_id` or `revoke_token` persisted), `RelayClient.revoke()` is
+          called against the provider pinned on the row (never a default). A
+          Relay **404 is confirmed absence** - the object no longer exists
+          remotely, so the remote half is already satisfied - whereas every
+          other failure (`RelayUnavailableError`/`RelayHTTPError`/missing or
+          disabled provider) is `relay_unreachable`, leaving the row, its
+          sender state, and its spool file all *preserved* for a manual retry
+          (no auto retry - a committed-but-unreachable object must never be
+          silently abandoned).
+        - **local second, only after the remote half is resolved**: delete the
+          staged spool (`spool/outgoing/<attachment_id>`, derived from the
+          validated id only - never `saved_path`, which is cleared to NULL,
+          never handed to the filesystem), then `sender.cancel()` in the same
+          transaction. An unlink failure is `spool_cleanup_failed` with the
+          row unchanged.
+
+        Result (state=CANCELLED, saved_path NULL, no sender-state row, no
+        spool file, history preserved) is only reached when both halves
+        completed."""
+        attachment_id = command.payload.get("attachment_id")
+        row = self._cancel_row(attachment_id)
+        if row is None:
+            return CommandOutcome.failed("attachment_not_found")
+        if row["direction"] != "sent" or row["state"] not in sender.AUTOMATIC_STATES:
+            return CommandOutcome.failed("invalid_state_transition")
+
+        sender_state = self._sender_state_row(attachment_id)
+        upload_id = sender_state["upload_id"] if sender_state is not None else None
+        revoke_token = sender_state["revoke_token"] if sender_state is not None else None
+        needs_remote = upload_id is not None or revoke_token is not None
+        if needs_remote:
+            if revoke_token is None:
+                # A remote session exists but its revoke token was never
+                # persisted - we cannot revoke it, so we cannot complete a
+                # safe cancel. Preserve everything for a manual retry.
+                return CommandOutcome.failed("relay_unreachable")
+            provider_id_text = _provider_id_text(row["direction"], row["provider_id"])
+            profile = self._provider_registry.resolve(provider_id_text) if provider_id_text else None
+            if profile is None or not profile.enabled:
+                return CommandOutcome.failed("relay_unreachable")
+            relay_client = self._relay_client_factory(provider_id_text) if provider_id_text else None
+            if relay_client is None:
+                return CommandOutcome.failed("relay_unreachable")
+            try:
+                relay_client.revoke(bytes.fromhex(row["transfer_id"]), revoke_token)
+            except RelayHTTPError as exc:
+                if exc.status_code != 404:
+                    return CommandOutcome.failed("relay_unreachable")
+                # 404 = confirmed absence: the remote half is already done.
+            except RelayError:
+                return CommandOutcome.failed("relay_unreachable")
+
+        spool_path = self._spool_path_for(attachment_id)
+        if spool_path is not None:
+            try:
+                spool_path.unlink(missing_ok=True)
+            except OSError:
+                return CommandOutcome.failed("spool_cleanup_failed")
+        self._conn.execute("UPDATE attachments SET saved_path = NULL WHERE id = ?", (attachment_id,))
+        try:
+            sender.cancel(self._conn, attachment_id, now=self._now())
+        except sender.SenderError:
+            self._rollback_silently()
+            return CommandOutcome.failed("invalid_state_transition")
+        return CommandOutcome.succeeded(
+            resource_id=attachment_id,
+            result={"attachment_id": attachment_id, "state": sender.CANCELLED},
         )
 
     def _refresh_snapshot(self) -> None:

--- a/tests/test_attachments_service.py
+++ b/tests/test_attachments_service.py
@@ -27,12 +27,14 @@ import pytest
 from nacl.signing import VerifyKey
 
 from meshsrv.attachments import codec, identity, receiver, sender
+from meshsrv.attachments.commands import Command
 from meshsrv.attachments.db import migrations
+from meshsrv.attachments.delivery.base import DeliveryError, DeliveryReceipt
 from meshsrv.attachments.delivery.fakes import FakeTextAdapter, InMemoryEther
 from meshsrv.attachments.key_exchange import KeyExchangeCoordinator
 from meshsrv.attachments.provider_registry import ProviderRegistry
 from meshsrv.attachments.relay.mock_server import MockRelayStore, create_mock_relay_app
-from meshsrv.attachments.relay_client import RelayClient
+from meshsrv.attachments.relay_client import RelayClient, RelayHTTPError
 from meshsrv.attachments.service import AttachmentsService, _provider_id_text
 from meshsrv.attachments.workspace import MCAWorkspaceManager
 from meshsrv.connectivity_monitor import ConnectivityMonitor
@@ -1428,3 +1430,348 @@ def test_wake_causes_a_tick_promptly_instead_of_waiting_for_the_full_interval(co
         assert sender.get_state(conn, attachment_id) != sender.DRAFT
     finally:
         service.stop()
+
+
+# ---- Step 1.6A.3C worker commands: attachment_cancel + contact_request_key -
+
+
+def _cancel_command(attachment_id):
+    return Command(
+        command_id=uuid.uuid4().hex,
+        kind="attachment_cancel",
+        payload={"attachment_id": attachment_id},
+        created_at=time.time(),
+    )
+
+
+def _request_key_command(contact_id, *, adapter_id="meshtastic", route_id=None):
+    return Command(
+        command_id=uuid.uuid4().hex,
+        kind="contact_request_key",
+        payload={
+            "contact_id": contact_id,
+            "adapter_id": adapter_id,
+            "route_id": route_id if route_id is not None else contact_id,
+        },
+        created_at=time.time(),
+    )
+
+
+def _insert_sender_state(conn, attachment_id, *, upload_id=None, revoke_token=None):
+    """Manually stage an `mca_sender_state` row (the two remote-cleanup
+    signals `_command_cancel` reads; the key/nonce columns are never touched
+    by the handler, so dummy values suffice)."""
+    conn.execute(
+        """
+        INSERT INTO mca_sender_state
+            (attachment_id, data_key, nonce_prefix, upload_id, revoke_token, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (attachment_id, "aa" * 16, "bb" * 12, upload_id, revoke_token, int(time.time()), int(time.time())),
+    )
+    conn.commit()
+
+
+def _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, delivery_adapter, relay_client_factory=None):
+    """A service built around a caller-supplied delivery adapter / relay
+    factory, so a single command's edge case can be driven against a
+    deliberately broken or instrumented collaborator."""
+    return AttachmentsService(
+        conn, workspace_manager=wsm, principal=principal, provider_registry=provider_registry,
+        key_exchange=key_exchange, connectivity_monitor=connectivity_monitor,
+        delivery_adapter=delivery_adapter, relay_client_factory=relay_client_factory,
+        max_per_tick=8,
+    )
+
+
+class _StubRelayClient:
+    """A RelayClient-shaped object whose `revoke()` records its arguments and
+    either succeeds ("ok") or raises the configured exception - for pinning
+    the remote-revoke half of cancel without the full mock Relay's session
+    bookkeeping."""
+
+    def __init__(self, revoke_result="ok"):
+        self.revoke_calls = []
+        self._revoke_result = revoke_result
+
+    def revoke(self, transfer_id, revoke_token):
+        self.revoke_calls.append((transfer_id, revoke_token))
+        if isinstance(self._revoke_result, Exception):
+            raise self._revoke_result
+        return None
+
+
+class _SentFalseAdapter(FakeTextAdapter):
+    def send(self, wire_payload, route, idempotency_key):
+        return DeliveryReceipt(sent=False, idempotency_key=idempotency_key, external_message_id=None, sent_at=None)
+
+
+class _RaisingSendAdapter(FakeTextAdapter):
+    def send(self, wire_payload, route, idempotency_key):
+        raise DeliveryError("simulated send failure")
+
+
+# ---- attachment_cancel -----------------------------------------------------
+
+
+def test_command_cancel_local_only_marks_cancelled_and_clears_saved_path(
+    conn, wsm, principal, registered_provider, remote_recipient, tmp_path, service
+):
+    """No `mca_sender_state` row -> no remote half; the worker clears
+    `saved_path` and calls `sender.cancel()` to CANCELLED, leaving no
+    sender-state row and preserving history."""
+    _, _, recipient_principal = remote_recipient
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+
+    outcome = service._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code is None
+    assert outcome.resource_id == attachment_id
+    assert dict(outcome.result) == {"attachment_id": attachment_id, "state": sender.CANCELLED}
+    assert sender.get_state(conn, attachment_id) == sender.CANCELLED
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT saved_path FROM attachments WHERE id = ?", (attachment_id,)).fetchone()
+    assert row["saved_path"] is None
+    assert conn.execute("SELECT 1 FROM mca_sender_state WHERE attachment_id = ?", (attachment_id,)).fetchone() is None
+
+
+def test_command_cancel_unknown_id_is_not_found(service):
+    outcome = service._dispatcher.dispatch(_cancel_command("0" * 32))
+    assert outcome.error_code == "attachment_not_found"
+    assert outcome.resource_id is None and outcome.result is None
+
+
+def test_command_cancel_revalidates_state_from_the_row_not_the_snapshot(
+    conn, wsm, principal, registered_provider, remote_recipient, tmp_path, service
+):
+    """The worker re-reads the row and re-applies the precondition - a row
+    that has since moved to SENT (e.g. between the request thread's snapshot
+    read and execution) must fail with `invalid_state_transition`, leaving
+    the row and its saved_path untouched."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+    conn.execute("UPDATE attachments SET state = ? WHERE id = ?", (sender.SENT, attachment_id))
+    conn.commit()
+
+    outcome = service._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code == "invalid_state_transition"
+    assert sender.get_state(conn, attachment_id) == sender.SENT
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT saved_path FROM attachments WHERE id = ?", (attachment_id,)).fetchone()
+    assert row["saved_path"] is not None
+
+
+def test_command_cancel_remote_revoke_404_is_confirmed_absence(
+    conn, wsm, principal, registered_provider, remote_recipient, tmp_path, service
+):
+    """A remote session exists (`upload_id` + `revoke_token` persisted), but
+    the mock Relay has no object for the transfer_id -> `revoke()` raises
+    `RelayHTTPError(404)`, which the handler treats as the object already
+    gone, so the local half still completes to CANCELLED."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+    _insert_sender_state(conn, attachment_id, upload_id="upload-1", revoke_token="revoke-1")
+
+    outcome = service._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code is None
+    assert sender.get_state(conn, attachment_id) == sender.CANCELLED
+    assert conn.execute("SELECT 1 FROM mca_sender_state WHERE attachment_id = ?", (attachment_id,)).fetchone() is None
+
+
+def test_command_cancel_remote_revoke_success_revokes_then_cleans_up(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, registered_provider, remote_recipient, tmp_path
+):
+    """The remote half resolves *before* the local half: `revoke()` is called
+    with the row's own transfer_id (hex-decoded) and revoke token, and only
+    after it returns does the row become CANCELLED."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+    transfer_id_hex = conn.execute("SELECT transfer_id FROM attachments WHERE id = ?", (attachment_id,)).fetchone()[0]
+    _insert_sender_state(conn, attachment_id, upload_id="upload-1", revoke_token="revoke-1")
+
+    stub = _StubRelayClient(revoke_result="ok")
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, FakeTextAdapter(InMemoryEther(), "local-addr"), relay_client_factory=lambda _: stub)
+
+    outcome = svc._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code is None
+    assert stub.revoke_calls == [(bytes.fromhex(transfer_id_hex), "revoke-1")]
+    assert sender.get_state(conn, attachment_id) == sender.CANCELLED
+
+
+def test_command_cancel_remote_revoke_non_404_is_relay_unreachable_and_preserves_row(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, registered_provider, remote_recipient, tmp_path
+):
+    """A non-404 Relay failure must NOT be treated as absence: the command
+    fails `relay_unreachable` and the row, its saved_path, and its sender
+    state are all preserved for a manual retry."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+    _insert_sender_state(conn, attachment_id, upload_id="upload-1", revoke_token="revoke-1")
+
+    stub = _StubRelayClient(revoke_result=RelayHTTPError(500, "relay_down", "down"))
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, FakeTextAdapter(InMemoryEther(), "local-addr"), relay_client_factory=lambda _: stub)
+
+    outcome = svc._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code == "relay_unreachable"
+    assert sender.get_state(conn, attachment_id) == sender.DRAFT
+    assert conn.execute("SELECT 1 FROM mca_sender_state WHERE attachment_id = ?", (attachment_id,)).fetchone() is not None
+
+
+def test_command_cancel_remote_session_without_a_revoke_token_is_relay_unreachable(
+    conn, wsm, principal, registered_provider, remote_recipient, tmp_path, service
+):
+    """`upload_id` persisted but `revoke_token` missing -> the worker cannot
+    revoke the remote object, so it must fail `relay_unreachable` and
+    preserve everything, rather than complete a cancel it cannot finish
+    remotely."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+    _insert_sender_state(conn, attachment_id, upload_id="upload-1", revoke_token=None)
+
+    outcome = service._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code == "relay_unreachable"
+    assert sender.get_state(conn, attachment_id) == sender.DRAFT
+    assert conn.execute("SELECT 1 FROM mca_sender_state WHERE attachment_id = ?", (attachment_id,)).fetchone() is not None
+
+
+def test_command_cancel_spool_unlink_failure_is_spool_cleanup_failed(
+    conn, wsm, principal, registered_provider, remote_recipient, tmp_path, service
+):
+    """A spool path that cannot be unlinked (here: a directory at the spool
+    path, which `Path.unlink()` refuses) fails `spool_cleanup_failed` with
+    the row unchanged - the cancel does not silently proceed past a spool it
+    could not delete."""
+    _, _, recipient_principal = remote_recipient
+    _bind_recipient(conn, recipient_principal)
+    attachment_id = _create_draft(conn, wsm, principal, recipient_principal=recipient_principal, registered_provider=registered_provider, tmp_path=tmp_path)
+
+    spool_path = service._spool_path_for(attachment_id)
+    spool_path.parent.mkdir(parents=True, exist_ok=True)
+    spool_path.mkdir()  # a directory, not a file -> unlink() raises IsADirectoryError
+
+    outcome = service._dispatcher.dispatch(_cancel_command(attachment_id))
+
+    assert outcome.error_code == "spool_cleanup_failed"
+    assert sender.get_state(conn, attachment_id) == sender.DRAFT
+
+
+# ---- contact_request_key ---------------------------------------------------
+
+
+def test_command_request_key_sends_direct_and_persists_the_quota(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, relay_client
+):
+    """The full happy path: revalidate -> rate-limit check (never asked ->
+    allowed) -> build_key_request -> encode/send over the fixed DIRECT route
+    (route_id == destination_address == the contact) -> `sent == True` ->
+    persist the quota timestamp -> succeeded with `{"contact_id", "status":
+    "requested"}`. The message actually reaches the contact's inbox."""
+    ether = InMemoryEther()
+    adapter = FakeTextAdapter(ether, "local-addr")
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, adapter, relay_client_factory=lambda _: relay_client)
+    contact = "!756f9960"
+
+    outcome = svc._dispatcher.dispatch(_request_key_command(contact))
+
+    assert outcome.error_code is None
+    assert outcome.resource_id == contact
+    assert dict(outcome.result) == {"contact_id": contact, "status": "requested"}
+
+    events = ether.drain(contact)
+    assert len(events) == 1
+    assert events[0]["from"] == "local-addr"
+    assert events[0]["idempotency_key"]  # the command id, used as the send idempotency key
+
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT last_request_sent_at FROM mca_key_exchange_contact_state WHERE workspace_id = ? AND adapter_id = ? AND source_address = ?",
+        (principal.workspace_id, ADAPTER_ID, contact),
+    ).fetchone()
+    assert row is not None and row["last_request_sent_at"] is not None
+
+
+def test_command_request_key_revalidates_and_rejects_an_already_ready_contact(
+    conn, remote_recipient, service
+):
+    """The worker re-reads the live binding, so a contact that became
+    `MCA_READY` since the request thread's snapshot read fails with
+    `key_already_known` and sends nothing."""
+    _, _, recipient_principal = remote_recipient
+    contact = "!756f9960"
+    _bind_recipient(conn, recipient_principal, transport_address=contact)
+
+    outcome = service._dispatcher.dispatch(_request_key_command(contact))
+
+    assert outcome.error_code == "key_already_known"
+
+
+def test_command_request_key_is_rate_limited(service, key_exchange):
+    contact = "!756f9960"
+    key_exchange.record_key_request_sent(contact, time.time())
+
+    outcome = service._dispatcher.dispatch(_request_key_command(contact))
+
+    assert outcome.error_code == "rate_limited"
+
+
+def test_command_request_key_radio_unavailable_without_a_delivery_adapter(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor
+):
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, None)
+    outcome = svc._dispatcher.dispatch(_request_key_command("!756f9960"))
+    assert outcome.error_code == "radio_unavailable"
+
+
+def test_command_request_key_radio_unavailable_when_the_receipt_is_not_sent(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, relay_client
+):
+    """`send()` returning `sent=False` consumes no quota and fails
+    `radio_unavailable`."""
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, _SentFalseAdapter(InMemoryEther(), "local-addr"), relay_client_factory=lambda _: relay_client)
+    contact = "!756f9960"
+
+    outcome = svc._dispatcher.dispatch(_request_key_command(contact))
+
+    assert outcome.error_code == "radio_unavailable"
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT last_request_sent_at FROM mca_key_exchange_contact_state WHERE workspace_id = ? AND adapter_id = ? AND source_address = ?",
+        (principal.workspace_id, ADAPTER_ID, contact),
+    ).fetchone()
+    assert row is None or row["last_request_sent_at"] is None  # no quota consumed
+
+
+def test_command_request_key_radio_unavailable_when_send_raises(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, relay_client
+):
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, _RaisingSendAdapter(InMemoryEther(), "local-addr"), relay_client_factory=lambda _: relay_client)
+    outcome = svc._dispatcher.dispatch(_request_key_command("!756f9960"))
+    assert outcome.error_code == "radio_unavailable"
+
+
+def test_command_request_key_revalidates_contact_id_and_route(
+    conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, relay_client
+):
+    """The worker never trusts the queue's payload: a malformed contact id,
+    a non-`meshtastic` adapter, or a route that disagrees with the contact
+    all fail `invalid_contact_id` before any send."""
+    svc = _service_with_delivery(conn, wsm, principal, provider_registry, key_exchange, connectivity_monitor, FakeTextAdapter(InMemoryEther(), "local-addr"), relay_client_factory=lambda _: relay_client)
+
+    cases = [
+        _request_key_command("not-hex"),
+        _request_key_command("!756f9960", adapter_id="not-meshtastic"),
+        _request_key_command("!756f9960", route_id="!aaaaaaaa"),
+    ]
+    for command in cases:
+        outcome = svc._dispatcher.dispatch(command)
+        assert outcome.error_code == "invalid_contact_id"

--- a/tests/test_key_exchange.py
+++ b/tests/test_key_exchange.py
@@ -348,6 +348,67 @@ def test_reject_pending_key_change_without_a_pending_change_raises(tmp_path, clo
         coordinator.reject_pending_key_change("!nobody")
 
 
+# ---- outgoing KEY_REQUEST throttle (Step 1.6A.3C) -------------------------
+
+
+def test_key_request_rate_limit_blocks_a_second_request_within_ten_minutes(tmp_path, clock):
+    _, _, _, coordinator = _make_node(tmp_path, "a", clock)
+    coordinator.check_key_request_rate_limit("!contact", clock())  # never sent -> allowed
+    coordinator.record_key_request_sent("!contact", clock())
+    clock.advance(60)
+    with pytest.raises(RateLimited):
+        coordinator.check_key_request_rate_limit("!contact", clock())
+
+
+def test_key_request_rate_limit_allows_after_ten_minutes(tmp_path, clock):
+    _, _, _, coordinator = _make_node(tmp_path, "a", clock)
+    coordinator.check_key_request_rate_limit("!contact", clock())
+    coordinator.record_key_request_sent("!contact", clock())
+    clock.advance(10 * 60 + 1)
+    coordinator.check_key_request_rate_limit("!contact", clock())  # no raise
+
+
+def test_key_request_rate_limit_survives_a_new_coordinator_instance(tmp_path, clock):
+    """The outgoing key-request quota is persisted (`last_request_sent_at`,
+    migration 13), so a process restart - modelled as a fresh coordinator over
+    the same connection - still enforces the interval."""
+    conn, workspace_manager, principal, coordinator = _make_node(tmp_path, "a", clock)
+    coordinator.check_key_request_rate_limit("!contact", clock())
+    coordinator.record_key_request_sent("!contact", clock())
+
+    restarted = KeyExchangeCoordinator(conn, workspace_manager, principal, "fake-text", now_fn=clock)
+    clock.advance(60)
+    with pytest.raises(RateLimited):
+        restarted.check_key_request_rate_limit("!contact", clock())
+
+
+def test_recording_a_key_request_does_not_block_an_announce(tmp_path, clock):
+    """The two throttles are independent: recording an outgoing key request
+    must not consume the KEY_ANNOUNCE gate (a subsequent inbound KEY_REQUEST
+    is still answered)."""
+    from nacl.signing import SigningKey
+
+    _, _, _, coordinator = _make_node(tmp_path, "a", clock)
+    coordinator.check_key_request_rate_limit("!contact", clock())
+    coordinator.record_key_request_sent("!contact", clock())
+
+    request = codec.encode_key_request(codec.KeyRequestFields(sender_key_id=b"\x02" * 8), SigningKey.generate())
+    reply = coordinator.handle_incoming(_direct_envelope(request, "!contact", clock()))
+    assert reply is not None
+
+
+def test_an_announce_does_not_block_a_key_request(tmp_path, clock):
+    """The two throttles are independent: recording an automatic KEY_ANNOUNCE
+    must not consume the outgoing key-request gate."""
+    from nacl.signing import SigningKey
+
+    _, _, _, coordinator = _make_node(tmp_path, "a", clock)
+    request = codec.encode_key_request(codec.KeyRequestFields(sender_key_id=b"\x02" * 8), SigningKey.generate())
+    coordinator.handle_incoming(_direct_envelope(request, "!contact", clock()))  # records announce
+
+    coordinator.check_key_request_rate_limit("!contact", clock())  # no raise
+
+
 # ---- full two-node round trip over the fake transport contract ---------
 
 

--- a/tests/test_mca_api_attachments.py
+++ b/tests/test_mca_api_attachments.py
@@ -1131,6 +1131,7 @@ _LIFECYCLE_PATHS = [
     f"/api/attachments/{ATTACHMENT_ID}/retry",
     f"/api/attachments/{ATTACHMENT_ID}/download",
     f"/api/attachments/{ATTACHMENT_ID}/reject",
+    f"/api/attachments/{ATTACHMENT_ID}/cancel",
 ]
 
 
@@ -1169,6 +1170,7 @@ def test_post_lifecycle_rejects_a_malformed_id(monkeypatch):
         "/api/attachments/not-hex/retry",
         "/api/attachments/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ/download",
         "/api/attachments/abc/reject",
+        "/api/attachments/abc/cancel",
     ]:
         resp = c.post(path)
         assert resp.status_code == 400, path
@@ -1254,10 +1256,48 @@ def test_consent_action_rejected_unless_received_and_waiting_consent(monkeypatch
     assert facade.submitted == []
 
 
+@pytest.mark.parametrize("state", sorted(sender.AUTOMATIC_STATES))
+def test_cancel_accepted_in_sent_automatic_states(monkeypatch, state):
+    # §7.4 cancel: an outgoing attachment in any automatic (pre-SENT) state is
+    # cancellable - same sent-side AUTOMATIC_STATES as retry, but *without* a
+    # received branch (a received row is never cancellable).
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(direction="sent", state=state)]))
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/attachments/{ATTACHMENT_ID}/cancel")
+    assert resp.status_code == 202
+    _assert_202_accepted(resp.get_json(), facade, "attachment_cancel")
+
+
+@pytest.mark.parametrize("direction,state", [
+    ("sent", sender.SENT),              # awaiting download ACK, not automatic
+    ("sent", sender.RECEIVED),
+    ("sent", sender.DOWNLOADED),        # terminal
+    ("sent", sender.EXPIRED),
+    ("sent", sender.REVOKED),
+    ("sent", sender.CANCELLED),
+    ("sent", sender.FAILED_VALIDATION),
+    ("sent", sender.FAILED_UPLOAD),
+    ("sent", sender.FAILED_RADIO),
+    ("received", receiver.WAITING_CONSENT),
+    ("received", receiver.DOWNLOADING),  # a received *automatic* state is still not cancellable
+    ("received", receiver.AVAILABLE),
+    ("received", receiver.REJECTED),
+])
+def test_cancel_rejected_outside_sent_automatic_states(monkeypatch, direction, state):
+    facade = _FakeFacade(snapshot=_snapshot([_attachment(direction=direction, state=state)]))
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/attachments/{ATTACHMENT_ID}/cancel")
+    assert resp.status_code == 409
+    assert resp.get_json()["error_code"] == "invalid_state_transition"
+    assert resp.get_json()["state"] == state
+    assert facade.submitted == []
+
+
 @pytest.mark.parametrize("path,direction,state", [
     (f"/api/attachments/{ATTACHMENT_ID}/retry", "sent", sender.DOWNLOADED),   # terminal, not automatic
     (f"/api/attachments/{ATTACHMENT_ID}/download", "sent", sender.DRAFT),     # wrong direction
     (f"/api/attachments/{ATTACHMENT_ID}/reject", "received", receiver.DOWNLOADING),  # not WAITING_CONSENT
+    (f"/api/attachments/{ATTACHMENT_ID}/cancel", "received", receiver.WAITING_CONSENT),  # received, not cancellable
 ])
 def test_409_state_transition_envelope_is_exact(monkeypatch, path, direction, state):
     # The synchronous 409 must be exactly {ok, error, error_code, state} - the
@@ -1345,6 +1385,7 @@ _CSRF_LIFECYCLE_CASES = [
     (f"/api/attachments/{ATTACHMENT_ID}/retry", "sent", sender.DRAFT),
     (f"/api/attachments/{ATTACHMENT_ID}/download", "received", receiver.WAITING_CONSENT),
     (f"/api/attachments/{ATTACHMENT_ID}/reject", "received", receiver.WAITING_CONSENT),
+    (f"/api/attachments/{ATTACHMENT_ID}/cancel", "sent", sender.DRAFT),
 ]
 
 
@@ -1385,6 +1426,156 @@ def test_post_lifecycle_valid_csrf_token_reaches_submission(monkeypatch, path, d
     resp = c.post(path, headers={"X-CSRF-Token": "session-token"})
     assert resp.status_code == 202
     _assert_202_accepted(resp.get_json(), facade, kind)
+
+
+# ---- Step 1.6A.3C: contact key request (§7.10) ------------------------------
+
+CONTACT_ID = "!756f9960"
+
+
+def _recipient_at(address, status):
+    """A recipient snapshot with exactly one binding: `address` at `status`
+    (`None` status == an empty snapshot, i.e. KEY_UNKNOWN for every address)."""
+    if status is None:
+        return RecipientSnapshot(by_address={})
+    return RecipientSnapshot(
+        by_address={
+            address: RecipientBindingSnapshot(
+                adapter_id="meshtastic",
+                transport_address=address,
+                key_id="2" * 16,
+                status=status,
+            )
+        }
+    )
+
+
+def _assert_request_key_202(body, facade, contact_id):
+    assert body["ok"] is True
+    assert set(body) == {"ok", "command_id"}
+    cid = body["command_id"]
+    assert len(cid) == 32 and all(ch in "0123456789abcdef" for ch in cid)
+    assert len(facade.submitted) == 1
+    cmd = facade.submitted[0]
+    assert cmd.kind == "contact_request_key"
+    assert dict(cmd.payload) == {
+        "contact_id": contact_id,
+        "adapter_id": mca_runtime.ADAPTER_ID,
+        "route_id": contact_id,
+    }
+
+
+def test_request_key_is_503_when_facade_missing(monkeypatch):
+    c = _client(monkeypatch, None)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 503
+    assert resp.get_json()["error_code"] == "mca_not_ready"
+
+
+def test_request_key_is_503_when_not_ready(monkeypatch):
+    facade = _FakeFacade()
+    facade.not_ready = True
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 503
+    assert resp.get_json()["error_code"] == "mca_not_ready"
+    assert facade.submitted == []
+
+
+@pytest.mark.parametrize("contact_id", [
+    "not-hex",       # no leading bang
+    "!756f996",      # 7 hex chars
+    "!756f99600",    # 9 hex chars
+    "!756F9960",     # uppercase hex
+    "756f9960",      # missing bang
+    "!gggggggg",     # non-hex alphabet
+])
+def test_request_key_rejects_a_malformed_contact_id(monkeypatch, contact_id):
+    c = _client(monkeypatch, _FakeFacade())
+    resp = c.post(f"/api/mca/contacts/{contact_id}/request-key")
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_contact_id"
+    assert resp.get_json()["ok"] is False
+
+
+@pytest.mark.parametrize("body", [
+    {"route": {"adapter_id": "meshtastic", "route_id": "!aaaaaaaa"}},   # route_id != contact_id
+    {"route": {"adapter_id": "not-meshtastic", "route_id": CONTACT_ID}},  # wrong adapter
+    {"route": "not-a-dict"},
+    [1, 2, 3],                                                          # body not an object
+])
+def test_request_key_rejects_a_bad_route_or_body(monkeypatch, body):
+    c = _client(monkeypatch, _FakeFacade(recipient=_recipient_at(CONTACT_ID, None)))
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key", json=body)
+    assert resp.status_code == 400
+    assert resp.get_json()["error_code"] == "invalid_contact_id"
+
+
+def test_request_key_rejects_an_already_ready_contact(monkeypatch):
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, AddressStatus.MCA_READY))
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 409
+    assert resp.get_json()["error_code"] == "key_already_known"
+    assert facade.submitted == []
+
+
+@pytest.mark.parametrize("status", [
+    None,                             # KEY_UNKNOWN (absent binding)
+    AddressStatus.KEY_UNVERIFIED,
+    AddressStatus.KEY_CHANGED,
+])
+def test_request_key_accepted_for_a_non_ready_contact(monkeypatch, status):
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, status))
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 202
+    _assert_request_key_202(resp.get_json(), facade, CONTACT_ID)
+
+
+def test_request_key_accepts_an_empty_body_and_a_matching_route(monkeypatch):
+    # An empty body (DIRECT route default) and an explicit matching DIRECT
+    # route are both accepted, and produce the same command payload.
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, None))
+    c = _client(monkeypatch, facade)
+
+    empty = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert empty.status_code == 202
+
+    matching = c.post(
+        f"/api/mca/contacts/{CONTACT_ID}/request-key",
+        json={"route": {"adapter_id": "meshtastic", "route_id": CONTACT_ID}},
+    )
+    assert matching.status_code == 202
+    assert len(facade.submitted) == 2
+    assert facade.submitted[0].payload == facade.submitted[1].payload
+
+
+def test_request_key_queue_full_is_429(monkeypatch):
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, None), queue_full=True)
+    c = _client(monkeypatch, facade)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 429
+    assert resp.get_json()["error_code"] == "command_queue_full"
+    assert facade.submitted == []
+
+
+def test_request_key_missing_csrf_token_is_403(monkeypatch):
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, None))
+    c = _csrf_client(monkeypatch, facade)
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key")
+    assert resp.status_code == 403
+    assert resp.get_json()["error_code"] == "csrf_invalid"
+    assert facade.submitted == []
+
+
+def test_request_key_valid_csrf_token_reaches_submission(monkeypatch):
+    facade = _FakeFacade(recipient=_recipient_at(CONTACT_ID, None))
+    c = _csrf_client(monkeypatch, facade)
+    _set_csrf_token(c, "session-token")
+    resp = c.post(f"/api/mca/contacts/{CONTACT_ID}/request-key", headers={"X-CSRF-Token": "session-token"})
+    assert resp.status_code == 202
+    _assert_request_key_202(resp.get_json(), facade, CONTACT_ID)
 
 
 # ---- Step 1.6A.3B: idempotent multipart create (POST /api/attachments) -----

--- a/tests/test_mca_db_migrations.py
+++ b/tests/test_mca_db_migrations.py
@@ -826,3 +826,47 @@ def test_migration_12_downgrade_then_reupgrade(conn):
     _insert_attachment(conn, "att-after-reupgrade")
     conn.commit()
     assert _dirty_ids(conn) == {"att-after-reupgrade"}
+
+
+# --------------------------------------------------------------------------
+# Migration 13 (Step 1.6A.3C): nullable `last_request_sent_at` on
+# `mca_key_exchange_contact_state` - a per-contact outgoing key-request
+# throttle, deliberately independent of the existing `last_announce_sent_at`
+# (announcing your own key vs. requesting a contact's key are different
+# actions and never share a quota window).
+# --------------------------------------------------------------------------
+
+def _contact_state_columns(conn) -> set:
+    return {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(mca_key_exchange_contact_state)").fetchall()
+    }
+
+
+def test_migration_13_adds_last_request_sent_at(conn):
+    migrate(conn, target_version=12)
+    assert "last_request_sent_at" not in _contact_state_columns(conn)
+
+    migrate(conn, target_version=13)
+    assert current_version(conn) == 13
+    assert "last_request_sent_at" in _contact_state_columns(conn)
+
+
+def test_migration_13_downgrade_then_reupgrade(conn):
+    migrate(conn, target_version=13)
+    assert "last_request_sent_at" in _contact_state_columns(conn)
+
+    migrate(conn, target_version=12)
+    assert "last_request_sent_at" not in _contact_state_columns(conn)
+
+    migrate(conn, target_version=13)
+    assert "last_request_sent_at" in _contact_state_columns(conn)
+
+
+def test_migration_13_is_a_noop_for_an_already_migrated_db(conn):
+    """Idempotency for the column migration: upgrading straight to LATEST and
+    calling migrate() again must not raise or duplicate the column."""
+    migrate(conn)
+    migrate(conn)  # idempotent, no "duplicate column" error
+    assert current_version(conn) == LATEST_VERSION
+    assert "last_request_sent_at" in _contact_state_columns(conn)

--- a/tests/test_mca_runtime_wiring.py
+++ b/tests/test_mca_runtime_wiring.py
@@ -246,16 +246,19 @@ def test_command_submitted_through_the_facade_is_drained_to_a_terminal_result(tm
     state, _, _ = _started_state(tmp_path, "e")
     try:
         facade = state.facade
-        command = Command(command_id="cmd-1", kind="attachment_cancel", payload={}, created_at=0.0)
+        # `attachment_save` is still enumerated-but-unwired (its own future
+        # sub-stage will add the handler), so it exercises the "kind has no
+        # handler" path regardless of how many handlers later steps wire.
+        command = Command(command_id="cmd-1", kind="attachment_save", payload={}, created_at=0.0)
         facade.submit(command)
         # Before any tick: registered queued (an immediate poll sees queued).
         assert facade.get_command("cmd-1").status == STATUS_QUEUED
 
         state.service.tick()
 
-        # The empty dispatcher means the enumerated kind has no handler, so
-        # the worker drains it to a terminal unsupported_command_kind FAILED
-        # - never a crash, never left stuck in running.
+        # An enumerated kind with no registered handler drains to a terminal
+        # unsupported_command_kind FAILED - never a crash, never left stuck in
+        # running.
         result = facade.get_command("cmd-1")
         assert result.status == STATUS_FAILED
         assert result.error_code == "unsupported_command_kind"
@@ -751,7 +754,7 @@ def test_real_service_wires_the_lifecycle_and_create_handlers(tmp_path):
         # kind->handler table shared by the state and the worker.
         assert dispatcher.supported_kinds() == frozenset({
             "attachment_create", "attachment_retry", "attachment_download",
-            "attachment_reject",
+            "attachment_reject", "attachment_cancel", "contact_request_key",
         })
         # Every other enumerated kind remains unwired -> unsupported.
         for kind in COMMAND_KINDS - dispatcher.supported_kinds():


### PR DESCRIPTION
## Step 1.6A.3C — two mutation endpoints

Closes Step 1.6A.3 in the MCAttach (attachment transfer) backend work.

### Part A — `POST /api/attachments/{id}/cancel` (§7.4)
Explicit user cancel of an outgoing attachment still in an automatic (pre-SENT) state. The worker resolves the **remote half first** (Relay `revoke()`, a 404 = confirmed absence) then the **local half** (delete the staged spool, `sender.cancel()`), leaving the row `CANCELLED` with no sender-state row, no spool file, and history preserved. Request threads stay pure validation/snapshot/queue; the worker remains the sole executor of Relay/filesystem side effects.

### Part B — `POST /api/mca/contacts/{id}/request-key` (§7.10)
Ask a contact to announce its MCA key over the fixed DIRECT route. Contact id is `!` + 8 lowercase hex; an empty body is accepted, or an optional route that must name `meshtastic` and the contact. Already-`MCA_READY` contacts → 409 `key_already_known`. **Migration 13** adds the nullable `last_request_sent_at` column; the outgoing key-request rate limit (one accepted request per address per 600s) is persisted **only after** the delivery receipt reports `sent == true`, so a failed send never consumes quota.

### Scope / invariants honored
- Request threads: validation + immutable snapshot reads + non-blocking command enqueue only. No MCA SQLite, Relay HTTP, radio, worker locks, or key material on request threads.
- Every mutation reaches a terminal `CommandRegistry` result via a typed `Command`.
- All error responses/logs sanitized (no tokens, keys, paths, filenames, recipient addresses, Relay bodies, or exception text).
- Existing CSRF protection applies to both endpoints; no MCA/1 wire-format change.

### Commits
1. `feat(attachments): add safe outgoing cancel command`
2. `feat(attachments): add rate-limited contact key request`
3. `test(attachments): cover cancel and request-key boundaries`
4. `docs(attachments): complete Step 1.6A.3 contract status`

### Verification
`pytest` 1806 passed / 38 skipped; `compileall`, `check-i18n.py`, `check_startup_calls.py`, `git diff --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)