### PR TITLE
🛡️ Sentinel: Sanitize error messages in top-processes endpoint

### DIFF
--- a/api/api_system.py
+++ b/api/api_system.py
@@ -230,7 +230,8 @@ def register_system_routes(app, get_cpu_temperature=None, get_app_version=None):
 
             return jsonify({"ok": True, "processes": results[:5]})
         except Exception as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 500
+            log_system_event("Top processes failed", "ERROR", str(exc), source="system")
+            return jsonify({"ok": False, "error": "Failed to retrieve top processes"}), 500
 
     def get_saved_wifi_names():
         result = network_config.list_wifi_connections()

--- a/tests/test_api_system.py
+++ b/tests/test_api_system.py
@@ -181,3 +181,32 @@ def test_system_info_model_field_is_none_when_unavailable(client, monkeypatch):
     response = client.get("/api/system/info")
 
     assert response.get_json()["model"] is None
+
+
+def test_top_processes_exception_sanitizes_error_and_logs(client, monkeypatch):
+    logged = []
+    monkeypatch.setattr(
+        api_system_module, "log_system_event",
+        lambda title, level="INFO", details="", source="system": logged.append(
+            {"title": title, "level": level, "details": details, "source": source}
+        ),
+    )
+
+    import psutil
+    def _raise(*args, **kwargs):
+        raise RuntimeError("Internal psutil failure: secret_path=/etc/shadow")
+
+    monkeypatch.setattr(psutil, "process_iter", _raise)
+
+    response = client.get("/api/system/top-processes")
+
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["ok"] is False
+    assert data["error"] == "Failed to retrieve top processes"
+    assert "secret_path" not in data["error"]
+
+    assert len(logged) == 1
+    assert logged[0]["source"] == "system"
+    assert logged[0]["level"] == "ERROR"
+    assert "Internal psutil failure: secret_path=/etc/shadow" in logged[0]["details"]


### PR DESCRIPTION
### 🚨 Severity
MEDIUM

### 💡 Vulnerability
Information Disclosure: `GET /api/system/top-processes` returned `str(exc)` in its JSON error response when an exception occurred while fetching system process metrics, leaking internal system implementation details or error state to the caller.

### 🎯 Impact
An attacker or unauthenticated user inspecting API responses could gain insight into system internals, file paths, or process states when an error is triggered.

### 🔧 Fix
Updated `api_system_top_processes()` in `api/api_system.py` to record the exception internally via `log_system_event` and return a generic sanitized error message (`"Failed to retrieve top processes"`) with HTTP 500 status.

### ✅ Verification
Added unit test `test_top_processes_exception_sanitizes_error_and_logs` in `tests/test_api_system.py` to ensure exception details are sanitized from the response and properly logged to system events. Verified all unit tests pass with `python3 -m pytest tests/test_api_system.py`.

---
*PR created automatically by Jules for task [15563906392636748602](https://jules.google.com/task/15563906392636748602) started by @FlintUA*