### PR TITLE
🛡️ Sentinel: Fix directory path traversal in delete_screenshot

### DIFF
--- a/camera/camera.py
+++ b/camera/camera.py
@@ -839,7 +839,11 @@ def list_screenshots():
 def delete_screenshot(filename):
     filepath = safe_screenshot_path(filename)
 
-    if filepath is None or not os.path.exists(filepath):
+    # Security check: Ensure filepath is a valid file within SCREENSHOTS_DIR.
+    # Prevent path traversal or directory resolution (e.g., "", ".", "..")
+    # from resolving to SCREENSHOTS_DIR or a subdirectory and attempting directory deletion via os.remove.
+    screenshots_root = os.path.abspath(SCREENSHOTS_DIR)
+    if filepath is None or filepath == screenshots_root or os.path.isdir(filepath) or not os.path.exists(filepath):
         return {"ok": False, "error": "File not found"}, 404
 
     os.remove(filepath)

--- a/tests/test_api_camera.py
+++ b/tests/test_api_camera.py
@@ -119,3 +119,23 @@ def test_api_camera_screenshot_file_serves_the_already_validated_path(api_env, m
     send_file_spy.assert_called_once()
     served_path = send_file_spy.call_args[0][0]
     assert served_path == camera_module.safe_screenshot_path("plain.jpg")
+
+
+def test_camera_delete_screenshot_directory_traversal_returns_404(api_env):
+    """Verifies that delete_screenshot() rejects directory resolution attempts
+    (such as "", ".", "..", or subdirectory paths) with 404 without attempting
+    to call os.remove on directories."""
+    # Test with empty string, dot, dot-dot
+    for invalid_name in ("", ".", "..", "2025", "2025/01"):
+        res, code = camera_module.delete_screenshot(invalid_name)
+        assert code == 404
+        assert res == {"ok": False, "error": "File not found"}
+
+
+def test_api_camera_screenshot_delete_traversal_route(api_env):
+    """Verifies DELETE /api/camera/screenshot/<path:filename> with traversal
+    payloads returns 404 and does not delete directories."""
+    for payload in ("..", ".", "2025"):
+        response = api_env["client"].delete(f"/api/camera/screenshot/{payload}")
+        assert response.status_code == 404
+        assert response.get_json() == {"ok": False, "error": "File not found"}


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Prevent directory deletion in delete_screenshot

- **Vulnerability:** Path traversal / Directory resolution in `delete_screenshot`.
- **Impact:** Passing directory paths like `""`, `"."`, `".."`, or subdirectories could resolve to directory paths, causing `os.remove` to raise `IsADirectoryError` / `PermissionError` (500 response) or potentially attempt unsafe operations on directories.
- **Fix:** In `camera/camera.py`, `delete_screenshot()` now verifies that the resolved path is not `SCREENSHOTS_DIR` itself, is not a directory (`os.path.isdir`), and is a valid existing file.
- **Verification:** Added automated unit tests in `tests/test_api_camera.py` testing `delete_screenshot` and `DELETE /api/camera/screenshot/<path:filename>` with traversal/directory inputs, confirming 404 response. Ran full test suite (1845 tests passing).

---
*PR created automatically by Jules for task [1902088318255795563](https://jules.google.com/task/1902088318255795563) started by @FlintUA*