### PR TITLE
Fix MCAttach Files final acceptance gaps (F1-F5) and Custom-TTL summary

### DIFF
--- a/static/files.js
+++ b/static/files.js
@@ -150,6 +150,14 @@
         ttl_above_maximum: 'Expiry is above the provider maximum',
     };
 
+    // UploadReadiness (config-only 3-value enum) — distinct from the richer
+    // UploadRejectionReason map above, which shares `upload_token_missing`.
+    var FILES_UPLOAD_READINESS_LABELS = {
+        ready: 'Ready',
+        upload_token_missing: 'No upload token configured',
+        upload_disabled: 'Uploads disabled',
+    };
+
     // ---- single internal state object --------------------------------------
 
     var state = {
@@ -181,6 +189,9 @@
         sendSignature: null,      // semantic send-form signature (C7 idempotency)
         sendClientRequestId: null,
         sendInFlight: false,
+        sendReadinessToken: 0,    // monotonic token — stale readiness responses dropped (F2)
+        sendReadiness: null,      // authoritative readiness result for the open send dialog
+        sendTtlDebounce: null,    // debounce timer for rapid Custom-TTL typing (F2)
 
         dialog: null,             // currently-open dialog element
         dialogReturnFocus: null,  // element to restore focus to on close (C11)
@@ -223,6 +234,7 @@
     function filesContactStatusLabel(s) { return t('files.contact.' + s, FILES_CONTACT_STATUS_LABELS[s] || s); }
     function filesRelayStateLabel(s) { return t('files.relay_state.' + s, FILES_RELAY_STATE_LABELS[s] || s); }
     function filesReadinessLabel(s) { return t('files.ready_reason.' + s, FILES_READINESS_LABELS[s] || s || 'Unknown'); }
+    function filesUploadReadinessLabel(s) { return t('files.upload_readiness.' + s, FILES_UPLOAD_READINESS_LABELS[s] || s || 'Unknown'); }
 
     function filesErrorCode(data) {
         var code = (data && data.error_code) ? data.error_code : 'internal_error';
@@ -428,7 +440,7 @@
     }
 
     function refreshContacts() {
-        guardedLoad('contacts', function () {
+        return guardedLoad('contacts', function () {
             return Promise.all([
                 api('/api/nodes_management'),
                 api('/api/mca/contacts'),
@@ -464,7 +476,7 @@
     }
 
     function loadConnectivity() {
-        guardedLoad('connectivity', function () {
+        return guardedLoad('connectivity', function () {
             return api('/api/mca/connectivity');
         }, function (r) {
             if (r.status === 200 && r.data && r.data.ok) {
@@ -473,16 +485,21 @@
                     relays: r.data.relays || {},
                 };
             }
+            // F2: fresh connectivity landing for the open Send dialog refreshes
+            // the status line and re-requests authoritative readiness.
+            renderSendStatus();
+            refreshSendReadiness();
         });
     }
 
     function loadSettings() {
-        guardedLoad('settings', function () {
+        return guardedLoad('settings', function () {
             return api('/api/settings');
         }, function (r) {
             if (r.status === 200 && r.data && r.data.ok && r.data.settings) {
                 state.settings = r.data.settings;
             }
+            renderSendStatus();
         });
     }
 
@@ -491,7 +508,7 @@
         var url = '/api/attachments?direction=' + encodeURIComponent(mapping.direction) +
             '&filter=' + encodeURIComponent(mapping.filter) +
             '&limit=' + LIST_LIMIT;
-        guardedLoad('transfers', function () {
+        return guardedLoad('transfers', function () {
             return api(url);
         }, function (r) {
             if (r.status !== 200 || !r.data || r.data.ok !== true) {
@@ -970,8 +987,8 @@
                     resourceKey: resourceKey,
                     queued: opts.queued,
                     success: opts.success,
-                    onSuccess: function () { loadTransfers(); },
-                    onUnknown: function () { loadTransfers(); },
+                    onSuccess: function () { return loadTransfers(); },
+                    onUnknown: function () { return loadTransfers(); },
                 });
             } else if (r.status === 409) {
                 toast(t('files.state_changed', 'This transfer changed — refreshing'), 'info');
@@ -1048,8 +1065,8 @@
                         resourceKey: resourceKey,
                         queued: t('files.deleting_local', 'Deleting local copy…'),
                         success: t('files.local_deleted', 'Local copy deleted'),
-                        onSuccess: function () { loadTransfers(); },
-                        onUnknown: function () { loadTransfers(); },
+                        onSuccess: function () { return loadTransfers(); },
+                        onUnknown: function () { return loadTransfers(); },
                     });
                 } else {
                     toast(filesErrorCode(r.data), 'error');
@@ -1092,8 +1109,8 @@
                     resourceKey: resourceKey,
                     queued: opts.queued,
                     success: opts.success,
-                    onSuccess: function () { refreshContacts(); },
-                    onUnknown: function () { refreshContacts(); },
+                    onSuccess: function () { return refreshContacts(); },
+                    onUnknown: function () { return refreshContacts(); },
                 });
             } else if (r.status === 429) {
                 var retry = (r.data && r.data.retry_after_seconds) || 600;
@@ -1339,10 +1356,17 @@
         for (var i = 0; i < children.length; i++) {
             var c = children[i];
             if (c === dialogRoot) continue;
+            // F4: store the prior native inert state (a real Element.inert boolean
+            // in the browser, an observable expando on the test double) alongside
+            // the prior aria-hidden, so BOTH are restored on every close path.
+            if (typeof c._filesPrevInert === 'undefined') {
+                c._filesPrevInert = (c.inert === true);
+            }
             if (typeof c._filesPrevAriaHidden === 'undefined') {
                 c._filesPrevAriaHidden = c.getAttribute ? c.getAttribute('aria-hidden') : null;
             }
             if (c.setAttribute) c.setAttribute('aria-hidden', 'true');
+            c.inert = true; // native property in the browser; expando in the harness
         }
     }
 
@@ -1358,6 +1382,10 @@
                     c.setAttribute('aria-hidden', c._filesPrevAriaHidden);
                 }
                 delete c._filesPrevAriaHidden;
+            }
+            if (typeof c._filesPrevInert !== 'undefined') {
+                c.inert = c._filesPrevInert === true;
+                delete c._filesPrevInert;
             }
         }
     }
@@ -1479,9 +1507,12 @@
             return;
         }
         // The custom-TTL number input fires 'input' as digits are typed, so the
-        // expiry summary updates live rather than only on blur.
+        // expiry summary updates live rather than only on blur; the authoritative
+        // readiness refresh is debounced (F2).
         if (target.id === 'filesSendCustomTtlSeconds') {
             renderSendExpiry();
+            renderSendSubmit();
+            scheduleSendReadinessRefresh();
             return;
         }
     }
@@ -1491,9 +1522,10 @@
     function onDocumentChange(e) {
         var target = e.target;
         if (!target || !target.id) return;
-        if (target.id === 'filesSendExpiry') { renderSendCustomTtl(); return; }
+        if (target.id === 'filesSendExpiry') { renderSendCustomTtl(); refreshSendReadiness(); return; }
         if (target.id === 'filesSendFile') { renderSendFileFeedback(); return; }
-        if (target.id === 'filesSendProvider') { renderSendProviderReadiness(); return; }
+        if (target.id === 'filesSendProvider') { renderSendProviderReadiness(); refreshSendReadiness(); return; }
+        if (target.id === 'filesSendRecipient') { renderSendSubmit(); return; }
     }
 
     // ---- filter (C5) -------------------------------------------------------
@@ -1569,9 +1601,6 @@
     function openSendDialog() {
         if (typeof document === 'undefined') return;
         closeModal();
-        loadConnectivity();
-        loadSettings();
-        loadProvidersForSend();
         var id = 'files-send';
         var html =
             '<div class="files-modal-backdrop" data-files-action="modal-backdrop-close" role="presentation">' +
@@ -1590,6 +1619,7 @@
                             '<span class="files-field-label">' + esc(t('files.send_provider', 'Relay provider')) + '</span>' +
                             '<select id="filesSendProvider"></select>' +
                             '<div class="files-send-readiness" id="filesSendReadiness" aria-live="polite"></div>' +
+                            '<div class="files-send-readiness-check" id="filesSendReadinessCheck" aria-live="polite"></div>' +
                         '</label>' +
                         '<label class="files-field">' +
                             '<span class="files-field-label">' + esc(t('files.send_file_label', 'File')) + '</span>' +
@@ -1620,10 +1650,17 @@
             '</div>';
         var el = openModalHtml(html, function () { state.sendInFlight = false; });
         el.className = 'files-dialog-root is-send';
+        // F2: render the dialog first, then start the fresh loads — each settles
+        // and updates the open dialog independently (order-independent).
         renderSendRecipients();
         renderSendProviders();
         renderSendStatus();
         renderSendCustomTtl();
+        renderSendSubmit();
+        refreshSendReadiness();
+        loadConnectivity();
+        loadSettings();
+        loadProvidersForSend();
     }
 
     function loadProvidersForSend() {
@@ -1635,6 +1672,9 @@
                 ? r.data.providers : [];
             renderSendProviders();
             renderSendStatus();
+            // F2: a fresh provider projection triggers the authoritative readiness
+            // request for the (now known) selected provider/TTL.
+            refreshSendReadiness();
         });
     }
 
@@ -1784,20 +1824,27 @@
         if (!el) return;
         var input = getEl('filesSendFile');
         var f = input && input.files && input.files.length ? input.files[0] : null;
-        if (!f) { el.innerHTML = ''; return; }
+        if (!f) { el.innerHTML = ''; renderSendSubmit(); return; }
+        // F1: an allowlisted extension or MIME is allowed; anything else is
+        // rejected locally (immediate, localized feedback). A stale rejection
+        // clears the moment an allowed file is selected — the server's magic-byte
+        // sniffing stays the real authority.
+        if (!fileTypeAllowed(f)) {
+            el.innerHTML = '<span class="files-status-error">' +
+                esc(t('files.err_mime', 'File type is not allowed')) + '</span>';
+            renderSendSubmit();
+            return;
+        }
         var name = (f.name || '').toLowerCase();
         var ext = name.indexOf('.') !== -1 ? name.split('.').pop() : '';
-        // R7: advisory MIME feedback from the server-authoritative allowlist
-        // (JPEG/PNG/WebP/PDF/TXT/LOG/CSV/JSON). The client only *describes* the
-        // file here; the server sniffs magic bytes and is the real authority,
-        // so an unrecognized type is a warning, never a hard block.
         var known = EXTENSION_MIME[ext] || (ALLOWED_MIME[f.type] ? f.type : '');
         var typeLine = known
             ? tparams('files.send_file_type', { type: known }, 'Type: ' + known)
-            : t('files.send_file_type_unknown', 'Type: unrecognized — the server will validate it');
+            : t('files.send_file_type_unknown', 'Type: unrecognized');
         el.innerHTML =
             '<span>' + esc(typeLine) + '</span>' +
             ' · <span>' + esc(tparams('files.send_file_size', { size: fmtBytes(f.size) }, 'Size: ' + fmtBytes(f.size))) + '</span>';
+        renderSendSubmit();
     }
 
     function renderSendCustomTtl() {
@@ -1811,7 +1858,21 @@
     function renderSendExpiry() {
         var summary = getEl('filesSendExpirySummary');
         if (!summary) return;
-        var ttl = sendTtlSeconds();
+        var ttl = sendTtlSecondsStrict();
+        // Section 7: a blank/invalid Custom TTL shows a localized prompt, not a
+        // fictitious 86400-second expiry. Expiry/grace are computed only once a
+        // valid value is present, and the value is checked against the selected
+        // provider's min/max locally before the summary is shown.
+        if (ttl === null) {
+            summary.innerHTML = '<span class="files-status-warn">' +
+                esc(t('files.err_ttl_custom', 'Enter a positive whole number of seconds for the custom expiry')) + '</span>';
+            return;
+        }
+        var minMax = sendTtlMinMaxError(ttl);
+        if (minMax) {
+            summary.innerHTML = '<span class="files-status-warn">' + esc(minMax) + '</span>';
+            return;
+        }
         var grace = sendGraceSeconds(ttl);
         var expiry = Math.floor(Date.now() / 1000) + ttl;
         summary.innerHTML =
@@ -1820,6 +1881,15 @@
     }
 
     function sendTtlSeconds() {
+        // Submit-path helper: returns the resolved TTL. submitSend validates a
+        // Custom value before this is ever consulted, so the 86400 fallback is
+        // unreachable in the custom branch during a real submit.
+        var ttl = sendTtlSecondsStrict();
+        if (ttl !== null) return ttl;
+        return 86400;
+    }
+
+    function sendTtlSecondsStrict() {
         var sel = getEl('filesSendExpiry');
         var mode = sel ? sel.value : 'default';
         if (mode === 'extended') return 604800;
@@ -1828,9 +1898,22 @@
             var raw = input ? String(input.value || '').trim() : '';
             var n = parseInt(raw, 10);
             if (raw !== '' && Number.isFinite(n) && String(n) === raw && n > 0) return n;
-            return 86400; // fallback; submitSend validates the custom value itself
+            return null; // blank/zero/non-integer/negative — no fictitious TTL
         }
         return 259200; // default 3 days
+    }
+
+    function sendTtlMinMaxError(ttl) {
+        var sel = getEl('filesSendProvider');
+        var p = sel && sel.value ? providerById(sel.value) : null;
+        if (!p) return null;
+        if (p.min_ttl_seconds != null && ttl < p.min_ttl_seconds) {
+            return filesReadinessLabel('ttl_below_minimum');
+        }
+        if (p.max_ttl_seconds != null && ttl > p.max_ttl_seconds) {
+            return filesReadinessLabel('ttl_above_maximum');
+        }
+        return null;
     }
 
     function sendGraceSeconds(ttl) {
@@ -1844,11 +1927,13 @@
         var expiry = getEl('filesSendExpiry');
         var comment = getEl('filesSendComment');
         var f = file && file.files && file.files.length ? file.files[0] : null;
+        var ttl = sendTtlSecondsStrict(); // null only for an invalid Custom value
         return [
             recipient ? recipient.value : '',
             provider ? provider.value : '',
             expiry ? expiry.value : 'default',
-            String(sendTtlSeconds()), // custom TTL is part of the semantic form
+            ttl === null ? '' : String(ttl), // exact TTL in the semantic form
+            ttl === null ? '' : String(sendGraceSeconds(ttl)), // exact grace too (Section 7)
             comment ? (comment.value || '').trim() : '',
             f ? f.name : '',
             f ? String(f.size) : '',
@@ -1865,6 +1950,102 @@
         state.sendInFlight = false;
         var submit = getEl('filesSendSubmit');
         if (submit) submit.disabled = false;
+    }
+
+    function isSendDialogOpen() {
+        return Boolean(state.dialog && state.dialog.className &&
+            String(state.dialog.className).indexOf('is-send') !== -1);
+    }
+
+    // F2: authoritative readiness for the exact requested TTL, rendered into a
+    // dedicated element (filesSendReadinessCheck) separate from the config-only
+    // Relay-state/upload line (filesSendReadiness). A monotonic token drops any
+    // response that no longer matches the latest request, so a slower older
+    // response or one landing after the dialog closed/advanced cannot overwrite
+    // the current value.
+    function renderSendReadinessCheck() {
+        var el = getEl('filesSendReadinessCheck');
+        if (!el) return;
+        var s = state.sendReadiness;
+        if (!s) { el.innerHTML = ''; return; }
+        if (s.pending) {
+            el.innerHTML = '<span>' + esc(t('files.readiness_checking', 'Checking upload…')) + '</span>';
+            return;
+        }
+        if (s.reason === 'ttl_invalid') {
+            el.innerHTML = '<span class="files-status-warn">' +
+                esc(t('files.err_ttl_custom', 'Enter a positive whole number of seconds for the custom expiry')) + '</span>';
+            return;
+        }
+        var label = s.ready
+            ? t('files.upload_ready', 'Upload: ready')
+            : t('files.upload_not_ready', 'Upload: not ready') + ' — ' + filesReadinessLabel(s.reason);
+        el.innerHTML = '<span class="' + (s.ready ? 'files-status-ok' : 'files-status-warn') + '">' + esc(label) + '</span>';
+    }
+
+    // F2: gate the Send button on every prerequisite the server will re-check at
+    // submit. This is proactive feedback only — never authoritative — and is
+    // intentionally kept out of unlockSend(), which the tests rely on to set
+    // disabled=false directly after a terminal command.
+    function renderSendSubmit() {
+        var submit = getEl('filesSendSubmit');
+        if (!submit) return;
+        if (state.sendInFlight) { submit.disabled = true; return; }
+        var recipient = getEl('filesSendRecipient');
+        var provider = getEl('filesSendProvider');
+        var fileInput = getEl('filesSendFile');
+        var hasRecipient = Boolean(recipient && recipient.value);
+        var hasProvider = Boolean(provider && provider.value);
+        var file = fileInput && fileInput.files && fileInput.files.length ? fileInput.files[0] : null;
+        var fileOk = Boolean(file && fileTypeAllowed(file) &&
+            (typeof file.size !== 'number' || file.size <= MAX_SEND_BYTES));
+        var ttlValid = sendTtlSecondsStrict() !== null;
+        var readinessOk = Boolean(state.sendReadiness && state.sendReadiness.ready);
+        submit.disabled = !(hasRecipient && hasProvider && fileOk && ttlValid && readinessOk);
+    }
+
+    function refreshSendReadiness() {
+        if (!isSendDialogOpen()) { state.sendReadiness = null; return; }
+        var sel = getEl('filesSendProvider');
+        var providerId = sel ? sel.value : '';
+        var ttl = sendTtlSecondsStrict();
+        var token = ++state.sendReadinessToken;
+
+        if (!providerId) {
+            state.sendReadiness = null;
+            renderSendReadinessCheck();
+            renderSendSubmit();
+            return;
+        }
+        if (ttl === null) {
+            state.sendReadiness = { providerId: providerId, ttl: null, ready: false, reason: 'ttl_invalid', pending: false };
+            renderSendReadinessCheck();
+            renderSendSubmit();
+            return;
+        }
+
+        state.sendReadiness = { providerId: providerId, ttl: ttl, ready: false, reason: 'checking', pending: true };
+        renderSendReadinessCheck();
+        renderSendSubmit();
+
+        api('/api/mca/providers/' + encodeURIComponent(providerId) +
+            '/upload-readiness?requested_ttl_seconds=' + ttl).then(function (r) {
+            if (token !== state.sendReadinessToken) return; // stale response — drop
+            if (!isSendDialogOpen()) return;                  // dialog closed/advanced — drop
+            var ready = Boolean(r.status === 200 && r.data && r.data.ok === true && r.data.ready);
+            var reason = ready ? null : (r.data && r.data.reason ? r.data.reason : 'relay_unreachable');
+            state.sendReadiness = { providerId: providerId, ttl: ttl, ready: ready, reason: reason, pending: false };
+            renderSendReadinessCheck();
+            renderSendSubmit();
+        });
+    }
+
+    function scheduleSendReadinessRefresh() {
+        if (state.sendTtlDebounce) clearTimeout(state.sendTtlDebounce);
+        state.sendTtlDebounce = setTimeout(function () {
+            state.sendTtlDebounce = null;
+            refreshSendReadiness();
+        }, 300);
     }
 
     function submitSend() {
@@ -1955,9 +2136,13 @@
                             unlockSend();
                             state.sendSignature = null;
                             state.sendClientRequestId = null;
-                            closeModal(false);
-                            loadTransfers();
-                            if (attachmentId) selectAttachment(attachmentId);
+                            // F5: close only after the authoritative refresh
+                            // settles, and return its Promise so the tracker
+                            // does not announce success early.
+                            return loadTransfers().then(function () {
+                                closeModal(false);
+                                if (attachmentId) selectAttachment(attachmentId);
+                            });
                         },
                         onFailed: function () {
                             // Keep the form (and its client_request_id) so the
@@ -1971,7 +2156,7 @@
                         },
                         onUnknown: function () {
                             unlockSend();
-                            loadTransfers();
+                            return loadTransfers();
                         },
                     });
                     // Do not claim success yet: the tracker owns the final outcome.
@@ -1987,14 +2172,14 @@
     }
 
     function fileTypeAllowed(file) {
+        if (!file) return false;
         var name = (file.name || '').toLowerCase();
         var ext = name.indexOf('.') !== -1 ? name.split('.').pop() : '';
-        if (EXTENSION_MIME[ext] || ALLOWED_MIME[file.type]) {
-            // extension or declared MIME is in the allowlist — good enough for feedback
-            return true;
-        }
-        // Unknown extension and unknown MIME: let the server decide (authoritative).
-        return true;
+        // F1: a recognized allowlisted extension OR a browser-supplied allowlisted
+        // MIME (even extensionless) is allowed. When both are absent/unrecognized
+        // the file is rejected locally — the server's magic-byte sniffing remains
+        // authoritative, so this is a client-side gate, never a guarantee.
+        return Boolean(EXTENSION_MIME[ext] || ALLOWED_MIME[file.type]);
     }
 
     // ---- provider settings (C8) --------------------------------------------
@@ -2300,6 +2485,13 @@
                         providerField('files.provider_protocol', 'Protocol version', p.protocol_version || '—') +
                         providerField('files.provider_token', 'Token', p.upload_token_configured ? '✓' : '—') +
                     '</div>' +
+                    '<div class="files-provider-fields files-provider-status">' +
+                        providerField('files.provider_upload_readiness', 'Upload readiness', providerUploadReadiness(p)) +
+                        providerField('files.provider_last_checked', 'Last checked', providerLastChecked(p)) +
+                        providerField('files.provider_last_check_result', 'Last check result', providerLastCheckResult(p)) +
+                        providerField('files.provider_last_latency', 'Latency', providerLastLatency(p)) +
+                        providerField('files.provider_last_error', 'Last error', providerLastError(p)) +
+                    '</div>' +
                     '<div class="files-provider-actions">' +
                         '<button type="button" class="files-action-btn" data-files-action="provider-edit" data-provider="' + esc(p.provider_id) + '"' + enabled + '>' +
                             esc(t('files.edit', 'Edit')) + '</button>' +
@@ -2330,6 +2522,26 @@
     function providerField(labelKey, fallback, value) {
         return '<div class="files-provider-field"><span class="files-provider-field-label">' +
             esc(t(labelKey, fallback)) + '</span><span class="files-provider-field-value">' + esc(value) + '</span></div>';
+    }
+
+    // F3: the shared provider card's live status fields. Values are localized
+    // (local-timezone timestamp, numeric-only latency, safe code/fallback) and
+    // never expose secrets or raw exception text.
+    function providerLastChecked(p) {
+        return p.last_checked_at ? fmtDate(p.last_checked_at) : t('files.provider_never_checked', 'Never checked');
+    }
+    function providerLastCheckResult(p) {
+        return p.last_check_result ? filesRelayStateLabel(p.last_check_result) : '—';
+    }
+    function providerLastLatency(p) {
+        return (typeof p.last_latency_ms === 'number' && Number.isFinite(p.last_latency_ms))
+            ? p.last_latency_ms + ' ms' : '—';
+    }
+    function providerLastError(p) {
+        return p.last_error_code ? p.last_error_code : '—';
+    }
+    function providerUploadReadiness(p) {
+        return filesUploadReadinessLabel(p.upload_readiness);
     }
 
     function providerProbe() {
@@ -2423,9 +2635,9 @@
                         if (resultEl) resultEl.innerHTML = '';
                         var originEl = getEl('filesProviderOrigin');
                         if (originEl) originEl.value = '';
-                        loadProviders();
+                        return loadProviders();
                     },
-                    onUnknown: function () { loadProviders(); },
+                    onUnknown: function () { return loadProviders(); },
                 });
             }).catch(function () {
                 toast(t('files.error.network_error', 'Network error'), 'error');

--- a/static/i18n/de.json
+++ b/static/i18n/de.json
@@ -277,6 +277,18 @@
       "ttl_below_minimum": "Ablauf liegt unter dem Anbieter-Minimum",
       "ttl_above_maximum": "Ablauf liegt über dem Anbieter-Maximum"
     },
+    "upload_readiness": {
+      "ready": "Bereit",
+      "upload_token_missing": "Kein Upload-Token konfiguriert",
+      "upload_disabled": "Uploads deaktiviert"
+    },
+    "readiness_checking": "Prüfe Upload…",
+    "provider_upload_readiness": "Upload-Bereitschaft",
+    "provider_last_checked": "Zuletzt geprüft",
+    "provider_last_check_result": "Letztes Prüfergebnis",
+    "provider_last_latency": "Latenz",
+    "provider_last_error": "Letzter Fehler",
+    "provider_never_checked": "Nie geprüft",
     "provider_display_name": "Anzeigename",
     "provider_enabled": "Aktiviert",
     "provider_upload_allowed": "Upload erlaubt",

--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -277,6 +277,18 @@
       "ttl_below_minimum": "Expiry is below the provider minimum",
       "ttl_above_maximum": "Expiry is above the provider maximum"
     },
+    "upload_readiness": {
+      "ready": "Ready",
+      "upload_token_missing": "No upload token configured",
+      "upload_disabled": "Uploads disabled"
+    },
+    "readiness_checking": "Checking upload…",
+    "provider_upload_readiness": "Upload readiness",
+    "provider_last_checked": "Last checked",
+    "provider_last_check_result": "Last check result",
+    "provider_last_latency": "Latency",
+    "provider_last_error": "Last error",
+    "provider_never_checked": "Never checked",
     "provider_display_name": "Display name",
     "provider_enabled": "Enabled",
     "provider_upload_allowed": "Upload allowed",

--- a/static/i18n/ru.json
+++ b/static/i18n/ru.json
@@ -277,6 +277,18 @@
       "ttl_below_minimum": "Срок ниже минимума провайдера",
       "ttl_above_maximum": "Срок выше максимума провайдера"
     },
+    "upload_readiness": {
+      "ready": "Готов",
+      "upload_token_missing": "Токен загрузки не настроен",
+      "upload_disabled": "Загрузки отключены"
+    },
+    "readiness_checking": "Проверка загрузки…",
+    "provider_upload_readiness": "Готовность загрузки",
+    "provider_last_checked": "Последняя проверка",
+    "provider_last_check_result": "Результат последней проверки",
+    "provider_last_latency": "Задержка",
+    "provider_last_error": "Последняя ошибка",
+    "provider_never_checked": "Никогда не проверялся",
     "provider_display_name": "Отображаемое имя",
     "provider_enabled": "Включено",
     "provider_upload_allowed": "Выгрузка разрешена",

--- a/static/i18n/uk.json
+++ b/static/i18n/uk.json
@@ -277,6 +277,18 @@
       "ttl_below_minimum": "Термін нижче мінімуму провайдера",
       "ttl_above_maximum": "Термін вище максимуму провайдера"
     },
+    "upload_readiness": {
+      "ready": "Готово",
+      "upload_token_missing": "Токен завантаження не налаштовано",
+      "upload_disabled": "Завантаження вимкнено"
+    },
+    "readiness_checking": "Перевірка завантаження…",
+    "provider_upload_readiness": "Готовність завантаження",
+    "provider_last_checked": "Остання перевірка",
+    "provider_last_check_result": "Результат останньої перевірки",
+    "provider_last_latency": "Затримка",
+    "provider_last_error": "Остання помилка",
+    "provider_never_checked": "Ніколи не перевірявся",
     "provider_display_name": "Відображуване ім'я",
     "provider_enabled": "Увімкнено",
     "provider_upload_allowed": "Вивантаження дозволено",

--- a/tests/frontend/test_files_ui.mjs
+++ b/tests/frontend/test_files_ui.mjs
@@ -1005,6 +1005,7 @@ async function test_modal_accessibility_and_escape() {
 
     // The background must be marked inert while the modal is open.
     assert.equal(main.getAttribute('aria-hidden'), 'true', 'background must be aria-hidden while a modal is open');
+    assert.equal(main.inert, true, 'background must carry the native inert property while a modal is open');
 
     // Escape closes the dialog and restores the background.
     dispatchKey(sandbox, 'Escape');
@@ -1013,6 +1014,7 @@ async function test_modal_accessibility_and_escape() {
         'Escape must close the dialog',
     );
     assert.equal(main.getAttribute('aria-hidden'), null, 'background inert state must be restored on close');
+    assert.equal(main.inert, false, 'background native inert property must be restored on close');
 
     console.log('PASS: test_modal_accessibility_and_escape');
 }
@@ -1086,20 +1088,64 @@ async function test_send_dialog_renders_custom_ttl_input() {
 async function test_send_file_feedback_shows_mime() {
     const sandbox = buildSandbox({ fetchImpl: defaultRoutes() });
     const fileInput = sandbox._document.getElementById('filesSendFile');
+    const feedback = () => sandbox._document.getElementById('filesSendFileFeedback').innerHTML;
 
+    // Allowlisted extension + MIME -> allowed, shows the type + size.
     fileInput.files = [{ name: 'report.pdf', size: 4096, type: 'application/pdf' }];
     dispatchChange(sandbox, 'filesSendFile');
-    let feedback = sandbox._document.getElementById('filesSendFileFeedback').innerHTML;
-    assert.match(feedback, /application\/pdf/, 'a known extension must surface its MIME type in the advisory feedback');
-    assert.match(feedback, /Size/, 'file size feedback must be present');
+    assert.match(feedback(), /application\/pdf/, 'an allowlisted extension must surface its MIME type');
+    assert.match(feedback(), /Size/, 'file size feedback must be present');
 
-    // Unknown type: advisory warning, not a hard block (server is authoritative).
+    // Allowlisted extension with an empty MIME -> still allowed (log -> text/plain).
+    fileInput.files = [{ name: 'notes.log', size: 512, type: '' }];
+    dispatchChange(sandbox, 'filesSendFile');
+    assert.match(feedback(), /text\/plain/, 'an allowlisted extension with an empty MIME must still be allowed');
+
+    // Extensionless file with an allowlisted MIME -> allowed.
+    fileInput.files = [{ name: 'blob', size: 2048, type: 'image/png' }];
+    dispatchChange(sandbox, 'filesSendFile');
+    assert.match(feedback(), /image\/png/, 'an allowlisted MIME must allow an extensionless file');
+
+    // Unknown extension + unknown MIME -> hard local rejection (F1).
     fileInput.files = [{ name: 'archive.bin', size: 128, type: 'application/octet-stream' }];
     dispatchChange(sandbox, 'filesSendFile');
-    feedback = sandbox._document.getElementById('filesSendFileFeedback').innerHTML;
-    assert.match(feedback, /unrecognized/, 'an unrecognized type must be described as unrecognized');
+    assert.match(feedback(), /File type is not allowed/, 'an unallowlisted type must be rejected with feedback');
+
+    // Rejected -> allowed clears the stale error.
+    fileInput.files = [{ name: 'report.pdf', size: 4096, type: 'application/pdf' }];
+    dispatchChange(sandbox, 'filesSendFile');
+    assert.doesNotMatch(feedback(), /not allowed/, 'selecting an allowed file must clear a stale rejection');
 
     console.log('PASS: test_send_file_feedback_shows_mime');
+}
+
+async function test_send_rejects_disallowed_file_blocks_requests() {
+    // F1: a disallowed file is rejected locally before any readiness or create
+    // request is issued.
+    let readinessCalls = 0;
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url.includes('upload-readiness')) {
+                readinessCalls += 1;
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            return undefined;
+        }),
+    });
+
+    prepareSendForm(sandbox, { fileName: 'archive.bin', mime: 'application/octet-stream' });
+    dispatch(sandbox, { 'data-files-action': 'send-submit' });
+    await new Promise((r) => setTimeout(r, 30));
+
+    assert.equal(
+        sandbox._document.getElementById('filesSendFileFeedback').textContent,
+        'File type is not allowed',
+        'a disallowed file must be rejected with localized feedback',
+    );
+    assert.equal(createRequests(sandbox).length, 0, 'a disallowed file must block the create POST');
+    assert.equal(readinessCalls, 0, 'a disallowed file must block the readiness request');
+
+    console.log('PASS: test_send_rejects_disallowed_file_blocks_requests');
 }
 
 async function test_send_lists_all_providers_with_reason() {
@@ -1190,6 +1236,335 @@ async function test_deactivate_clears_open_dialog() {
     console.log('PASS: test_deactivate_clears_open_dialog');
 }
 
+// ---- final-acceptance regressions (F1-F5, Section 7) -------------------------
+
+async function test_send_proactive_readiness_exact_ttl() {
+    // F2: opening the Send dialog triggers a proactive, authoritative readiness
+    // request for the EXACT requested TTL (the default 3-day TTL here).
+    const ttlSeen = [];
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                return json(200, { ok: true, providers: [provider('prov1', { is_default: true })] });
+            }
+            if (url.includes('upload-readiness')) {
+                const m = url.match(/requested_ttl_seconds=(\d+)/);
+                ttlSeen.push(m ? parseInt(m[1], 10) : null);
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'send' });
+    await waitFor(() => ttlSeen.length >= 1);
+
+    assert.equal(ttlSeen[0], 259200, 'the proactive check must use the exact default TTL');
+    const check = sandbox._document.getElementById('filesSendReadinessCheck').innerHTML;
+    assert.match(check, /Upload: ready/, 'the readiness check must render ready for the exact TTL');
+
+    console.log('PASS: test_send_proactive_readiness_exact_ttl');
+}
+
+async function test_send_readiness_stale_response_dropped() {
+    // F2: a slow, older readiness response (for a superseded TTL) must be
+    // dropped by the monotonic token and never overwrite the newer result.
+    const pending = []; // { ttl, resolve } in request order
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                return json(200, { ok: true, providers: [provider('prov1', { is_default: true })] });
+            }
+            if (url.includes('upload-readiness')) {
+                const m = url.match(/requested_ttl_seconds=(\d+)/);
+                const ttl = m ? parseInt(m[1], 10) : null;
+                return new Promise((resolve) => { pending.push({ ttl, resolve }); });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'send' });
+    await waitFor(() => pending.length >= 1);
+
+    // Switch to a valid custom TTL -> a newer readiness request for ttl=120.
+    sandbox._document.getElementById('filesSendExpiry').value = 'custom';
+    sandbox._document.getElementById('filesSendCustomTtlSeconds').value = '120';
+    dispatchChange(sandbox, 'filesSendExpiry');
+    await waitFor(() => pending.some((p) => p.ttl === 120));
+
+    const newest = pending.filter((p) => p.ttl === 120).pop();
+    const older = pending.filter((p) => p.ttl === 259200);
+    assert.ok(newest && older.length >= 1, 'an older and a newer readiness request must both have fired');
+
+    newest.resolve(json(200, { ok: true, ready: true, reason: null }));
+    await waitFor(() => /Upload: ready/.test(sandbox._document.getElementById('filesSendReadinessCheck').innerHTML));
+
+    // Every older (default-TTL) response lands after the newer one and must be
+    // dropped rather than overwriting the ready result.
+    older.forEach((p) => p.resolve(json(200, { ok: true, ready: false, reason: 'relay_unreachable' })));
+    await new Promise((r) => setTimeout(r, 30));
+    assert.match(
+        sandbox._document.getElementById('filesSendReadinessCheck').innerHTML,
+        /Upload: ready/,
+        'a stale readiness response must not overwrite the newer result',
+    );
+
+    console.log('PASS: test_send_readiness_stale_response_dropped');
+}
+
+async function test_send_readiness_blank_custom_ttl_no_request() {
+    // F2 + Section 7: a blank Custom TTL shows a localized prompt and issues no
+    // readiness request (no fictitious 86400-second TTL is fabricated).
+    let readinessCalls = 0;
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                return json(200, { ok: true, providers: [provider('prov1', { is_default: true })] });
+            }
+            if (url.includes('upload-readiness')) {
+                readinessCalls += 1;
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'send' });
+    await waitFor(() => readinessCalls >= 1); // the default-TTL check already fired
+
+    sandbox._document.getElementById('filesSendExpiry').value = 'custom';
+    sandbox._document.getElementById('filesSendCustomTtlSeconds').value = '';
+    dispatchChange(sandbox, 'filesSendExpiry');
+    await new Promise((r) => setTimeout(r, 40));
+
+    const callsAtBlank = readinessCalls;
+    const check = sandbox._document.getElementById('filesSendReadinessCheck').innerHTML;
+    const summary = sandbox._document.getElementById('filesSendExpirySummary').innerHTML;
+    assert.match(check, /whole number/, 'a blank custom TTL must show the local prompt, not request readiness');
+    assert.match(summary, /whole number/, 'the expiry summary must prompt for a value, not show a fictitious expiry');
+    assert.doesNotMatch(summary, /86400/, 'the summary must never show a fabricated 86400-second expiry');
+
+    await new Promise((r) => setTimeout(r, 40));
+    assert.equal(readinessCalls, callsAtBlank, 'a blank custom TTL must not issue a readiness request');
+
+    console.log('PASS: test_send_readiness_blank_custom_ttl_no_request');
+}
+
+async function test_send_custom_ttl_summary_local_validation() {
+    // Section 7: the Custom-TTL summary validates against the provider min/max
+    // locally (below-min / above-max prompts), and renders expiry+grace only
+    // for a valid value.
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                return json(200, { ok: true, providers: [provider('prov1', { is_default: true, min_ttl_seconds: 60, max_ttl_seconds: 3600 })] });
+            }
+            if (url.includes('upload-readiness')) {
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'send' });
+    await waitFor(() => (sandbox._document.getElementById('filesSendProvider').innerHTML || '').includes('prov1'));
+
+    const summary = () => sandbox._document.getElementById('filesSendExpirySummary').innerHTML;
+    const setTtl = (v) => {
+        sandbox._document.getElementById('filesSendExpiry').value = 'custom';
+        sandbox._document.getElementById('filesSendCustomTtlSeconds').value = v;
+        dispatchChange(sandbox, 'filesSendExpiry');
+    };
+
+    setTtl('30'); // below min (60)
+    assert.match(summary(), /below the provider minimum/, 'a below-minimum TTL must be flagged locally');
+    assert.doesNotMatch(summary(), /86400/, 'no fabricated expiry for a below-minimum TTL');
+
+    setTtl('7200'); // above max (3600)
+    assert.match(summary(), /above the provider maximum/, 'an above-maximum TTL must be flagged locally');
+
+    setTtl('120'); // valid
+    assert.match(summary(), /Expires/, 'a valid custom TTL must render the expiry summary');
+    assert.match(summary(), /grace/, 'a valid custom TTL must render the download grace');
+    assert.doesNotMatch(summary(), /provider minimum|provider maximum/, 'a valid custom TTL must not show a min/max error');
+
+    console.log('PASS: test_send_custom_ttl_summary_local_validation');
+}
+
+async function test_send_create_success_waits_for_refresh() {
+    // F5: a create that succeeds must not announce success until the
+    // authoritative transfer refresh has settled, and then exactly once.
+    let listResolve;
+    const listGate = new Promise((r) => { listResolve = r; });
+    let listCalls = 0;
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url.includes('upload-readiness')) {
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            if (url === '/api/attachments') {
+                return json(202, { ok: true, command_id: 'cmd-ok', attachment_id: null });
+            }
+            if (url === '/api/mca/commands/cmd-ok') {
+                return json(200, { ok: true, command: { command_id: 'cmd-ok', status: 'succeeded' } });
+            }
+            if (url.startsWith('/api/attachments?')) {
+                listCalls += 1;
+                await listGate;
+                return json(200, { ok: true, attachments: [], total: 0 });
+            }
+            return undefined;
+        }),
+    });
+
+    prepareSendForm(sandbox, {});
+    dispatch(sandbox, { 'data-files-action': 'send-submit' });
+
+    await waitFor(() => createRequests(sandbox).length === 1);
+    await waitFor(() => listCalls >= 1); // the onSuccess refresh is in flight, held
+
+    assert.ok(
+        !sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'success'),
+        'create success must not be announced before the transfer refresh settles',
+    );
+
+    listResolve();
+    await waitFor(() => sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'success'));
+    const successes = sandbox._notifications.filter((n) => n.kind === 'update' && n.type === 'success').length;
+    assert.equal(successes, 1, 'create success must fire exactly once after the refresh settles');
+
+    console.log('PASS: test_send_create_success_waits_for_refresh');
+}
+
+async function test_send_unknown_awaits_refresh() {
+    // F5: a 404 (unknown after restart) must wait for the refresh to settle
+    // before announcing, and must never replay the create.
+    let listResolve;
+    const listGate = new Promise((r) => { listResolve = r; });
+    let listCalls = 0;
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url.includes('upload-readiness')) {
+                return json(200, { ok: true, ready: true, reason: null });
+            }
+            if (url === '/api/attachments') {
+                return json(202, { ok: true, command_id: 'cmd-unk', attachment_id: null });
+            }
+            if (url === '/api/mca/commands/cmd-unk') {
+                return json(404, { ok: false, error: 'not found', error_code: 'attachment_not_found' });
+            }
+            if (url.startsWith('/api/attachments?')) {
+                listCalls += 1;
+                await listGate;
+                return json(200, { ok: true, attachments: [], total: 0 });
+            }
+            return undefined;
+        }),
+    });
+
+    prepareSendForm(sandbox, {});
+    dispatch(sandbox, { 'data-files-action': 'send-submit' });
+
+    await waitFor(() => createRequests(sandbox).length === 1);
+    await waitFor(() => listCalls >= 1); // onUnknown refresh in flight, held
+
+    assert.ok(
+        !sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'warning'),
+        'the unknown warning must wait for the refresh to settle',
+    );
+
+    listResolve();
+    await waitFor(() => sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'warning'));
+    assert.equal(createRequests(sandbox).length, 1, 'unknown must never replay the create');
+
+    console.log('PASS: test_send_unknown_awaits_refresh');
+}
+
+async function test_provider_command_awaits_refresh() {
+    // F5: a provider command that succeeds must not announce success until the
+    // authoritative provider refresh has settled, and then exactly once.
+    let providersCalls = 0;
+    let refreshResolve;
+    const refreshGate = new Promise((r) => { refreshResolve = r; });
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                providersCalls += 1;
+                if (providersCalls >= 2) await refreshGate;
+                return json(200, { ok: true, providers: [provider('prov1')] });
+            }
+            if (url === '/api/mca/providers/prov1') {
+                return json(202, { ok: true, command_id: 'cmd-prov' });
+            }
+            if (url === '/api/mca/commands/cmd-prov') {
+                return json(200, { ok: true, command: { command_id: 'cmd-prov', status: 'succeeded' } });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'providers' });
+    await waitFor(() => (sandbox._document.elements.get('filesProvidersList')?.innerHTML || '').includes('provider-toggle'));
+
+    dispatch(sandbox, { 'data-files-action': 'provider-toggle', 'data-provider': 'prov1' });
+    await waitFor(() => providersCalls >= 2); // the onSuccess refresh is in flight, held
+
+    assert.ok(
+        !sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'success'),
+        'provider success must not be announced before the refresh settles',
+    );
+
+    refreshResolve();
+    await waitFor(() => sandbox._notifications.some((n) => n.kind === 'update' && n.type === 'success'));
+    const successes = sandbox._notifications.filter((n) => n.kind === 'update' && n.type === 'success').length;
+    assert.equal(successes, 1, 'provider success must fire exactly once after the refresh settles');
+
+    console.log('PASS: test_provider_command_awaits_refresh');
+}
+
+async function test_provider_card_shows_status_fields() {
+    // F3: the shared provider card must render the live status fields — upload
+    // readiness, last-checked timestamp, last check result, latency, last error
+    // — with numeric-only latency and a safe fallback for a null error code.
+    const sandbox = buildSandbox({
+        fetchImpl: defaultRoutes(async (url) => {
+            if (url === '/api/mca/providers') {
+                return json(200, { ok: true, providers: [provider('prov1', {
+                    last_checked_at: 1700000000,
+                    last_check_result: 'online',
+                    last_latency_ms: 42,
+                    last_error_code: null,
+                    upload_readiness: 'ready',
+                })] });
+            }
+            return undefined;
+        }),
+    });
+
+    activate(sandbox);
+    dispatch(sandbox, { 'data-files-action': 'providers' });
+    await waitFor(() => (sandbox._document.elements.get('filesProvidersList')?.innerHTML || '').includes('provider-toggle'));
+
+    const html = sandbox._document.elements.get('filesProvidersList').innerHTML;
+    assert.match(html, /Upload readiness/, 'the provider card must show upload readiness');
+    assert.match(html, /Ready/, 'upload readiness must render its localized value');
+    assert.match(html, /Last checked/, 'the provider card must show the last-checked timestamp');
+    assert.match(html, /Last check result/, 'the provider card must show the last check result');
+    assert.match(html, /Online/, 'the last check result must render its localized value');
+    assert.match(html, /Latency/, 'the provider card must show latency');
+    assert.match(html, /42 ms/, 'the provider card must render numeric-only latency');
+    assert.match(html, /Last error/, 'the provider card must show the last error');
+    assert.match(html, /—/, 'a null error code must render the em-dash fallback, not raw text');
+
+    console.log('PASS: test_provider_card_shows_status_fields');
+}
+
 async function main() {
     await test_activate_merges_contacts_and_excludes_local();
     await test_trust_confirm_shows_full_fingerprint();
@@ -1215,7 +1590,17 @@ async function main() {
     await test_send_lists_all_providers_with_reason();
     await test_send_custom_ttl_validation();
     await test_deactivate_clears_open_dialog();
-    console.log('All files UI behavior tests passed (24 scenarios).');
+    // Final-acceptance regressions (F1-F5, Section 7).
+    await test_send_rejects_disallowed_file_blocks_requests();
+    await test_send_proactive_readiness_exact_ttl();
+    await test_send_readiness_stale_response_dropped();
+    await test_send_readiness_blank_custom_ttl_no_request();
+    await test_send_custom_ttl_summary_local_validation();
+    await test_send_create_success_waits_for_refresh();
+    await test_send_unknown_awaits_refresh();
+    await test_provider_command_awaits_refresh();
+    await test_provider_card_shows_status_fields();
+    console.log('All files UI behavior tests passed (33 scenarios).');
 }
 
 main()


### PR DESCRIPTION
## Summary

Correction pass on the already-merged #248 (Files workspace residual defects), closing the five residual acceptance gaps found by independent review plus the directly-related Custom-TTL summary gap. No R1–R4 reopening, no Files-workspace redesign, no new MCAttach features.

## F1–F5 resolution

| # | Finding | Resolution |
|---|---------|------------|
| F1 | `fileTypeAllowed()` accepted unknown types, deferring everything to the server | Now rejects locally when both extension and MIME are absent/unrecognized; allowlisted extension (even with empty MIME) or allowlisted MIME (even extensionless) is accepted; immediate localized feedback clears on an allowed selection. Server magic-byte sniffing stays authoritative. |
| F2 | Send dialog readiness wasn't proactive/exact/race-safe | Added a proactive, monotonic-token-guarded `upload-readiness` request for the exact requested TTL (`requested_ttl_seconds`), rendered into a dedicated element; Send is gated on recipient/provider/file/valid-TTL/allowed-type/positive-readiness and re-checked at submit (TOCTOU). |
| F3 | Provider card omitted live status fields | Rendered upload readiness, last-checked, last check result, latency (numeric-only), and last error (safe code/fallback) in the shared provider component. |
| F4 | Modal background inertness was aria-hidden-only | Sets the native `inert` property and restores it (alongside aria-hidden) on every close path, honoring pre-existing inert/aria-hidden state. |
| F5 | Command success fired before the authoritative refresh settled | `refreshContacts`/`loadTransfers`/`loadConnectivity`/`loadSettings` now return their guarded-load Promises; every command `onSuccess`/`onUnknown` callback returns the refresh it starts, so success is announced only after the refresh settles. |
| §7 | Blank/invalid Custom TTL showed a fictitious 86400s expiry | Blank/invalid Custom TTL shows a localized prompt; expiry/grace are computed only for a valid value, validated against provider min/max locally, and the exact TTL + grace are folded into the idempotency signature. |

## Verification

- `python -m compileall api meshsrv` ✅
- `python scripts/check-i18n.py` ✅ (all four catalogs in sync)
- `python scripts/check_startup_calls.py --check` ✅
- `node --check static/files.js` / `static/chat.js` ✅
- `node tests/frontend/*.mjs` ✅ (33 Files scenarios + CSRF + updates)
- `python -m pytest` ✅ 2049 passed, 38 skipped (no regression)
- `git diff --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)